### PR TITLE
fix #4408

### DIFF
--- a/rts/System/Platform/Threading.cpp
+++ b/rts/System/Platform/Threading.cpp
@@ -227,7 +227,7 @@ namespace Threading {
 		{
 			int workerCount = -1;
 #ifndef UNIT_TEST
-			workerCount = configHandler->GetUnsigned("WorkerThreadCount");
+			workerCount = std::min(ThreadPool::GetMaxThreads() - 1, configHandler->GetUnsigned("WorkerThreadCount"));
 			ThreadPool::SetThreadSpinTime(configHandler->GetUnsigned("WorkerThreadSpinTime"));
 #endif
 			// For latency reasons our worker threads yield rarely and so eat a lot cputime with idleing.


### PR DESCRIPTION
- if you try to set WorkerThreadCount higher than N=#_of_cores in springsettings.cfg, Threading code will only allow ThreadPool to use N-1 threads at most.
