### PR TITLE
Update FastMath.h

### DIFF
--- a/rts/System/FastMath.h
+++ b/rts/System/FastMath.h
@@ -11,7 +11,7 @@
 #include "System/maindefines.h"
 
 #ifdef _MSC_VER
-#define __builtin_sqrtf math::sqrtf
+#define __builtin_sqrtf streflop::sqrtf
 #endif
 
 #ifdef __GNUC__


### PR DESCRIPTION
fixes compiling issues on Visual Studio 2012 CTP
