### PR TITLE
fix SDL issue on Mac OS

### DIFF
--- a/rts/System/Main.cpp
+++ b/rts/System/Main.cpp
@@ -21,7 +21,7 @@
 	#include "System/Platform/Win/win32.h"
 #endif
 
-#ifndef __APPLE__
+#if !defined(__APPLE__) || !defined(HEADLESS)
 	// SDL_main.h contains a macro that replaces the main function on some OS, see SDL_main.h for details
 	#include <SDL_main.h>
 #endif


### PR DESCRIPTION
adjusted the SDL_main include to appear in all non-headless targets
