### PR TITLE
Fix a warning in AIAICheats.h

### DIFF
--- a/AI/Wrappers/LegacyCpp/AIAICheats.h
+++ b/AI/Wrappers/LegacyCpp/AIAICheats.h
@@ -20,7 +20,7 @@
 
 #include "IAICheats.h"
 
-class SSkirmishAICallback;
+struct SSkirmishAICallback;
 class CAIAICallback;
 
 /**


### PR DESCRIPTION
Mess with struct/class may lead to linker errors under MSVC.
