### PR TITLE
add mapgen

### DIFF
--- a/cont/base/springcontent/mapgenerator/mapinfo_template.lua
+++ b/cont/base/springcontent/mapgenerator/mapinfo_template.lua
@@ -1,0 +1,321 @@
+--------------------------------------------------------------------------------
+--------------------------------------------------------------------------------
+-- mapinfo.lua
+--
+
+local mapinfo = {
+	name        = "${NAME}",
+	shortname   = "",
+	description = "${DESCRIPTION}",
+	author      = "",
+	version     = "",
+	--mutator   = "deployment";
+	--mapfile   = "", --// location of smf/sm3 file (optional)
+	modtype     = 3, --// 1=primary, 0=hidden, 3=map
+	depend      = {"Map Helper v1"},
+	replace     = {},
+
+	--startpic   = "", --// deprecated
+	--StartMusic = "", --// deprecated
+
+	maphardness     = 100,
+	notDeformable   = false,
+	gravity         = 130,
+	tidalStrength   = 0,
+	maxMetal        = 0.02,
+	extractorRadius = 500.0,
+	voidWater       = false,
+	autoShowMetal   = true,
+
+
+	smf = {
+		--minheight = 1000,
+		--maxheight = -300,
+		--smtFileName0 = "",
+		--smtFileName1 = "",
+		--smtFileName.. = "",
+		--smtFileNameN = "",
+	},
+
+	sound = {
+		--// Sets the _reverb_ preset (= echo parameters),
+		--// passfilter (the direct sound) is unchanged.
+		--//
+		--// To get a list of all possible presets check:
+		--//   https://github.com/spring/spring/blob/master/rts/System/Sound/EFXPresets.cpp
+		--//
+		--// Hint:
+		--// You can change the preset at runtime via:
+		--//   /tset UseEFX [1|0]
+		--//   /tset snd_eaxpreset preset_name   (may change to a real cmd in the future)
+		--//   /tset snd_filter %gainlf %gainhf  (may    "   "  "  "    "  "   "    "   )
+		preset = "default",
+
+		passfilter = {
+			--// Note, you likely want to set these
+			--// tags due to the fact that they are
+			--// _not_ set by `preset`!
+			--// So if you want to create a muffled
+			--// sound you need to use them.
+			gainlf = 1.0,
+			gainhf = 1.0,
+		},
+
+		reverb = {
+			--// Normally you just want use the `preset` tag
+			--// but you can use handtweak a preset if wanted
+			--// with the following tags.
+			--// To know their function & ranges check the
+			--// official OpenAL1.1 SDK document.
+
+			--density
+			--diffusion
+			--gain
+			--gainhf
+			--gainlf
+			--decaytime
+			--decayhflimit
+			--decayhfratio
+			--decaylfratio
+			--reflectionsgain
+			--reflectionsdelay
+			--reflectionspan
+			--latereverbgain
+			--latereverbdelay
+			--latereverbpan
+			--echotime
+			--echodepth
+			--modtime
+			--moddepth
+			--airabsorptiongainhf
+			--hfreference
+			--lfreference
+			--roomrollofffactor
+		},
+	},
+
+	resources = {
+		--grassBladeTex = "",
+
+		--grassShadingTex = "",
+		--detailTex = "",
+		--specularTex = "",
+		--splatDetailTex = "",
+		--splatDistrTex = "",
+		--skyReflectModTex = "",
+		--detailNormalTex = "",
+		--lightEmissionTex = "",
+	},
+
+	splats = {
+		texScales = {0.02, 0.02, 0.02, 0.02},
+		texMults  = {1.0, 1.0, 1.0, 1.0},
+	},
+
+	atmosphere = {
+		minWind      = 5.0,
+		maxWind      = 25.0,
+
+		fogStart     = 0.1,
+		fogEnd       = 1.0,
+		fogColor     = {0.7, 0.7, 0.8},
+
+		sunColor     = {1.0, 1.0, 1.0},
+		skyColor     = {0.1, 0.15, 0.7},
+		skyDir       = {0.0, 0.0, -1.0},
+		skyBox       = "",
+
+		cloudDensity = 0.5,
+		cloudColor   = {1.0, 1.0, 1.0},
+	},
+
+	grass = {
+		bladeWaveScale = 1.0,
+		bladeWidth  = 0.32,
+		bladeHeight = 4.0,
+		bladeAngle  = 1.57,
+		bladeColor  = {0.59, 0.81, 0.57}, --// does nothing when `grassBladeTex` is set
+	},
+
+	lighting = {
+		--// dynsun
+		sunStartAngle = 0.0,
+		sunOrbitTime  = 1440.0,
+		sunDir        = {0.0, 1.0, 2.0, 1e9},
+
+		--// unit & ground lighting
+		groundAmbientColor  = {0.5, 0.5, 0.5},
+		groundDiffuseColor  = {0.5, 0.5, 0.5},
+		groundSpecularColor = {0.1, 0.1, 0.1},
+		groundShadowDensity = 0.8,
+		unitAmbientColor    = {0.4, 0.4, 0.4},
+		unitDiffuseColor    = {0.7, 0.7, 0.7},
+		unitSpecularColor   = {0.7, 0.7, 0.7},
+		unitShadowDensity   = 0.8,
+
+		specularExponent    = 100.0,
+	},
+
+	water = {
+		damage =  0.0,
+
+		repeatX = 0.0,
+		repeatY = 0.0,
+
+		absorb    = {0.0, 0.0, 0.0},
+		baseColor = {0.0, 0.0, 0.0},
+		minColor  = {0.0, 0.0, 0.0},
+
+		ambientFactor  = 1.0,
+		diffuseFactor  = 1.0,
+		specularFactor = 1.0,
+		specularPower  = 20.0,
+
+		planeColor = {0.0, 0.4, 0.0},
+
+		surfaceColor  = {0.75, 0.8, 0.85},
+		surfaceAlpha  = 0.55,
+		diffuseColor  = {1.0, 1.0, 1.0},
+		specularColor = {0.5, 0.5, 0.5},
+
+		fresnelMin   = 0.2,
+		fresnelMax   = 0.8,
+		fresnelPower = 4.0,
+
+		reflectionDistortion = 1.0,
+
+		blurBase      = 2.0,
+		blurExponent = 1.5,
+
+		perlinStartFreq  =  8.0,
+		perlinLacunarity = 3.0,
+		perlinAmplitude  =  0.9,
+		windSpeed = 1.0, --// does nothing yet
+
+		shoreWaves = true,
+		forceRendering = false,
+
+		--// undefined == load them from resources.lua!
+		--texture =       "",
+		--foamTexture =   "",
+		--normalTexture = "",
+		--caustics = {
+		--	"",
+		--	"",
+		--},
+	},
+
+	teams = {
+		${START_POSITIONS}
+	},
+
+	terrainTypes = {
+		[0] = {
+			name = "Default",
+			hardness = 1.0,
+			receiveTracks = true,
+			moveSpeeds = {
+				tank  = 1.0,
+				kbot  = 1.0,
+				hover = 1.0,
+				ship  = 1.0,
+			},
+		},
+	},
+
+	custom = {
+		fog = {
+			color    = {0.26, 0.30, 0.41},
+			height   = "80%", --// allows either absolue sizes or in percent of map's MaxHeight
+			fogatten = 0.003,
+		},
+		precipitation = {
+			density   = 30000,
+			size      = 1.5,
+			speed     = 50,
+			windscale = 1.2,
+			texture   = 'LuaGaia/effects/snowflake.png',
+		},
+	},
+}
+
+--------------------------------------------------------------------------------
+--------------------------------------------------------------------------------
+-- Helper
+
+local function lowerkeys(ta)
+	local fix = {}
+	for i,v in pairs(ta) do
+		if (type(i) == "string") then
+			if (i ~= i:lower()) then
+				fix[#fix+1] = i
+			end
+		end
+		if (type(v) == "table") then
+			lowerkeys(v)
+		end
+	end
+
+	for i=1,#fix do
+		local idx = fix[i]
+		ta[idx:lower()] = ta[idx]
+		ta[idx] = nil
+	end
+end
+
+lowerkeys(mapinfo)
+
+--------------------------------------------------------------------------------
+--------------------------------------------------------------------------------
+-- Map Options
+
+if (Spring) then
+	local function tmerge(t1, t2)
+		for i,v in pairs(t2) do
+			if (type(v) == "table") then
+				t1[i] = t1[i] or {}
+				tmerge(t1[i], v)
+			else
+				t1[i] = v
+			end
+		end
+	end
+
+	-- make code safe in unitsync
+	if (not Spring.GetMapOptions) then
+		Spring.GetMapOptions = function() return {} end
+	end
+	function tobool(val)
+		local t = type(val)
+		if (t == 'nil') then
+			return false
+		elseif (t == 'boolean') then
+			return val
+		elseif (t == 'number') then
+			return (val ~= 0)
+		elseif (t == 'string') then
+			return ((val ~= '0') and (val ~= 'false'))
+		end
+		return false
+	end
+
+	getfenv()["mapinfo"] = mapinfo
+		local files = VFS.DirList("mapconfig/mapinfo/", "*.lua")
+		table.sort(files)
+		for i=1,#files do
+			local newcfg = VFS.Include(files[i])
+			if newcfg then
+				lowerkeys(newcfg)
+				tmerge(mapinfo, newcfg)
+			end
+		end
+	getfenv()["mapinfo"] = nil
+end
+
+--------------------------------------------------------------------------------
+--------------------------------------------------------------------------------
+
+return mapinfo
+
+--------------------------------------------------------------------------------
+--------------------------------------------------------------------------------

--- a/rts/Game/GameSetup.cpp
+++ b/rts/Game/GameSetup.cpp
@@ -375,6 +375,7 @@ bool CGameSetup::Init(const std::string& buf)
 	// Used by dedicated server only
 	file.GetTDef(mapHash, unsigned(0), "GAME\\MapHash");
 	file.GetTDef(modHash, unsigned(0), "GAME\\ModHash");
+	file.GetTDef(mapSeed, unsigned(0), "GAME\\MapSeed");
 
 	gameID      = file.SGetValueDef("",  "GAME\\GameID");
 	modName     = file.SGetValueDef("",  "GAME\\Gametype");

--- a/rts/Game/GameSetup.h
+++ b/rts/Game/GameSetup.h
@@ -52,6 +52,7 @@ public:
 	bool fixedAllies;
 	unsigned int mapHash;
 	unsigned int modHash;
+	unsigned int mapSeed;
 	std::string MapFile() const;
 	std::string mapName;
 	std::string modName;

--- a/rts/Game/PreGame.cpp
+++ b/rts/Game/PreGame.cpp
@@ -21,6 +21,7 @@
 #include "PlayerHandler.h"
 #include "System/TimeProfiler.h"
 #include "UI/InfoConsole.h"
+#include "Map/Generation/SimpleMapGenerator.h"
 
 #include "aGui/Gui.h"
 #include "ExternalAI/SkirmishAIHandler.h"
@@ -180,6 +181,11 @@ void CPreGame::StartServer(const std::string& setupscript)
 
 	if (setup->mapName.empty()) {
 		throw content_error("No map selected in startscript");
+	}
+
+	if(setup->mapSeed) {
+		CSimpleMapGenerator gen(setup);
+		gen.Generate();
 	}
 
 	// We must map the map into VFS this early, because server needs the start positions.

--- a/rts/Map/CMakeLists.txt
+++ b/rts/Map/CMakeLists.txt
@@ -13,6 +13,8 @@ SET(sources_engine_Map
 		"${CMAKE_CURRENT_SOURCE_DIR}/MetalMap.cpp"
 		"${CMAKE_CURRENT_SOURCE_DIR}/NoMapDamage.cpp"
 		"${CMAKE_CURRENT_SOURCE_DIR}/ReadMap.cpp"
+		"${CMAKE_CURRENT_SOURCE_DIR}/Generation/MapGenerator.cpp"
+		"${CMAKE_CURRENT_SOURCE_DIR}/Generation/SimpleMapGenerator.cpp"
 		"${CMAKE_CURRENT_SOURCE_DIR}/SM3/Frustum.cpp"
 		"${CMAKE_CURRENT_SOURCE_DIR}/SM3/Plane.cpp"
 		"${CMAKE_CURRENT_SOURCE_DIR}/SM3/SM3GroundDrawer.cpp"

--- a/rts/Map/Generation/MapGenerator.cpp
+++ b/rts/Map/Generation/MapGenerator.cpp
@@ -1,0 +1,290 @@
+/* This file is part of the Spring engine (GPL v2 or later), see LICENSE.html */
+
+#include "MapGenerator.h"
+#include "System/FileSystem/FileHandler.h"
+#include "System/Exceptions.h"
+#include "System/FileSystem/VFSHandler.h"
+#include "System/FileSystem/ArchiveScanner.h"
+#include "System/FileSystem/Archives/VirtualArchive.h"
+#include "Map/SMF/SMFFormat.h"
+#include "Game/LoadScreen.h"
+#include "Rendering/GL/myGL.h"
+
+#include <boost/algorithm/string.hpp>
+#include <fstream>
+
+CMapGenerator::CMapGenerator(const CGameSetup* setup) : setup(setup)
+{
+}
+
+CMapGenerator::~CMapGenerator()
+{
+}
+
+void CMapGenerator::Generate()
+{
+	//loadscreen->SetLoadMessage("Generating map");
+
+	//Create archive for map
+	std::string mapArchivePath = setup->mapName + "." + virtualArchiveFactory->GetDefaultExtension();
+	CVirtualArchive* archive = virtualArchiveFactory->AddArchive(setup->mapName);
+
+	//Create arrays that can be filled by top class
+	int2 gridSize = GetGridSize();
+	const int dimensions = (gridSize.x + 1) * (gridSize.y + 1);
+	heightMap.resize(dimensions);
+	metalMap.resize(dimensions);
+
+	//Generate map and fill archive files
+	GenerateMap();
+	GenerateSMF(archive);
+	GenerateMapInfo(archive);
+	GenerateSMT(archive);
+
+	//Add archive to vfs
+	archiveScanner->ScanArchive(mapArchivePath);
+
+	//Write to disk for testing
+	//archive->WriteToFile();
+}
+
+void CMapGenerator::AppendToBuffer(CVirtualFile* file, const void* data, int size)
+{
+	file->buffer.insert(file->buffer.end(), (boost::uint8_t*)data, (boost::uint8_t*)data + size);
+}
+
+void CMapGenerator::SetToBuffer(CVirtualFile* file, const void* data, int size, int position)
+{
+	std::copy((boost::uint8_t*)data, (boost::uint8_t*)data + size, file->buffer.begin() + position);
+}
+
+void CMapGenerator::GenerateSMF(CVirtualArchive* archive)
+{
+	CVirtualFile* fileSMF = archive->AddFile("maps/generated.smf");
+
+	//FileBuffer b;
+
+	SMFHeader smfHeader;
+	MapTileHeader smfTile;
+	MapFeatureHeader smfFeature;
+
+	//--- Make SMFHeader ---
+	strcpy(smfHeader.magic, "spring map file");
+	smfHeader.version = 1;
+	smfHeader.mapid = 0x524d4746 ^ (int)setup->mapSeed;
+
+	//Set settings
+	smfHeader.mapx = GetGridSize().x;
+	smfHeader.mapy = GetGridSize().y;
+	smfHeader.squareSize = 8;
+	smfHeader.texelPerSquare = 8;
+	smfHeader.tilesize = 32;
+	smfHeader.minHeight = -100;
+	smfHeader.maxHeight = 0x1000;
+
+	const int numSmallTiles = 1; //2087; //32 * 32 * (mapSize.x  / 2) * (mapSize.y / 2);
+	const char smtFileName[] = "generated.smt";
+
+	//--- Extra headers ---
+	ExtraHeader vegHeader;
+	vegHeader.type = MEH_Vegetation;
+	vegHeader.size = sizeof(int);
+
+	smfHeader.numExtraHeaders =  1;
+
+	//Make buffers for each map
+	int heightmapDimensions = (smfHeader.mapx + 1) * (smfHeader.mapy + 1);
+	int typemapDimensions = (smfHeader.mapx / 2) * (smfHeader.mapy / 2);
+	int metalmapDimensions = (smfHeader.mapx / 2) * (smfHeader.mapy / 2);
+	int tilemapDimensions =  (smfHeader.mapx * smfHeader.mapy) / 16;
+	int vegmapDimensions = (smfHeader.mapx / 4) * (smfHeader.mapy / 4);
+
+	int heightmapSize = heightmapDimensions * sizeof(short);
+	int typemapSize = typemapDimensions * sizeof(unsigned char);
+	int metalmapSize = metalmapDimensions * sizeof(unsigned char);
+	int tilemapSize = tilemapDimensions * sizeof(int);
+	int tilemapTotalSize = sizeof(MapTileHeader) + sizeof(numSmallTiles) + sizeof(smtFileName) + tilemapSize;
+	int vegmapSize = vegmapDimensions * sizeof(unsigned char);
+
+	short* heightmapPtr = new short[heightmapDimensions];
+	unsigned char* typemapPtr = new unsigned char[typemapDimensions];
+	unsigned char* metalmapPtr = new unsigned char[metalmapDimensions];
+	int* tilemapPtr = new int[tilemapDimensions];
+	unsigned char* vegmapPtr = new unsigned char[vegmapDimensions];
+
+	//--- Set offsets, increment each member with the previous one ---
+	int vegmapOffset = sizeof(smfHeader) + sizeof(vegHeader) + sizeof(int);
+	smfHeader.heightmapPtr = vegmapOffset + vegmapSize;
+	smfHeader.typeMapPtr = smfHeader.heightmapPtr + heightmapSize;
+	smfHeader.tilesPtr = smfHeader.typeMapPtr + typemapSize;
+	smfHeader.minimapPtr = 0; //smfHeader.tilesPtr + sizeof(MapTileHeader);
+	smfHeader.metalmapPtr = smfHeader.tilesPtr + tilemapTotalSize;  //smfHeader.minimapPtr + minimapSize;
+	smfHeader.featurePtr = smfHeader.metalmapPtr + metalmapSize;
+
+	//--- Make MapTileHeader ---
+	smfTile.numTileFiles = 1;
+	smfTile.numTiles = numSmallTiles;
+
+	//--- Make MapFeatureHeader ---
+	smfFeature.numFeatures = 0;
+	smfFeature.numFeatureType = 0;
+
+	//--- Update Ptrs and write to buffer ---
+	memset(vegmapPtr, 0, vegmapSize);
+
+	float heightMin = smfHeader.minHeight;
+	float heightMax = smfHeader.maxHeight;
+	float heightMul = (float)0xFFFF / (smfHeader.maxHeight - smfHeader.minHeight);
+	for(int x = 0; x < heightmapDimensions; x++)
+	{
+		float h = heightMap[x];
+		if(h < heightMin) h = heightMin;
+		if(h > heightMax) h = heightMax;
+		h -= heightMin;
+		h *= heightMul;
+		heightmapPtr[x] = (short)h;
+	}
+
+	memset(typemapPtr, 0, typemapSize);
+
+	/*for(u32 x = 0; x < smfHeader.mapx; x++)
+	{
+		for(u32 y = 0; y < smfHeader.mapy; y++)
+		{
+			u32 index =
+			tilemapPtr[]
+		}
+	}*/
+
+	memset(tilemapPtr, 0, tilemapSize);
+
+	memset(metalmapPtr, 0, metalmapSize);
+
+	//--- Write to final buffer ---
+	//std::vector<boost::uint8_t>& smb = fileSMF->buffer;
+	AppendToBuffer(fileSMF, smfHeader);
+
+	AppendToBuffer(fileSMF, vegHeader);
+	AppendToBuffer(fileSMF, vegmapOffset);
+	AppendToBuffer(fileSMF, vegmapPtr, vegmapSize);
+
+	AppendToBuffer(fileSMF, heightmapPtr, heightmapSize);
+	AppendToBuffer(fileSMF, typemapPtr, typemapSize);
+
+	AppendToBuffer(fileSMF, smfTile);
+	AppendToBuffer(fileSMF, numSmallTiles);
+	AppendToBuffer(fileSMF, smtFileName, sizeof(smtFileName));
+	AppendToBuffer(fileSMF, tilemapPtr, tilemapSize);
+
+	AppendToBuffer(fileSMF, metalmapPtr, metalmapSize);
+	AppendToBuffer(fileSMF, smfFeature);
+
+	delete[] heightmapPtr;
+	delete[] typemapPtr;
+	delete[] metalmapPtr;
+	delete[] tilemapPtr;
+	delete[] vegmapPtr;
+}
+
+void CMapGenerator::GenerateMapInfo(CVirtualArchive* archive)
+{
+
+	CVirtualFile* fileMapInfo = archive->AddFile("mapinfo.lua");
+
+	//Open template mapinfo.lua
+	const std::string luaTemplate = "mapgenerator/mapinfo_template.lua";
+	CFileHandler fh(luaTemplate, SPRING_VFS_PWD_ALL);
+	if(!fh.FileExists())
+	{
+		throw content_error("Error generating map: " + luaTemplate + " not found");
+	}
+
+	std::string luaInfo;
+	fh.LoadStringData(luaInfo);
+
+	//Make info to put in mapinfo
+	std::stringstream ss;
+	std::string startPosString;
+	const std::vector<int2>& startPositions = GetStartPositions();
+	for(size_t x = 0; x < startPositions.size(); x++)
+	{
+		ss << "[" << x << "] = {startPos = {x = " << startPositions[x].x << ", z = " << startPositions[x].y << "}},";
+	}
+	startPosString = ss.str();
+
+	//Replace tags in mapinfo.lua
+	boost::replace_first(luaInfo, "${NAME}", setup->mapName);
+	boost::replace_first(luaInfo, "${DESCRIPTION}", GetMapDescription());
+	boost::replace_first(luaInfo, "${START_POSITIONS}", startPosString);
+
+	//Copy to filebuffer
+	fileMapInfo->buffer.assign(luaInfo.begin(), luaInfo.end());
+}
+
+void CMapGenerator::GenerateSMT(CVirtualArchive* archive)
+{
+	CVirtualFile* fileSMT = archive->AddFile("maps/generated.smt");
+
+	const int tileSize = 32;
+
+	//--- Make TileFileHeader ---
+	TileFileHeader smtHeader;
+	strcpy(smtHeader.magic, "spring tilefile");
+	smtHeader.version = 1;
+	smtHeader.numTiles = 1; //32 * 32 * (generator->GetMapSize().x * 32) * (generator->GetMapSize().y * 32);
+	smtHeader.tileSize = tileSize;
+	smtHeader.compressionType = 1;
+
+	const int bpp = 3;
+	int tilePos = 0;
+	unsigned char tileData[tileSize * tileSize * bpp];
+	for(int x = 0; x < tileSize; x++)
+	{
+		for(int y = 0; y < tileSize; y++)
+		{
+			tileData[tilePos] = 0;
+			tileData[tilePos + 1] = 0xFF;
+			tileData[tilePos + 2] = 0;
+			tilePos += bpp;
+		}
+	}
+	glClearErrors();
+	GLuint tileTex;
+	glGenTextures(1, &tileTex);
+	glBindTexture(GL_TEXTURE_2D, tileTex);
+
+	glTexImage2D(GL_TEXTURE_2D, 0, GL_COMPRESSED_RGB_S3TC_DXT1_EXT, tileSize, tileSize, 0, GL_RGB, GL_UNSIGNED_BYTE, tileData);
+	glGenerateMipmapEXT(GL_TEXTURE_2D);
+	char tileDataDXT[SMALL_TILE_SIZE];
+
+	int dxtImageOffset = 0;
+	int dxtImageSize = 512;
+	for(int x = 0; x < 4; x++)
+	{
+		glGetCompressedTexImage(GL_TEXTURE_2D, x, tileDataDXT + dxtImageOffset);
+		dxtImageOffset += dxtImageSize;
+		dxtImageSize /= 4;
+	}
+
+	glDeleteTextures(1, &tileTex);
+
+	GLenum errorcode = glGetError();
+	if(errorcode != GL_NO_ERROR)
+	{
+		throw content_error("Error generating map - texture generation not supported");
+	}
+
+	size_t totalSize = sizeof(TileFileHeader);
+	fileSMT->buffer.resize(totalSize);
+
+	int writePosition = 0;
+	memcpy(&(fileSMT->buffer[writePosition]), &smtHeader, sizeof(smtHeader));
+	writePosition += sizeof(smtHeader);
+
+	fileSMT->buffer.resize(fileSMT->buffer.size() + smtHeader.numTiles * SMALL_TILE_SIZE);
+	for(int x = 0; x < smtHeader.numTiles; x++)
+	{
+		memcpy(&(fileSMT->buffer[writePosition]), tileDataDXT, SMALL_TILE_SIZE);
+		writePosition += SMALL_TILE_SIZE;
+	}
+}

--- a/rts/Map/Generation/MapGenerator.h
+++ b/rts/Map/Generation/MapGenerator.h
@@ -1,0 +1,56 @@
+/* This file is part of the Spring engine (GPL v2 or later), see LICENSE.html */
+
+#ifndef _MAP_GENERATOR_H_
+#define _MAP_GENERATOR_H_
+
+#include "Game/GameSetup.h"
+#include "System/Vec2.h"
+#include "Map/SMF/SMFReadMap.h"
+
+class CVirtualFile;
+class CVirtualArchive;
+class CMapGenerator
+{
+public:
+	virtual ~CMapGenerator();
+
+	void Generate();
+
+protected:
+	CMapGenerator(const CGameSetup* setup);
+
+	const CGameSetup* const setup;
+
+	std::vector<float>& GetHeightMap()
+	{ return heightMap; }
+
+	virtual int2 GetGridSize() const
+	{ return int2(GetMapSize().x * CSMFReadMap::bigSquareSize, GetMapSize().y * CSMFReadMap::bigSquareSize); }
+
+private:
+	void GenerateSMF(CVirtualArchive* archive);
+	void GenerateMapInfo(CVirtualArchive* archive);
+	void GenerateSMT(CVirtualArchive* archive);
+
+	template<typename T>
+	void AppendToBuffer(CVirtualFile* file, const T& data)
+	{ AppendToBuffer(file, &data, sizeof(T)); }
+
+	template<typename T>
+	void SetToBuffer(CVirtualFile* file, const T& data, int position)
+	{ SetToBuffer(file, &data, sizeof(T), position); }
+
+	void AppendToBuffer(CVirtualFile* file, const void* data, int size);
+	void SetToBuffer(CVirtualFile* file, const void* data, int size, int position);
+
+	virtual void GenerateMap() = 0;
+	virtual const int2& GetMapSize() const = 0;
+	virtual const std::vector<int2>& GetStartPositions() const = 0;
+	virtual const std::string& GetMapDescription() const = 0;
+
+	std::vector<float> heightMap;
+	std::vector<float> metalMap;
+
+};
+
+#endif // _MAP_GENERATOR_H_

--- a/rts/Map/Generation/SimpleMapGenerator.cpp
+++ b/rts/Map/Generation/SimpleMapGenerator.cpp
@@ -1,0 +1,36 @@
+/* This file is part of the Spring engine (GPL v2 or later), see LICENSE.html */
+
+#include "SimpleMapGenerator.h"
+
+CSimpleMapGenerator::CSimpleMapGenerator(const CGameSetup* setup) : CMapGenerator(setup)
+{
+	GenerateInfo();
+}
+
+CSimpleMapGenerator::~CSimpleMapGenerator()
+{
+
+}
+
+void CSimpleMapGenerator::GenerateInfo()
+{
+	mapSize = int2(5, 5);
+}
+
+void CSimpleMapGenerator::GenerateMap()
+{
+	startPositions.push_back(int2(20, 20));
+	startPositions.push_back(int2(500, 500));
+
+	mapDescription = "The Split Canyon";
+
+	int2 gs = GetGridSize();
+	std::vector<float>& map = GetHeightMap();
+	for(int x = 0; x < gs.x; x++)
+	{
+		for(int y = 0; y < gs.y; y++)
+		{
+			map[y * gs.x + x] = 50.0f;
+		}
+	}
+}

--- a/rts/Map/Generation/SimpleMapGenerator.h
+++ b/rts/Map/Generation/SimpleMapGenerator.h
@@ -1,0 +1,33 @@
+/* This file is part of the Spring engine (GPL v2 or later), see LICENSE.html */
+
+#ifndef _SIMPLE_MAP_GENERATOR_H_
+#define _SIMPLE_MAP_GENERATOR_H_
+
+#include "MapGenerator.h"
+
+class CSimpleMapGenerator : public CMapGenerator
+{
+public:
+	CSimpleMapGenerator(const CGameSetup* setup);
+	virtual ~CSimpleMapGenerator();
+
+private:
+	void GenerateInfo();
+
+	virtual void GenerateMap();
+
+	virtual const int2& GetMapSize() const
+	{ return mapSize; }
+
+	virtual const std::vector<int2>& GetStartPositions() const
+	{ return startPositions; }
+
+	virtual const std::string& GetMapDescription() const
+	{ return mapDescription; }
+
+	std::vector<int2> startPositions;
+	int2 mapSize;
+	std::string mapDescription;
+};
+
+#endif // _SIMPLE_MAP_GENERATOR_H_

--- a/rts/Rendering/Env/IGroundDecalDrawer.h
+++ b/rts/Rendering/Env/IGroundDecalDrawer.h
@@ -8,7 +8,7 @@
 //class CUnit;
 class CSolidObject;
 //struct CExplosionEvent;
-class SolidObjectGroundDecal;
+struct SolidObjectGroundDecal;
 struct S3DModel;
 
 struct GhostSolidObject {

--- a/rts/System/FileSystem/ArchiveLoader.cpp
+++ b/rts/System/FileSystem/ArchiveLoader.cpp
@@ -9,6 +9,7 @@
 #include "Archives/DirArchive.h"
 #include "Archives/ZipArchive.h"
 #include "Archives/SevenZipArchive.h"
+#include "Archives/VirtualArchive.h"
 
 #include "FileSystem.h"
 #include "DataDirsAccess.h"
@@ -23,6 +24,7 @@ CArchiveLoader::CArchiveLoader()
 	AddFactory(new CDirArchiveFactory());
 	AddFactory(new CZipArchiveFactory());
 	AddFactory(new CSevenZipArchiveFactory());
+	AddFactory(new CVirtualArchiveFactory());
 }
 
 CArchiveLoader::~CArchiveLoader()

--- a/rts/System/FileSystem/ArchiveScanner.h
+++ b/rts/System/FileSystem/ArchiveScanner.h
@@ -118,6 +118,7 @@ public:
 	unsigned int GetArchiveCompleteChecksum(const std::string& name) const;
 	/// like GetArchiveCompleteChecksum, throws exception if mismatch
 	void CheckArchive(const std::string& name, unsigned checksum) const;
+	void ScanArchive(const std::string& fullName, bool checksum = false);
 
 	std::string ArchiveFromName(const std::string& s) const;
 	std::string NameFromArchive(const std::string& s) const;
@@ -178,7 +179,6 @@ private:
 	void ScanDirs(const std::vector<std::string>& dirs, bool checksum = false);
 	void Scan(const std::string& curPath, bool doChecksum);
 
-	void ScanArchive(const std::string& fullName, bool checksum = false);
 	/// scan mapinfo / modinfo lua files
 	bool ScanArchiveLua(IArchive* ar, const std::string& fileName, ArchiveInfo& ai, std::string& err);
 

--- a/rts/System/FileSystem/Archives/CMakeLists.txt
+++ b/rts/System/FileSystem/Archives/CMakeLists.txt
@@ -10,6 +10,7 @@ add_library(archives STATIC
 	IArchive.cpp
 	PoolArchive.cpp
 	SevenZipArchive.cpp
+	VirtualArchive.cpp
 	ZipArchive.cpp
 	${sources_engine_System_Log}
 	${sources_engine_System_Log_sinkConsole}

--- a/rts/System/FileSystem/Archives/VirtualArchive.cpp
+++ b/rts/System/FileSystem/Archives/VirtualArchive.cpp
@@ -1,0 +1,164 @@
+/* This file is part of the Spring engine (GPL v2 or later), see LICENSE.html */
+
+#include "VirtualArchive.h"
+#include "System/FileSystem/FileSystem.h"
+#include "System/FileSystem/DataDirsAccess.h"
+#include "System/FileSystem/FileQueryFlags.h"
+#include "System/Log/ILog.h"
+
+#include "minizip/zip.h"
+#include <cassert>
+
+CVirtualArchiveFactory* virtualArchiveFactory;
+
+CVirtualArchiveFactory::CVirtualArchiveFactory() : IArchiveFactory("sva")
+{
+	virtualArchiveFactory = this;
+}
+
+CVirtualArchiveFactory::~CVirtualArchiveFactory()
+{
+	virtualArchiveFactory = 0;
+}
+
+CVirtualArchive* CVirtualArchiveFactory::AddArchive(const std::string& fileName)
+{
+	CVirtualArchive* archive = new CVirtualArchive(fileName);
+	archives.push_back(archive);
+	return archive;
+}
+
+IArchive* CVirtualArchiveFactory::DoCreateArchive(const std::string& fileName) const
+{
+	const std::string baseName = FileSystem::GetBasename(fileName);
+
+	for(std::vector<CVirtualArchive*>::const_iterator it = archives.begin(); it != archives.end(); ++it)
+	{
+		CVirtualArchive* archive = *it;
+		if(archive->GetFileName() == baseName)
+		{
+			return archive->Open();
+		}
+	}
+
+	return 0;
+}
+
+CVirtualArchiveOpen::CVirtualArchiveOpen(CVirtualArchive* archive, const std::string& fileName) : IArchive(fileName), archive(archive)
+{
+	//Set subclass name index to archive's index (doesn't update while archive is open)
+	lcNameIndex = archive->GetNameIndex();
+}
+
+CVirtualArchiveOpen::~CVirtualArchiveOpen()
+{
+}
+
+bool CVirtualArchiveOpen::IsOpen()
+{
+	//Virtual archives are stored in memory and as such always open
+	return true;
+}
+
+unsigned int CVirtualArchiveOpen::NumFiles() const
+{
+	return archive->NumFiles();
+}
+
+bool CVirtualArchiveOpen::GetFile( unsigned int fid, std::vector<boost::uint8_t>& buffer )
+{
+	return archive->GetFile(fid, buffer);
+}
+
+void CVirtualArchiveOpen::FileInfo( unsigned int fid, std::string& name, int& size ) const
+{
+	return archive->FileInfo(fid, name, size);
+}
+
+CVirtualArchive::CVirtualArchive(const std::string& fileName) : fileName(fileName)
+{
+}
+
+CVirtualArchive::~CVirtualArchive()
+{
+	for(std::vector<CVirtualFile*>::iterator it = files.begin(); it != files.end(); ++it)
+	{
+		delete *it;
+	}
+	files.clear();
+
+}
+
+CVirtualArchiveOpen* CVirtualArchive::Open()
+{
+	return new CVirtualArchiveOpen(this, fileName);
+}
+
+unsigned int CVirtualArchive::NumFiles() const
+{
+	return files.size();
+}
+
+bool CVirtualArchive::GetFile( unsigned int fid, std::vector<boost::uint8_t>& buffer )
+{
+	if(fid >= files.size()) return false;
+
+	CVirtualFile* file = files[fid];
+	buffer = file->buffer;
+
+	return true;
+}
+
+void CVirtualArchive::FileInfo( unsigned int fid, std::string& name, int& size ) const
+{
+	assert(fid < files.size());
+
+	CVirtualFile* file = files[fid];
+	name = file->GetName();
+	size = file->buffer.size();
+}
+
+CVirtualFile* CVirtualArchive::AddFile(const std::string& name)
+{
+	unsigned int fidcounter = files.size();
+	CVirtualFile* file = new CVirtualFile(fidcounter, name);
+	files.push_back(file);
+
+	lcNameIndex[name] = fidcounter;
+
+	return file;
+}
+
+void CVirtualArchive::WriteToFile()
+{
+	std::string zipFilePath = dataDirsAccess.LocateFile(fileName, FileQueryFlags::WRITE) + ".sdz";
+	LOG("Writing zip file for virtual archive %s to %s", fileName.c_str(), zipFilePath.c_str());
+
+	zipFile zip = zipOpen(zipFilePath.c_str(), APPEND_STATUS_CREATE);
+	if(!zip)
+	{
+		LOG("Could not open zip file %s for writing", zipFilePath.c_str());
+		return;
+	}
+
+	for(std::vector<CVirtualFile*>::iterator it = files.begin(); it != files.end(); ++it)
+	{
+		CVirtualFile* file = *it;
+
+		zipOpenNewFileInZip(zip, file->GetName().c_str(), NULL, NULL, 0, NULL, 0, NULL, Z_DEFLATED, Z_BEST_COMPRESSION);
+		zipWriteInFileInZip(zip, file->buffer.data(), file->buffer.size());
+		zipCloseFileInZip(zip);
+	}
+
+	zipClose(zip, NULL);
+}
+
+CVirtualFile::CVirtualFile(int fid, const std::string& name) : name(name), fid(fid)
+{
+
+}
+
+CVirtualFile::~CVirtualFile()
+{
+
+}

--- a/rts/System/FileSystem/Archives/VirtualArchive.h
+++ b/rts/System/FileSystem/Archives/VirtualArchive.h
@@ -1,0 +1,110 @@
+/* This file is part of the Spring engine (GPL v2 or later), see LICENSE.html */
+
+#ifndef _VIRTUAL_ARCHIVE_H
+#define _VIRTUAL_ARCHIVE_H
+
+#include "ArchiveFactory.h"
+#include "IArchive.h"
+#include <vector>
+#include <string>
+
+class CVirtualArchive;
+
+/**
+ * Creates virtual non-existing archives which can be created during runtime
+ */
+class CVirtualArchiveFactory : public IArchiveFactory {
+public:
+	CVirtualArchiveFactory();
+	virtual ~CVirtualArchiveFactory();
+
+	/**
+	 * Registers and creates a new virtual archive to the factory
+	 * @param filePath Path with which the archive can be found and opened
+	 */
+	CVirtualArchive* AddArchive(const std::string& fileName);
+
+private:
+	IArchive* DoCreateArchive(const std::string& fileName) const;
+
+	std::vector<CVirtualArchive*> archives;
+};
+
+extern CVirtualArchiveFactory* virtualArchiveFactory;
+
+/**
+ * A file in a virtual archive
+ */
+class CVirtualFile
+{
+public:
+	CVirtualFile(int fid, const std::string& name);
+	virtual ~CVirtualFile();
+
+	std::vector<boost::uint8_t> buffer;
+
+	const std::string& GetName() const
+	{ return name; }
+
+	int GetFID() const
+	{ return fid; }
+
+private:
+	const std::string name;
+	int fid;
+};
+
+/**
+ * An opened virtual archive, as archives get deleted after being
+ * opened with IArchiveFactory::DoCreateArchive all the data in a virtual archive is lost.
+ * Therefore an 'opened' class is created and the actual archive is preserved
+ */
+class CVirtualArchiveOpen : public IArchive
+{
+public:
+	CVirtualArchiveOpen(CVirtualArchive* archive, const std::string& fileName);
+	virtual ~CVirtualArchiveOpen();
+
+	virtual bool IsOpen();
+	virtual unsigned int NumFiles() const;
+	virtual bool GetFile( unsigned int fid, std::vector<boost::uint8_t>& buffer );
+	virtual void FileInfo( unsigned int fid, std::string& name, int& size ) const;
+
+private:
+	CVirtualArchive* archive;
+};
+
+/**
+ * A virtual archive
+ */
+class CVirtualArchive
+{
+public:
+	CVirtualArchive(const std::string& fileName);
+	virtual ~CVirtualArchive();
+
+	CVirtualArchiveOpen* Open();
+	CVirtualFile* AddFile(const std::string& file);
+
+	unsigned int NumFiles() const;
+	bool GetFile( unsigned int fid, std::vector<boost::uint8_t>& buffer );
+	void FileInfo( unsigned int fid, std::string& name, int& size ) const;
+
+	const std::string& GetFileName() const
+	{ return fileName; }
+
+	const std::map<std::string, unsigned int>& GetNameIndex() const
+	{ return lcNameIndex; }
+
+	void WriteToFile();
+
+private:
+	friend class CVirtualArchiveOpen;
+
+	std::vector<CVirtualFile*> files;
+	std::string fileName;
+	std::map<std::string, unsigned int> lcNameIndex;
+
+};
+
+#endif // _VIRTUAL_ARCHIVE_H


### PR DESCRIPTION
Added the possiblity of generating maps to spring.

When a MapSeed is added to script.txt, the generator creates an archive in memory using the name given in MapName.

I've added a CVirtualArchive class which is an archive that can be created and manipulated during runtime (unlike the existing ones which require files to be on disk)

CMapGenerator contains all the base code for map generation, such as creating the actual archive and putting the smf, smt, and mapinfo.lua in.

CSImpleMapGenerator is a simple example generation class (to be improved upon) which generates a flat landscape and places spawnpoints.

In the future, a lua-based map generator could be added for example, so map scripts could be used instead of actual maps, which are much smaller and would add a ton of variety.
