### PR TITLE
Fixed plane behavior issues

### DIFF
--- a/rts/Sim/MoveTypes/StrafeAirMoveType.cpp
+++ b/rts/Sim/MoveTypes/StrafeAirMoveType.cpp
@@ -853,24 +853,19 @@ bool CStrafeAirMoveType::UpdateFlying(float wantedHeight, float engine)
 	float goalDotRight = goalDir2D.dot(rightDir2D.Normalize2D());
 
 	const float aGoalDotFront = goalDir2D.dot(frontdir);
-	const float goalDotFront = aGoalDotFront * 0.5f + 0.501f;
 
-	if (goalDotFront != 0.0f) {
-		goalDotRight /= goalDotFront;
-	}
-
-	// if goal-position is behind us and goal-distance
-	// is less than our turning radius, turn the other
-	// way --> often insufficient for small turn radii,
-	// also need to fly straight for some distance
-	#if 1
-	if (goalDir2D.dot(frontdir) < -0.1f && goalDist2D < TurnRadius(turnRadius, spd.w)) {
+	// If goal-position is behind us and goal-distance is less 
+	// than our turning radius, turn the other way.
+	// If goal-distance is half turn radius then turn if
+	// goal-position is not in front within a 45 degree arc.
+	// This is to prevent becoming stuck in a small circle 
+	// around goal-position.
+	if ((goalDist2D < turnRadius * 0.5f && goalDir2D.dot(frontdir) < 0.7f) || (goalDist2D < turnRadius && goalDir2D.dot(frontdir) < -0.1f)) {
 		if (!owner->UnderFirstPersonControl() || owner->fpsControlPlayer->fpsController.mouse2) {
 			goalDotRight *= -1.0f;
 		}
 	}
-	#endif
-
+	
 	if (lastColWarning != NULL) {
 		const float3 otherDif = lastColWarning->pos - pos;
 		const float otherLength = otherDif.Length();


### PR DESCRIPTION
- Planes turn at the correct distance from their move goal.
- Planes no longer become confused by terrain changes while trying to bank.
- Fixed units circling around move goal instead of strafing through.
- Fixed occasional roll jittering which occurs just after passing a move goal.
