### PR TITLE
Add myGravity tag to WeaponDefs[] table

### DIFF
--- a/rts/Lua/LuaWeaponDefs.cpp
+++ b/rts/Lua/LuaWeaponDefs.cpp
@@ -525,6 +525,7 @@ static bool InitParamMap()
 
 	ADD_BOOL("selfExplode", wd.selfExplode);
 	ADD_BOOL("gravityAffected", wd.gravityAffected);
+	ADD_FLOAT("myGravity", wd.myGravity);
 	ADD_BOOL("noExplode", wd.noExplode);
 	ADD_FLOAT("startvelocity", wd.startvelocity);
 	ADD_FLOAT("weaponAcceleration", wd.weaponacceleration);


### PR DESCRIPTION
When using WeaponDefs[id].mygravity it returned nil, though engine uses that tag for setting custom gravity for ballistic weapons.
