### PR TITLE
adjusted zip command to start folder hierarchy at the .app level

### DIFF
--- a/buildbot/slave/create_Mac_bundle.sh
+++ b/buildbot/slave/create_Mac_bundle.sh
@@ -134,8 +134,9 @@ done
 # here, the bundle should be ready, a little compression and voila
 
 ARCHIVE_NAME=Spring_${VERSION}.zip
-echo "-- creating archive"
-zip -r9 ${TMP_PATH}/${ARCHIVE_NAME} .
+echo "-- creating ${TMP_PATH}/${ARCHIVE_NAME}"
+cd ${TMP_PATH}
+zip -r9 ${ARCHIVE_NAME} ${BUNDLE_NAME}
 
 echo "-- done"
 


### PR DESCRIPTION
right now the .zip file contains everything inside the .app/Contents folder, while the zip should contain the .app folder intact (while be deflated correctly into the final bundle on Mac)
