### PR TITLE
Cpuid improvement (mantis #4445)

### DIFF
--- a/rts/System/Platform/CpuID.cpp
+++ b/rts/System/Platform/CpuID.cpp
@@ -1,13 +1,25 @@
 /* This file is part of the Spring engine (GPL v2 or later), see LICENSE.html */
 
 #include "CpuID.h"
+#include "System/Platform/Threading.h"
+#include "System/Log/ILog.h"
 //#include <cstddef>
 #ifdef _MSC_VER
 	#include <intrin.h>
 #endif
 
+#include <assert.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <errno.h>
+#include <algorithm>
+#include <sched.h>
+#include <stdio.h>
+#include <set>
+
 
 namespace springproc {
+
 #if defined(__GNUC__)
 	// function inlining breaks this
 	_noinline void ExecCPUID(unsigned int* a, unsigned int* b, unsigned int* c, unsigned int* d)
@@ -16,7 +28,7 @@ namespace springproc {
 		__asm__ __volatile__(
 			"cpuid"
 			: "=a" (*a), "=b" (*b), "=c" (*c), "=d" (*d)
-			: "0" (*a)
+			: "0" (*a), "2" (*c)
 		);
 	#else
 		#ifdef __x86_64__
@@ -56,4 +68,242 @@ namespace springproc {
 	{
 	}
 #endif
+
+	CpuId::CpuId(): shiftCore(0), shiftPackage(0),
+	  maskVirtual(0),  maskCore(0), maskPackage(0),
+	  hasLeaf11(false)
+	{
+		nbProcessors = Threading::GetLogicalCpuCores();
+		// TODO: allocating a bit more than needed, maybe move
+		// this after determining the numbers.
+
+		affinityMaskOfCores = new uint64_t[nbProcessors];
+		affinityMaskOfPackages = new uint64_t[nbProcessors];
+		processorApicIds = new uint32_t[nbProcessors];
+
+		unsigned int eax = 0, ebx = 0, ecx = 0, edx = 0;
+		eax = 0;
+		ExecCPUID(&eax, &ebx, &ecx, &edx);
+
+		// Check if it Intel
+		if (ebx == 0x756e6547) {	// "Genu", from "GenuineIntel"
+			getIdsIntel();
+		} else if (ebx == 0x68747541) {	// "htuA" from "AuthenticAMD"
+			// TODO: AMD has also something similar to SMT (called CMT) in Bulldozer
+			// microarchitecture (FX processors).
+			getIdsAmd();
+		}
+	}
+
+	// Function based on Figure 1 from Kuo_CpuTopology_rc1.rh1.final.pdf
+	void CpuId::getIdsIntel()
+	{
+		int maxLeaf;
+		unsigned int eax = 0, ebx = 0, ecx = 0, edx = 0;
+		eax = 0;
+		ExecCPUID(&eax, &ebx, &ecx, &edx);
+
+		maxLeaf = eax;
+		if (maxLeaf >= 0xB) {
+			eax = 11;
+			ecx = 0;
+			ExecCPUID(&eax, &ebx, &ecx, &edx);
+
+			// Check if cpuid leaf 11 really exists
+			if (ebx != 0) {
+				hasLeaf11 = true;
+				LOG_L(L_DEBUG,"[CpuId] leaf 11 support\n");
+				getMasksIntelLeaf11();
+				getIdsIntelEnumerate();
+				return;
+			}
+		}
+
+		if (maxLeaf >= 4) {
+			LOG_L(L_DEBUG,"[CpuId] leaf 4 support\n");
+			getMasksIntelLeaf1and4();
+			getIdsIntelEnumerate();
+			return;
+		}
+		// Either it is a very old processor, or the cpuid instruction is disabled
+		// from BIOS. Print a warning an use processor number
+		LOG_L(L_WARNING,"[CpuId] Max cpuid leaf is less than 4! Using OS processor number.\n");
+		setDefault();
+	}
+
+	void CpuId::getMasksIntelLeaf11Enumerate()
+	{
+		uint32_t currentLevel = 0;
+		unsigned int eax = 0, ebx = 0, ecx = 0, edx = 0;
+		eax = 1;
+
+		ExecCPUID(&eax, &ebx, &ecx, &edx);
+
+		eax = 11;
+		ecx = currentLevel;
+		currentLevel++;
+		ExecCPUID(&eax, &ebx, &ecx, &edx);
+
+		if ((ebx && 0xFFFF) == 0)
+			return;
+
+		if (((ecx >> 8) & 0xFF) == 1) {
+			LOG_L(L_DEBUG,"[CpuId] SMT level found\n");
+			shiftCore = eax & 0xf;
+		} else {
+			LOG_L(L_DEBUG,"[CpuId] No SMT level supported\n");
+		}
+
+		eax = 11;
+		ecx = currentLevel;
+		currentLevel++;
+		ExecCPUID(&eax, &ebx, &ecx, &edx);
+
+		if (((ecx >> 8) & 0xFF) == 2) {
+			LOG_L(L_DEBUG,"[CpuId] Core level found\n");
+			    // Practically this is shiftCore + shitVirtual so it is shiftPackage
+			    shiftPackage = eax & 0xf;
+		} else {
+			LOG_L(L_DEBUG,"[CpuId] NO Core level supported\n");
+		}
+	}
+
+	// Implementing "Sub ID Extraction Parameters for x2APIC ID" from
+	// Kuo_CpuTopology_rc1.rh1.final.pdf
+
+	void CpuId::getMasksIntelLeaf11()
+	{
+		getMasksIntelLeaf11Enumerate();
+
+		// We determined the shifts now compute the masks
+		maskVirtual = ~((-1) << shiftCore);
+		maskCore = (~((-1) << shiftPackage)) ^ maskVirtual;
+		maskPackage = (-1) << shiftPackage;
+	}
+
+	void CpuId::getMasksIntelLeaf1and4()
+	{
+		int i;
+
+		unsigned int eax = 0, ebx = 0, ecx = 0, edx = 0;
+
+		unsigned maxAddressableLogical;
+		unsigned maxAddressableCores;
+
+		eax = 1;
+		ExecCPUID(&eax, &ebx, &ecx, &edx);
+
+		maxAddressableLogical = (ebx >> 18) & 0xff;
+
+		eax = 4;
+		ecx = 0;
+		ExecCPUID(&eax, &ebx, &ecx, &edx);
+		maxAddressableCores = ((eax >> 26) & 0x3f) + 1;
+
+		shiftCore = (maxAddressableLogical / maxAddressableCores);
+		// We compute the next power of 2 that is larger than shiftPackage
+		i = 0;
+		while ((1 << i) < shiftCore)
+			i++;
+		shiftCore = i;
+
+		i = 0;
+		while ((1 << i) < maxAddressableCores)
+			i++;
+		shiftPackage = i;
+
+		// We determined the shifts now compute the masks
+		maskVirtual = ~((-1) << shiftCore);
+		maskCore = (~((-1) << shiftPackage)) ^ maskVirtual;
+		maskPackage = (-1) << shiftPackage;
+	}
+
+	void CpuId::getIdsIntelEnumerate()
+	{
+		int processorNumber = Threading::GetLogicalCpuCores();
+		assert(processorNumber <= 64);	// as the affinity mask is a uint64_t
+		for (size_t processor = 0; processor < processorNumber; processor++) {
+			Threading::SetAffinity(((uint32_t) 1) << processor);
+			processorApicIds[processor] = getApicIdIntel();
+		}
+
+		std::pair < std::set < uint32_t >::iterator, bool > ret;
+		// We determine the total numbers of cores cores
+		std::set < uint32_t > cores;
+		for (size_t processor = 0; processor < processorNumber; processor++) {
+			ret = cores.insert(processorApicIds[processor] >> shiftCore);
+			if (ret.second) {
+				affinityMaskOfCores[cores.size() - 1] =
+				    ((uint64_t) 1) << processor;
+			}
+		}
+		coreTotalNumber = cores.size();
+
+		// We determine the total numbers of packages cores
+		std::set < uint32_t > packages;
+		for (size_t processor = 0; processor < processorNumber; processor++) {
+			ret =
+			    packages.
+			    insert(processorApicIds[processor] >> shiftPackage);
+			if (ret.second) {
+				affinityMaskOfPackages[packages.size() - 1] =
+				    ((uint64_t) 1) << processor;
+			}
+		}
+
+		packageTotalNumber = packages.size();
+	}
+
+	uint32_t CpuId::getApicIdIntel()
+	{
+		unsigned int eax = 0, ebx = 0, ecx = 0, edx = 0;
+
+		if (hasLeaf11) {
+			eax = 11;
+			ExecCPUID(&eax, &ebx, &ecx, &edx);
+			return edx;
+		} else {
+			eax = 1;
+			ExecCPUID(&eax, &ebx, &ecx, &edx);
+			return (unsigned char)(ebx >> 24);
+		}
+	}
+
+	void CpuId::getIdsAmd()
+	{
+		LOG_L(L_WARNING,"[CpuId] ht/smt/cmt detection for AMD is not implemented! Using processor number reported by OS.\n");
+		setDefault();
+	}
+
+	int CpuId::getCoreTotalNumber()
+	{
+		return coreTotalNumber;
+	}
+
+	int CpuId::getPackageTotalNumber()
+	{
+		return packageTotalNumber;
+	}
+
+	uint64_t CpuId::getAffinityMaskOfCore(int x)
+	{
+		return affinityMaskOfCores[x];
+	}
+
+	uint64_t CpuId::getAffinityMaskOfPackage(int x)
+	{
+		return affinityMaskOfPackages[x];
+	}
+
+	void CpuId::setDefault()
+	{
+		coreTotalNumber = Threading::GetLogicalCpuCores();
+		packageTotalNumber = Threading::GetLogicalCpuCores();
+
+		// As we could not determine anything just set affinity mask to (-1)
+		for (int i = 0; i < Threading::GetLogicalCpuCores(); i++) {
+			affinityMaskOfCores[i] = affinityMaskOfPackages[i] = -1;
+		}
+	}
+
 }

--- a/rts/System/Platform/CpuID.h
+++ b/rts/System/Platform/CpuID.h
@@ -9,8 +9,88 @@
 	#define _noinline
 #endif
 
+#include <stdint.h>
+
 namespace springproc {
 	_noinline void ExecCPUID(unsigned int* a, unsigned int* b, unsigned int* c, unsigned int* d);
+
+	/** Class to detect the processor topology, more specifically,
+	    for now it can detect the number of real (not hyper threaded
+	    core.
+	
+	    It uses 'cpuid' instructions to query the information. It
+	    implements both the new (i7 and above) and legacy (from P4 on
+	    methods).
+	    
+	    The implementation is done only for Intel processor for now, as at 
+	    the time of the writing it was not clear how to achieve a similar
+	    result for AMD CMT multithreading.
+	    
+	    This file is based on the following documentations from Intel:
+	    - "Intel® 64 Architecture Processor Topology Enumeration" 
+	      (Kuo_CpuTopology_rc1.rh1.final.pdf)
+	    - "Intel® 64 and IA-32 Architectures Software Developer’s Manual
+	     Volume 3A: System Programming Guide, Part 1"
+	      (64-ia-32-architectures-software-developer-vol-3a-part-1-manual.pdf)
+	    - "Intel® 64 and IA-32 Architectures Software Developer’s Manual
+	     Volume 2A: Instruction Set Reference, A-M"
+	      (64-ia-32-architectures-software-developer-vol-2a-manual.pdf) */
+
+	class CpuId {
+	 private:
+		void getIdsAmd();
+		void getIdsIntel();
+		void setDefault();
+
+		int nbProcessors;
+		int coreTotalNumber;
+		int packageTotalNumber;
+
+		/** Array of the size coreTotalNumber, containing for each
+		    core the affinity mask. */
+		uint64_t *affinityMaskOfCores;
+		uint64_t *affinityMaskOfPackages;
+
+		////////////////////////
+		// Intel specific fields
+
+		uint32_t* processorApicIds;
+
+		void getIdsIntelEnumerate();
+
+		void getMasksIntelLeaf11Enumerate();
+		void getMasksIntelLeaf11();
+		void getMasksIntelLeaf1and4();
+
+		uint32_t getApicIdIntel();
+
+		uint32_t shiftCore;
+		uint32_t shiftPackage;
+
+		uint32_t maskVirtual;
+		uint32_t maskCore;
+		uint32_t maskPackage;
+
+		bool hasLeaf11;
+
+		////////////////////////
+		// AMD specific fields
+
+		////////////////////////
+	 public:
+		CpuId();
+
+		/** Total number of cores in the system. This excludes SMT/HT 
+		    cores. */
+		int getCoreTotalNumber();
+
+		/** Total number of physical processor dies in the system. */
+		int getPackageTotalNumber();
+
+		uint64_t getAffinityMaskOfCore(int x);
+		uint64_t getAffinityMaskOfPackage(int x);
+	};
+
 }
 
 #endif // CPUID_H

--- a/rts/System/Platform/Threading.cpp
+++ b/rts/System/Platform/Threading.cpp
@@ -216,9 +216,13 @@ namespace Threading {
 	}
 
 
+	/** Function that returns the number of real cpu cores (not 
+	    hyperthreading ones). These are the total cores in the system
+	    (across all existing processors, if more than one)*/
 	int GetPhysicalCpuCores() {
-		//FIXME substract HTT cores here!
-		return GetLogicalCpuCores();
+		// Get CPU features
+		springproc::CpuId cpuid;
+		return cpuid.getCoreTotalNumber();;
 	}
 
 


### PR DESCRIPTION
Fix for bug 4445. Implemented cpuid based core identification for Intel processors. 
