### PR TITLE
Two more functions for LUA math module 

### DIFF
--- a/rts/Lua/CMakeLists.txt
+++ b/rts/Lua/CMakeLists.txt
@@ -19,6 +19,7 @@ SET(sources_engine_Lua
 		"${CMAKE_CURRENT_SOURCE_DIR}/LuaInputReceiver.cpp"
 		"${CMAKE_CURRENT_SOURCE_DIR}/LuaIntro.cpp"
 		"${CMAKE_CURRENT_SOURCE_DIR}/LuaMaterial.cpp"
+		"${CMAKE_CURRENT_SOURCE_DIR}/LuaMathExtra.cpp"
 		"${CMAKE_CURRENT_SOURCE_DIR}/LuaMetalMap.cpp"
 		"${CMAKE_CURRENT_SOURCE_DIR}/LuaOpenGL.cpp"
 		"${CMAKE_CURRENT_SOURCE_DIR}/LuaOpenGLUtils.cpp"

--- a/rts/Lua/LuaHandle.cpp
+++ b/rts/Lua/LuaHandle.cpp
@@ -10,6 +10,7 @@
 #include "LuaHashString.h"
 #include "LuaOpenGL.h"
 #include "LuaBitOps.h"
+#include "LuaMathExtra.h"
 #include "LuaUtils.h"
 #include "LuaZip.h"
 #include "Game/GlobalUnsynced.h"
@@ -2920,6 +2921,7 @@ bool CLuaHandle::AddBasicCalls(lua_State *L)
 	// extra math utilities
 	lua_getglobal(L, "math");
 	LuaBitOps::PushEntries(L);
+	LuaMathExtra::PushEntries(L);
 	lua_pop(L, 1);
 
 	return true;

--- a/rts/Lua/LuaMathExtra.cpp
+++ b/rts/Lua/LuaMathExtra.cpp
@@ -1,0 +1,54 @@
+/* This file is part of the Spring engine (GPL v2 or later), see LICENSE.html */
+
+#include "streflop_cond.h"
+#include "LuaMathExtra.h"
+#include "LuaInclude.h"
+#include "LuaUtils.h"
+
+
+/******************************************************************************/
+/******************************************************************************/
+
+bool LuaMathExtra::PushEntries(lua_State* L)
+{
+	LuaPushNamedCFunc(L, "hypot",  hypot);
+	LuaPushNamedCFunc(L, "diag",   diag);
+	LuaPushNamedCFunc(L, "clamp",  clamp);
+	return true;
+}
+
+
+/******************************************************************************/
+/******************************************************************************/
+
+int LuaMathExtra::hypot (lua_State *L) {
+  lua_pushnumber(L, math::hypot(luaL_checknumber_noassert(L, 1), luaL_checknumber_noassert(L, 2)));
+  return 1;
+}
+
+int LuaMathExtra::diag (lua_State *L) {
+  int n = lua_gettop(L);  /* number of arguments */
+  lua_Number res = 0.0f;
+  int i;
+  for (i=1; i<=n; i++) {
+    lua_Number d = luaL_checknumber_noassert(L, i);
+    res += d*d;
+  }
+  lua_pushnumber(L, math::sqrt(res));
+  return 1;
+}
+
+int LuaMathExtra::clamp (lua_State *L) {
+  lua_Number clamp = luaL_checknumber_noassert(L, 1);
+  lua_Number lbound = luaL_checknumber_noassert(L, 2);
+  lua_Number ubound = luaL_checknumber_noassert(L, 3);
+  if (clamp < lbound)
+    clamp = lbound;
+  else if (clamp > ubound)
+    clamp = ubound;
+  lua_pushnumber(L, clamp);
+  return 1;
+}
+
+/******************************************************************************/
+/******************************************************************************/

--- a/rts/Lua/LuaMathExtra.h
+++ b/rts/Lua/LuaMathExtra.h
@@ -1,0 +1,18 @@
+/* This file is part of the Spring engine (GPL v2 or later), see LICENSE.html */
+
+#ifndef LUA_MATH_EXTRA_H
+#define LUA_MATH_EXTRA_H
+
+struct lua_State;
+
+class LuaMathExtra {
+	public:
+		static bool PushEntries(lua_State* L);
+
+	private:
+		static int hypot(lua_State* L);
+		static int diag(lua_State* L);
+		static int clamp(lua_State* L);
+};
+
+#endif /* LUA_MATH_EXTRA_H */

--- a/rts/lib/lua/src/lmathlib.cpp
+++ b/rts/lib/lua/src/lmathlib.cpp
@@ -120,23 +120,6 @@ static int math_sqrt (lua_State *L) {
   return 1;
 }
 
-static int math_hypot (lua_State *L) {
-  lua_pushnumber(L, math::hypot(luaL_checknumber_noassert(L, 1), luaL_checknumber_noassert(L, 2)));
-  return 1;
-}
-
-static int math_diag (lua_State *L) {
-  int n = lua_gettop(L);  /* number of arguments */
-  lua_Number res = 0.0f;
-  int i;
-  for (i=1; i<=n; i++) {
-    lua_Number d = luaL_checknumber_noassert(L, i);
-    res += d*d;
-  }
-  lua_pushnumber(L, math::sqrt(res));
-  return 1;
-}
-
 static int math_pow (lua_State *L) {
   lua_pushnumber(L, math::pow(luaL_checknumber_noassert(L, 1), luaL_checknumber_noassert(L, 2)));
   return 1;
@@ -209,19 +192,6 @@ static int math_max (lua_State *L) {
 }
 
 
-static int math_clamp (lua_State *L) {
-  lua_Number clamp = luaL_checknumber_noassert(L, 1);
-  lua_Number lbound = luaL_checknumber_noassert(L, 2);
-  lua_Number ubound = luaL_checknumber_noassert(L, 3);
-  if (clamp < lbound)
-    clamp = lbound;
-  else if (clamp > ubound)
-    clamp = ubound;
-  lua_pushnumber(L, clamp);
-  return 1;
-}
-
-
 static int lua_streflop_random_seed = 0;
 
 static int math_random (lua_State *L) {
@@ -281,16 +251,13 @@ static const luaL_Reg mathlib[] = {
   {"atan2", math_atan2},
   {"atan",  math_atan},
   {"ceil",  math_ceil},
-  {"clamp", math_clamp},
   {"cosh",   math_cosh},
   {"cos",   math_cos},
   {"deg",   math_deg},
-  {"diag",  math_diag},
   {"exp",   math_exp},
   {"floor", math_floor},
   {"fmod",   math_fmod},
   {"frexp", math_frexp},
-  {"hypot", math_hypot},
   {"ldexp", math_ldexp},
   {"log10", math_log10},
   {"log",   math_log},


### PR DESCRIPTION
That hypot turned out to be a performance flop, but math.diag() might be an interesting alternative
I'm also surprized that clamp didn't exist
