### PR TITLE
Fix return-type and value of Pathing::GetApproximateLength

### DIFF
--- a/AI/Wrappers/Cpp/bin/combine_wrappCommands.awk
+++ b/AI/Wrappers/Cpp/bin/combine_wrappCommands.awk
@@ -229,20 +229,15 @@ function printNativeFP2F() {
 			print("\t" "internal_ret = id_clb[skirmishAIId]->Engine_handleCommand(skirmishAIId, COMMAND_TO_ID_ENGINE, -1, " topicName ", &commandData);") >> outFile_nc;
 			print("") >> outFile_nc;
 
-			if (retParam != "") {
-				print("\t" "internal_ret = commandData." retParam ";") >> outFile_nc;
-			}
-
 			if (hasRetType) {
-				# this is unused, delete
 				print("\t" "if (internal_ret == 0) {") >> outFile_nc;
-				print("\t\t" "internal_ret = commandData." retParam ";") >> outFile_nc;
+				print("\t\t" "return commandData." retParam ";") >> outFile_nc;
 				print("\t" "} else {") >> outFile_nc;
-				print("\t\t" "internal_ret = 0;") >> outFile_nc;
+				print("\t\t" "return (" retType ")0;") >> outFile_nc;
 				print("\t" "}") >> outFile_nc;
+			} else {
+				print("\t" "return internal_ret;") >> outFile_nc;
 			}
-
-			print("\t" "return internal_ret;") >> outFile_nc;
 			print("}") >> outFile_nc;
 
 			if (match(fullName, /^Unit_/)) {


### PR DESCRIPTION
Changes generation of this not very useful code (ORIGINAL):

```
EXPORT(float) bridged_Pathing_getApproximateLength(int skirmishAIId, float* start_posF3, float* end_posF3, int pathType, float goalRadius) {

    struct SGetApproximateLengthPathCommand commandData;
    int internal_ret;
    commandData.start_posF3 = start_posF3;
    commandData.end_posF3 = end_posF3;
    commandData.pathType = pathType;
    commandData.goalRadius = goalRadius;

    internal_ret = id_clb[skirmishAIId]->Engine_handleCommand(skirmishAIId, COMMAND_TO_ID_ENGINE, -1, COMMAND_PATH_GET_APPROXIMATE_LENGTH, &commandData);

    internal_ret = commandData.ret_approximatePathLength;
    if (internal_ret == 0) {
        internal_ret = commandData.ret_approximatePathLength;
    } else {
        internal_ret = 0;
    }
    return internal_ret;
}
```

to more meaningful code (FIXED):

```
EXPORT(float) bridged_Pathing_getApproximateLength(int skirmishAIId, float* start_posF3, float* end_posF3, int pathType, float goalRadius) {

    struct SGetApproximateLengthPathCommand commandData;
    int internal_ret;
    commandData.start_posF3 = start_posF3;
    commandData.end_posF3 = end_posF3;
    commandData.pathType = pathType;
    commandData.goalRadius = goalRadius;

    internal_ret = id_clb[skirmishAIId]->Engine_handleCommand(skirmishAIId, COMMAND_TO_ID_ENGINE, -1, COMMAND_PATH_GET_APPROXIMATE_LENGTH, &commandData);

    if (internal_ret == 0) {
        return commandData.ret_approximatePathLength;
    } else {
        return (float)0;
    }
}
```

That way function will return proper value instead of always 0.

PS: Strange behavior noticed. If start point = end point then length is always 10. Not a big problem and its anyway ApproximateLength.
