### PR TITLE
Fix clang error

### DIFF
--- a/rts/Rendering/Textures/S3OTextureHandler.cpp
+++ b/rts/Rendering/Textures/S3OTextureHandler.cpp
@@ -97,7 +97,7 @@ int CS3OTextureHandler::LoadS3OTextureNow(const S3DModel* model)
 		if (model->invertTexYAxis)
 			texBitMaps[0].ReverseYAxis();
 
-		textureCache[model->tex1] = {texBitMaps[0].CreateTexture(true), texBitMaps[0].xsize, texBitMaps[0].ysize};
+		textureCache[model->tex1] = {texBitMaps[0].CreateTexture(true), (unsigned int)texBitMaps[0].xsize, (unsigned int)texBitMaps[0].ysize};
 	}
 
 	if (texCacheIters[1] == textureCache.end()) {
@@ -114,7 +114,7 @@ int CS3OTextureHandler::LoadS3OTextureNow(const S3DModel* model)
 		if (model->invertTexYAxis)
 			texBitMaps[1].ReverseYAxis();
 
-		textureCache[model->tex2] = {texBitMaps[1].CreateTexture(true), texBitMaps[1].xsize, texBitMaps[1].ysize};
+		textureCache[model->tex2] = {texBitMaps[1].CreateTexture(true), (unsigned int)texBitMaps[1].xsize, (unsigned int)texBitMaps[1].ysize};
 	}
 
 	if (texCacheIters[0] == textureCache.end() || texCacheIters[1] == textureCache.end()) {


### PR DESCRIPTION
Fix this:

```
[ 37%] Building CXX object rts/builds/legacy/CMakeFiles/engine-legacy.dir/__/__/Rendering/Textures/S3OTextureHandler.cpp.o
/home/amdmi3/projects/external/spring/rts/Rendering/Textures/S3OTextureHandler.cpp:100:67: error: non-constant-expression cannot be narrowed from type 'int' to
      'unsigned int' in initializer list [-Wc++11-narrowing]
                textureCache[model->tex1] = {texBitMaps[0].CreateTexture(true), texBitMaps[0].xsize, texBitMaps[0].ysize};
                                                                                ^~~~~~~~~~~~~~~~~~~
/home/amdmi3/projects/external/spring/rts/Rendering/Textures/S3OTextureHandler.cpp:100:67: note: override this message by inserting an explicit cast
                textureCache[model->tex1] = {texBitMaps[0].CreateTexture(true), texBitMaps[0].xsize, texBitMaps[0].ysize};
                                                                                ^~~~~~~~~~~~~~~~~~~
                                                                                static_cast<unsigned int>( )
/home/amdmi3/projects/external/spring/rts/Rendering/Textures/S3OTextureHandler.cpp:100:88: error: non-constant-expression cannot be narrowed from type 'int' to
      'unsigned int' in initializer list [-Wc++11-narrowing]
                textureCache[model->tex1] = {texBitMaps[0].CreateTexture(true), texBitMaps[0].xsize, texBitMaps[0].ysize};
                                                                                                     ^~~~~~~~~~~~~~~~~~~
/home/amdmi3/projects/external/spring/rts/Rendering/Textures/S3OTextureHandler.cpp:100:88: note: override this message by inserting an explicit cast
                textureCache[model->tex1] = {texBitMaps[0].CreateTexture(true), texBitMaps[0].xsize, texBitMaps[0].ysize};
                                                                                                     ^~~~~~~~~~~~~~~~~~~
                                                                                                     static_cast<unsigned int>( )
/home/amdmi3/projects/external/spring/rts/Rendering/Textures/S3OTextureHandler.cpp:117:67: error: non-constant-expression cannot be narrowed from type 'int' to
      'unsigned int' in initializer list [-Wc++11-narrowing]
                textureCache[model->tex2] = {texBitMaps[1].CreateTexture(true), texBitMaps[1].xsize, texBitMaps[1].ysize};
                                                                                ^~~~~~~~~~~~~~~~~~~
/home/amdmi3/projects/external/spring/rts/Rendering/Textures/S3OTextureHandler.cpp:117:67: note: override this message by inserting an explicit cast
                textureCache[model->tex2] = {texBitMaps[1].CreateTexture(true), texBitMaps[1].xsize, texBitMaps[1].ysize};
                                                                                ^~~~~~~~~~~~~~~~~~~
                                                                                static_cast<unsigned int>( )
/home/amdmi3/projects/external/spring/rts/Rendering/Textures/S3OTextureHandler.cpp:117:88: error: non-constant-expression cannot be narrowed from type 'int' to
      'unsigned int' in initializer list [-Wc++11-narrowing]
                textureCache[model->tex2] = {texBitMaps[1].CreateTexture(true), texBitMaps[1].xsize, texBitMaps[1].ysize};
                                                                                                     ^~~~~~~~~~~~~~~~~~~
/home/amdmi3/projects/external/spring/rts/Rendering/Textures/S3OTextureHandler.cpp:117:88: note: override this message by inserting an explicit cast
                textureCache[model->tex2] = {texBitMaps[1].CreateTexture(true), texBitMaps[1].xsize, texBitMaps[1].ysize};
                                                                                                     ^~~~~~~~~~~~~~~~~~~
                                                                                                     static_cast<unsigned int>( )
4 errors generated.
```
