### PR TITLE
Propose Spring to render same world twice to assist stereoscopic widget (with a working code)

### DIFF
--- a/rts/Game/Game.cpp
+++ b/rts/Game/Game.cpp
@@ -214,6 +214,8 @@ CR_REG_METADATA(CGame, (
 	CR_MEMBER(playing),
 	CR_IGNORED(msgProcTimeLeft),
 	CR_IGNORED(consumeSpeedMult),
+	CR_IGNORED(doubleDrawIndex),
+	CR_IGNORED(doDoubleDraw),
 
 	CR_POSTLOAD(PostLoad)
 ))
@@ -348,6 +350,8 @@ CGame::CGame(const std::string& mapName, const std::string& modName, ILoadSaveHa
 	, saveFile(saveFile)
 	, finishedLoading(false)
 	, gameOver(false)
+	, doDoubleDraw(false)
+	, doubleDrawIndex(1)
 {
 	game = this;
 
@@ -1186,8 +1190,20 @@ bool CGame::UpdateUnsynced(const spring_time currentTime)
 	return false;
 }
 
-
 bool CGame::Draw() {
+	if (doDoubleDraw)
+	{
+		// We draw the same world twice to help stereoscopic widget to produce stable 3D image.
+		// Activated by command "/DoubleDraw 1", status check by call-out Spring.GetIsDoubleDraw()
+		// and Spring.GetDoubleDrawIndex()
+		doubleDrawIndex = 2;
+		DrawAll();
+		doubleDrawIndex = 1;
+	}
+	return DrawAll();
+}
+
+bool CGame::DrawAll() {
 	const spring_time currentTimePreUpdate = spring_gettime();
 
 	if (UpdateUnsynced(currentTimePreUpdate))

--- a/rts/Game/Game.h
+++ b/rts/Game/Game.h
@@ -73,6 +73,10 @@ public:
 	bool IsGameOver() const { return gameOver; }
 	bool IsLagging(float maxLatency = 500.0f) const;
 
+	void SetDoubleDraw(bool enableDoubleDraw) { doDoubleDraw = enableDoubleDraw; } 
+	bool IsDoubleDraw() { return doDoubleDraw; }
+	int GetDoubleDrawIndex() { return doubleDrawIndex; } 
+
 	const std::map<int, PlayerTrafficInfo>& GetPlayerTraffic() const {
 		return playerTraffic;
 	}
@@ -103,6 +107,7 @@ public:
 	GameDrawMode GetDrawMode() const { return gameDrawMode; }
 
 private:
+	bool DrawAll();
 	bool Draw();
 	bool DrawMT();
 
@@ -223,6 +228,8 @@ private:
 
 	volatile bool finishedLoading;
 	bool gameOver;
+	bool doDoubleDraw;
+	int doubleDrawIndex;
 };
 
 

--- a/rts/Game/UnsyncedGameCommands.cpp
+++ b/rts/Game/UnsyncedGameCommands.cpp
@@ -332,6 +332,28 @@ private:
 };
 
 
+class DoubleDrawExecutor : public IUnsyncedActionExecutor {
+public:
+	DoubleDrawExecutor() : IUnsyncedActionExecutor("DoubleDraw",
+			"Enable/Disable render the same world twice (for stabilizing stereoscopic image): 0=off, 1=on") {}
+
+	bool Execute(const UnsyncedAction& action) const {
+
+		
+		if (!action.GetArgs().empty()) {
+			int useDoubleDraw = -1;
+			sscanf((action.GetArgs()).c_str(), "%i", &useDoubleDraw);
+
+			game->SetDoubleDraw(useDoubleDraw > 0);
+		} else {
+			// toggle
+			game->SetDoubleDraw(!game->IsDoubleDraw());
+		}
+		LogSystemStatus("DoubleDraw", game->IsDoubleDraw());
+		return true;
+	}
+};
+
 
 /**
  * Special case executor which allows to combine multiple commands into one,
@@ -3160,6 +3182,7 @@ bool CGame::ActionReleased(const Action& action)
 
 void UnsyncedGameCommands::AddDefaultActionExecutors() {
 
+	AddActionExecutor(new DoubleDrawExecutor());
 	AddActionExecutor(new SelectActionExecutor());
 	AddActionExecutor(new SelectUnitsActionExecutor());
 	AddActionExecutor(new SelectCycleActionExecutor());

--- a/rts/Lua/LuaUnsyncedRead.cpp
+++ b/rts/Lua/LuaUnsyncedRead.cpp
@@ -89,6 +89,8 @@ bool LuaUnsyncedRead::PushEntries(lua_State* L)
 	lua_pushcfunction(L, x);    \
 	lua_rawset(L, -3)
 
+	REGISTER_LUA_CFUNC(GetDoubleDrawIndex);
+	REGISTER_LUA_CFUNC(IsDoubleDrawing);
 	REGISTER_LUA_CFUNC(IsReplay);
 	REGISTER_LUA_CFUNC(GetReplayLength);
 	REGISTER_LUA_CFUNC(GetModUICtrl);
@@ -278,6 +280,24 @@ static inline CFeature* ParseFeature(lua_State* L, const char* caller, int index
 //
 //  The call-outs
 //
+
+
+int LuaUnsyncedRead::GetDoubleDrawIndex(lua_State* L)
+{
+	lua_pushnumber(L, game->GetDoubleDrawIndex());
+	return 1;
+}
+
+int LuaUnsyncedRead::IsDoubleDrawing(lua_State* L)
+{
+	if (game->IsDoubleDraw()) {
+		lua_pushboolean(L, true);
+	} else {
+		lua_pushboolean(L, false);
+	}
+	return 1;
+}
+
 
 int LuaUnsyncedRead::IsReplay(lua_State* L)
 {

--- a/rts/Lua/LuaUnsyncedRead.h
+++ b/rts/Lua/LuaUnsyncedRead.h
@@ -13,6 +13,8 @@ class LuaUnsyncedRead {
 		static bool PushEntries(lua_State* L);
 
 	private:
+		static int GetDoubleDrawIndex(lua_State* L);
+		static int IsDoubleDrawing(lua_State* L);
 		static int IsReplay(lua_State* L);
 		static int GetReplayLength(lua_State* L);
 		static int GetModUICtrl(lua_State* L);


### PR DESCRIPTION
There is a stereoscopic widget that emulate 3D vision by moving camera left & right ( https://github.com/ZeroK-RTS/Zero-K/blob/master/LuaUI/Widgets/gfx_stereo3d.lua ) . But the method used by this widget cannot work properly for moving units. If Spring could render same world twice then that method could work!

I have tried it, here is the result with rendering twice:
(try to focus on the circular white cursor using cross-eye technique)
![stereoscopic- with doubledraw](https://cloud.githubusercontent.com/assets/2525365/4146207/efac2a04-3407-11e4-95d7-9c8dc5b237e7.jpg)

The following is the same scene but without rendering twice:
![stereoscopic- no doubledraw](https://cloud.githubusercontent.com/assets/2525365/4146238/4a2565a4-3408-11e4-92d6-fd0e46ee8cda.jpg)

The boat in the centre is moving and it doesn't 3D correctly in second image.

In the proposed code-change I added the following Interface:
/doubledraw 1|0 : enable/disable double drawing
Spring.IsDoubleDrawing(): to check if double drawing is active
Spring.GetDoubleDrawIndex(): output 1 or 2 to assist widget to select which draw-frame to displayed as left-eye or right-eye
