### PR TITLE
Fix build on FreeBSD (there's no std::_Exit)

### DIFF
--- a/rts/System/Platform/Linux/CrashHandler.cpp
+++ b/rts/System/Platform/Linux/CrashHandler.cpp
@@ -342,7 +342,7 @@ static void ForcedExitAfterFiveSecs() {
 __FORCE_ALIGN_STACK__
 static void ForcedExitAfterTenSecs() {
 	boost::this_thread::sleep(boost::posix_time::seconds(10));
-	std::_Exit(-1);
+	exit(-1);
 }
 
 


### PR DESCRIPTION
Also make ForcedExitAfterTenSecs() consistent with ForcedExitAfterFiveSecs() above
