### PR TITLE
Strafing planes turn around at max range

### DIFF
--- a/rts/Sim/MoveTypes/StrafeAirMoveType.cpp
+++ b/rts/Sim/MoveTypes/StrafeAirMoveType.cpp
@@ -842,7 +842,7 @@ bool CStrafeAirMoveType::UpdateFlying(float wantedHeight, float engine)
 	}
 
 	// RHS is needed for moving targets (when called by UpdateAttack)
-	const bool allowUnlockYR = (goalDist2D >= TurnRadius(turnRadius, spd.w) || goalVec.dot(owner->frontdir) > 0.0f);
+	const bool allowUnlockYR = (goalDist2D >= owner->maxRange || goalVec.dot(owner->frontdir) > 0.0f);
 	const bool forceUnlockYR = ((gs->frameNum - owner->lastFireWeapon) >= GAME_SPEED * 3);
 
 	// yaw and roll have to be unblocked after a certain time or aircraft


### PR DESCRIPTION
This is instead of using turn radius and current speed. Common strafing aircraft have range much longer than their reasonable turn radius. It makes the most sense to use their maximum range to determine how far they should fly when performing a strafe.