### PR TITLE
Fix possible crash in unit_script.lua

### DIFF
--- a/cont/base/springcontent/LuaGadgets/Gadgets/unit_script.lua
+++ b/cont/base/springcontent/LuaGadgets/Gadgets/unit_script.lua
@@ -374,7 +374,7 @@ function Spring.UnitScript.StartThread(fun, ...)
 	local thread = {
 		thread = co,
 		-- signal_mask is inherited from current thread, if any
-		signal_mask = (co_running() and activeUnit.threads[co_running()].signal_mask or 0),
+		signal_mask = (co_running() and (activeUnit.threads[co_running()] and activeUnit.threads[co_running()].signal_mask) or 0),
 		unitID = activeUnit.unitID,
 	}
 


### PR DESCRIPTION
Lua crash can occur here if a gadget using coroutines calls an animation in a LUS script, as the running coroutine does not belong to the activeUnit.
