### PR TITLE
Update create_Mac_bundle.sh

### DIFF
--- a/buildbot/slave/osx/create_Mac_bundle.sh
+++ b/buildbot/slave/osx/create_Mac_bundle.sh
@@ -70,6 +70,9 @@ do
 		echo "---- installing ${dylib}"
 		cp ${MACPORTS_BASE}/${dylib} lib
 
+		# strip down lib's subdirectories (if any)
+		dylib=lib/`echo ${dylib} | egrep -o [^/]*$`
+
 		# take write permissions on the bundled lib
 		chmod u+w ${dylib}
 


### PR DESCRIPTION
Support sub-directories in Macports library folder (motivated by gcc47 sub-directorizing its libraries in "lib/gcc47/lib_" instead of "lib/lib_")
