### PR TITLE
fix clang warning: <...> hides overloaded virtual function

### DIFF
--- a/rts/Rendering/ProjectileDrawer.cpp
+++ b/rts/Rendering/ProjectileDrawer.cpp
@@ -745,7 +745,7 @@ bool CProjectileDrawer::DrawProjectileModel(const CProjectile* p, bool shadowPas
 		glPushMatrix();
 			glMultMatrixf(wp->GetTransformMatrix(wp->GetProjectileType() == WEAPON_MISSILE_PROJECTILE));
 
-			if (!(/*p->luaDraw &&*/ eventHandler.DrawProjectile(p))) {
+			if (!(/*p->luaDraw &&*/ eventHandler.DrawProjectile(p, true, true))) {
 				wp->model->DrawStatic();
 			}
 		glPopMatrix();
@@ -766,7 +766,7 @@ bool CProjectileDrawer::DrawProjectileModel(const CProjectile* p, bool shadowPas
 			glTranslatef3(pp->pos);
 			glRotatef(pp->spinAngle, pp->spinVec.x, pp->spinVec.y, pp->spinVec.z);
 
-			if (!(/*p->luaDraw &&*/ eventHandler.DrawProjectile(p))) {
+			if (!(/*p->luaDraw &&*/ eventHandler.DrawProjectile(p, true, true))) {
 				glCallList(pp->dispList);
 			}
 		glPopMatrix();

--- a/rts/System/EventClient.cpp
+++ b/rts/System/EventClient.cpp
@@ -137,7 +137,7 @@ void CEventClient::DrawInMiniMap() {}
 bool CEventClient::DrawUnit(const CUnit* unit) { return false; }
 bool CEventClient::DrawFeature(const CFeature* feature) { return false; }
 bool CEventClient::DrawShield(const CUnit* unit, const CWeapon* weapon) { return false; }
-bool CEventClient::DrawProjectile(const CProjectile* projectile) { return false; }
+bool CEventClient::DrawProjectile(const CProjectile* projectile, bool drawReflection, bool drawRefraction) { return false; }
 
 void CEventClient::GameProgress(int gameFrame) {}
 

--- a/rts/System/EventClient.h
+++ b/rts/System/EventClient.h
@@ -300,7 +300,7 @@ class CEventClient
 		virtual bool DrawUnit(const CUnit* unit);
 		virtual bool DrawFeature(const CFeature* feature);
 		virtual bool DrawShield(const CUnit* unit, const CWeapon* weapon);
-		virtual bool DrawProjectile(const CProjectile* projectile);
+		virtual bool DrawProjectile(const CProjectile* projectile, bool drawReflection, bool drawRefraction);
 
 		virtual void GameProgress(int gameFrame);
 

--- a/rts/System/EventHandler.cpp
+++ b/rts/System/EventHandler.cpp
@@ -583,7 +583,7 @@ DRAW_CALLIN(InMiniMap)
 DRAW_ENTITY_CALLIN(Unit, (const CUnit* unit), (unit))
 DRAW_ENTITY_CALLIN(Feature, (const CFeature* feature), (feature))
 DRAW_ENTITY_CALLIN(Shield, (const CUnit* unit, const CWeapon* weapon), (unit, weapon))
-DRAW_ENTITY_CALLIN(Projectile, (const CProjectile* projectile), (projectile))
+DRAW_ENTITY_CALLIN(Projectile, (const CProjectile* projectile, bool drawReflection, bool drawRefraction), (projectile, drawReflection, drawRefraction))
 
 /******************************************************************************/
 /******************************************************************************/

--- a/rts/System/EventHandler.h
+++ b/rts/System/EventHandler.h
@@ -254,7 +254,7 @@ class CEventHandler
 		bool DrawUnit(const CUnit* unit);
 		bool DrawFeature(const CFeature* feature);
 		bool DrawShield(const CUnit* unit, const CWeapon* weapon);
-		bool DrawProjectile(const CProjectile* projectile);
+		bool DrawProjectile(const CProjectile* projectile, bool drawReflection, bool drawRefraction);
 
 		/// @brief this UNSYNCED event is generated every GameServer::gameProgressFrameInterval
 		/// it skips network queuing and caching and can be used to calculate the current catchup


### PR DESCRIPTION
i'm not sure how to correctly fix this warning.

ideas?!

with this commit warning is fixed, but idk if "eventHandler.DrawProjectile(p, true, true)" is correct.
