### PR TITLE
Add support for SSMF Detail Normal Textures:

### DIFF
--- a/cont/base/maphelper/maphelper/mapdefaults.lua
+++ b/cont/base/maphelper/maphelper/mapdefaults.lua
@@ -103,6 +103,10 @@ local mapDefaults = {
     detailNormalTex   = '',
     lightEmissionTex  = '',
     parallaxHeightTex = '',
+    splatDetailNormalTex1 = '',
+    splatDetailNormalTex2 = '',
+    splatDetailNormalTex3 = '',
+    splatDetailNormalTex4 = '',
   },
 
   defaultTerrainType = {

--- a/cont/base/maphelper/maphelper/parse_tdf_map.lua
+++ b/cont/base/maphelper/maphelper/parse_tdf_map.lua
@@ -207,6 +207,10 @@ return function(sourceText)
      detailNormalTex   = map.detailnormaltex,
      lightEmissionTex  = map.lightemissiontex,
      parallaxHeightTex = map.parallaxheighttex,
+	 splatDetailNormalTex1 = map.splatdetailnormaltex1,
+	 splatDetailNormalTex2 = map.splatdetailnormaltex2,
+	 splatDetailNormalTex3 = map.splatdetailnormaltex3,
+	 splatDetailNormalTex4 = map.splatdetailnormaltex4,
   }
 
   ConvertTerrainTypes(map)

--- a/rts/Map/MapInfo.cpp
+++ b/rts/Map/MapInfo.cpp
@@ -63,7 +63,7 @@ CMapInfo::CMapInfo(const std::string& mapInfoFile, const string& mapName)
 	ReadSound();
 
 	//FIXME save all data in an array, so we can destroy the lua context (to save mem)?
-	//delete parser; 
+	//delete parser;
 }
 
 CMapInfo::~CMapInfo()
@@ -326,6 +326,10 @@ void CMapInfo::ReadSMF()
 	smf.specularTexName    = mapResTable.GetString("specularTex", "");
 	smf.splatDetailTexName = mapResTable.GetString("splatDetailTex", "");
 	smf.splatDistrTexName  = mapResTable.GetString("splatDistrTex", "");
+	smf.splatDetailNormalTex1Name  = mapResTable.GetString("splatDetailNormalTex1", "");
+	smf.splatDetailNormalTex2Name  = mapResTable.GetString("splatDetailNormalTex2", "");
+	smf.splatDetailNormalTex3Name  = mapResTable.GetString("splatDetailNormalTex3", "");
+	smf.splatDetailNormalTex4Name  = mapResTable.GetString("splatDetailNormalTex4", "");
 
 	smf.grassShadingTexName = mapResTable.GetString("grassShadingTex", "");
 
@@ -350,6 +354,11 @@ void CMapInfo::ReadSMF()
 	if (!smf.detailNormalTexName.empty()) { smf.detailNormalTexName = "maps/" + smf.detailNormalTexName; }
 	if (!smf.lightEmissionTexName.empty()) { smf.lightEmissionTexName = "maps/" + smf.lightEmissionTexName; }
 	if (!smf.parallaxHeightTexName.empty()) { smf.parallaxHeightTexName = "maps/" + smf.parallaxHeightTexName; }
+
+	if (!smf.splatDetailNormalTex1Name.empty()) { smf.splatDetailNormalTex1Name = "maps/" + smf.splatDetailNormalTex1Name; }
+	if (!smf.splatDetailNormalTex2Name.empty()) { smf.splatDetailNormalTex2Name = "maps/" + smf.splatDetailNormalTex2Name; }
+	if (!smf.splatDetailNormalTex3Name.empty()) { smf.splatDetailNormalTex3Name = "maps/" + smf.splatDetailNormalTex3Name; }
+	if (!smf.splatDetailNormalTex4Name.empty()) { smf.splatDetailNormalTex4Name = "maps/" + smf.splatDetailNormalTex4Name; }
 
 	// height overrides
 	const LuaTable& smfTable = parser->GetRoot().SubTable("smf");
@@ -450,7 +459,7 @@ void CMapInfo::ReadSound()
 
 		if (luaType == LuaTable::NIL)
 			continue;
-		
+
 		const ALuint param = it->second;
 		const unsigned& type = alParamType[param];
 		switch (type) {

--- a/rts/Map/MapInfo.h
+++ b/rts/Map/MapInfo.h
@@ -181,6 +181,11 @@ public:
 		std::string detailNormalTexName;
 		std::string lightEmissionTexName;
 		std::string parallaxHeightTexName;
+		std::string splatDetailNormalTex1Name;
+		std::string splatDetailNormalTex2Name;
+		std::string splatDetailNormalTex3Name;
+		std::string splatDetailNormalTex4Name;
+
 
 		float minHeight;
 		bool  minHeightOverride;

--- a/rts/Map/SMF/SMFReadMap.cpp
+++ b/rts/Map/SMF/SMFReadMap.cpp
@@ -40,6 +40,10 @@ CSMFReadMap::CSMFReadMap(std::string mapname)
 	, normalsTex(0)
 	, minimapTex(0)
 	, splatDetailTex(0)
+	, splatDetailNormalTex1(0)
+	, splatDetailNormalTex2(0)
+	, splatDetailNormalTex3(0)
+	, splatDetailNormalTex4(0)
 	, splatDistrTex(0)
 	, skyReflectModTex(0)
 	, detailNormalTex(0)
@@ -52,6 +56,7 @@ CSMFReadMap::CSMFReadMap(std::string mapname)
 
 	haveSpecularTexture = !(mapInfo->smf.specularTexName.empty());
 	haveSplatTexture = (!mapInfo->smf.splatDetailTexName.empty() && !mapInfo->smf.splatDistrTexName.empty());
+	haveSplatNormalTexture = (!mapInfo->smf.splatDistrTexName.empty() && !mapInfo->smf.splatDetailNormalTex1Name.empty());
 
 	ParseHeader();
 	LoadHeightMap();
@@ -83,6 +88,10 @@ CSMFReadMap::~CSMFReadMap()
 	glDeleteTextures(1, &shadingTex       );
 	glDeleteTextures(1, &normalsTex       );
 	glDeleteTextures(1, &splatDetailTex   );
+	glDeleteTextures(1, &splatDetailNormalTex1   );
+	glDeleteTextures(1, &splatDetailNormalTex2   );
+	glDeleteTextures(1, &splatDetailNormalTex3   );
+	glDeleteTextures(1, &splatDetailNormalTex4   );
 	glDeleteTextures(1, &splatDistrTex    );
 	glDeleteTextures(1, &grassShadingTex  );
 	glDeleteTextures(1, &skyReflectModTex );
@@ -246,6 +255,67 @@ void CSMFReadMap::CreateSplatDetailTextures()
 
 	splatDetailTex = splatDetailTexBM.CreateTexture(true);
 	splatDistrTex = splatDistrTexBM.CreateTexture(true);
+
+	if (!haveSplatNormalTexture){
+        return;
+	}
+
+	CBitmap splatDetailNormalTex1BM;
+
+	if (!splatDetailNormalTex1BM.Load(mapInfo->smf.splatDetailNormalTex1Name)) {
+		splatDetailNormalTex1BM.channels = 4;
+		splatDetailNormalTex1BM.Alloc(1, 1);
+		splatDetailNormalTex1BM.mem[0] = 127; //RGB is packed standard normal map
+		splatDetailNormalTex1BM.mem[1] = 127;
+		splatDetailNormalTex1BM.mem[2] = 255;
+		splatDetailNormalTex1BM.mem[3] = 127; //Alpha is diffuse as in old-style detail textures
+	}
+
+	splatDetailNormalTex1 = splatDetailNormalTex1BM.CreateTexture(true);
+
+
+	CBitmap splatDetailNormalTex2BM;
+
+	if (!splatDetailNormalTex2BM.Load(mapInfo->smf.splatDetailNormalTex2Name)) {
+		splatDetailNormalTex2BM.channels = 4;
+		splatDetailNormalTex2BM.Alloc(1, 1);
+		splatDetailNormalTex2BM.mem[0] = 127; //RGB is packed standard normal map
+		splatDetailNormalTex2BM.mem[1] = 127;
+		splatDetailNormalTex2BM.mem[2] = 255;
+		splatDetailNormalTex2BM.mem[3] = 127; //Alpha is diffuse as in old-style detail textures
+	}
+
+	splatDetailNormalTex2 = splatDetailNormalTex2BM.CreateTexture(true);
+
+
+	CBitmap splatDetailNormalTex3BM;
+
+	if (!splatDetailNormalTex3BM.Load(mapInfo->smf.splatDetailNormalTex3Name)) {
+		splatDetailNormalTex3BM.channels = 4;
+		splatDetailNormalTex3BM.Alloc(1, 1);
+		splatDetailNormalTex3BM.mem[0] = 127; //RGB is packed standard normal map
+		splatDetailNormalTex3BM.mem[1] = 127;
+		splatDetailNormalTex3BM.mem[2] = 255;
+		splatDetailNormalTex3BM.mem[3] = 127; //Alpha is diffuse as in old-style detail textures
+	}
+
+	splatDetailNormalTex3 = splatDetailNormalTex3BM.CreateTexture(true);
+
+	CBitmap splatDetailNormalTex4BM;
+
+	if (!splatDetailNormalTex4BM.Load(mapInfo->smf.splatDetailNormalTex4Name)) {
+		splatDetailNormalTex4BM.channels = 4;
+		splatDetailNormalTex4BM.Alloc(1, 1);
+		splatDetailNormalTex4BM.mem[0] = 127; //RGB is packed standard normal map
+		splatDetailNormalTex4BM.mem[1] = 127;
+		splatDetailNormalTex4BM.mem[2] = 255;
+		splatDetailNormalTex4BM.mem[3] = 127; //Alpha is diffuse as in old-style detail textures
+	}
+
+	splatDetailNormalTex4 = splatDetailNormalTex4BM.CreateTexture(true);
+
+
+
 }
 
 

--- a/rts/Map/SMF/SMFReadMap.h
+++ b/rts/Map/SMF/SMFReadMap.h
@@ -39,6 +39,10 @@ public:
 	unsigned int GetSpecularTexture() const { return specularTex; }
 	unsigned int GetGrassShadingTexture() const { return grassShadingTex; }
 	unsigned int GetSplatDetailTexture() const { return splatDetailTex; }
+	unsigned int GetSplatDetailNormalTexture1() const { return splatDetailNormalTex1; }
+	unsigned int GetSplatDetailNormalTexture2() const { return splatDetailNormalTex2; }
+	unsigned int GetSplatDetailNormalTexture3() const { return splatDetailNormalTex3; }
+	unsigned int GetSplatDetailNormalTexture4() const { return splatDetailNormalTex4; }
 	unsigned int GetSplatDistrTexture() const { return splatDistrTex; }
 	unsigned int GetSkyReflectModTexture() const { return skyReflectModTex; }
 	unsigned int GetDetailNormalTexture() const { return detailNormalTex; }
@@ -67,6 +71,7 @@ public:
 
 	bool HaveSpecularTexture() const { return haveSpecularTexture; }
 	bool HaveSplatTexture() const { return haveSplatTexture; }
+	bool HaveSplatNormalTexture() const { return haveSplatNormalTexture; }
 
 private:
 	void ParseHeader();
@@ -122,6 +127,10 @@ protected:
 	unsigned int normalsTex;        // holds vertex normals in RGBA32F internal format (GL_RGBA + GL_FLOAT)
 	unsigned int minimapTex;        // supplied by the map
 	unsigned int splatDetailTex;    // contains per-channel separate greyscale detail-textures (overrides detailTex)
+	unsigned int splatDetailNormalTex1;    // contains RGBA texture with RGB channels containing normals and alpha containing greyscale diffuse for splat detail normals (overrides detailTex)
+	unsigned int splatDetailNormalTex2;    // contains RGBA texture with RGB channels containing normals and alpha containing greyscale diffuse for splat detail normals (overrides detailTex)
+	unsigned int splatDetailNormalTex3;    // contains RGBA texture with RGB channels containing normals and alpha containing greyscale diffuse for splat detail normals (overrides detailTex)
+	unsigned int splatDetailNormalTex4;    // contains RGBA texture with RGB channels containing normals and alpha containing greyscale diffuse for splat detail normals (overrides detailTex)
 	unsigned int splatDistrTex;     // specifies the per-channel distribution of splatDetailTex (map-wide, overrides detailTex)
 	unsigned int grassShadingTex;   // specifies grass-blade modulation color (defaults to minimapTex)
 	unsigned int skyReflectModTex;  // modulates sky-reflection RGB intensities (must be the same size as specularTex)
@@ -131,6 +140,7 @@ protected:
 
 	bool haveSpecularTexture;
 	bool haveSplatTexture;
+	bool haveSplatNormalTexture;
 
 	unsigned char waterHeightColors[1024 * 4];
 

--- a/rts/Map/SMF/SMFRenderState.cpp
+++ b/rts/Map/SMF/SMFRenderState.cpp
@@ -112,6 +112,7 @@ bool SMFRenderStateGLSL::Init(const CSMFGroundDrawer* smfGroundDrawer) {
 		glslShaders[n]->SetFlag("SMF_VOID_GROUND",              int(mapInfo->map.voidGround));
 		glslShaders[n]->SetFlag("SMF_ARB_LIGHTING",             int(!smfMap->HaveSpecularTexture()));
 		glslShaders[n]->SetFlag("SMF_DETAIL_TEXTURE_SPLATTING", int(smfMap->HaveSplatTexture()));
+		glslShaders[n]->SetFlag("SMF_DETAIL_NORMAL_TEXTURE_SPLATTING", int(smfMap->HaveSplatNormalTexture()));
 		glslShaders[n]->SetFlag("SMF_WATER_ABSORPTION",         int(smfMap->HasVisibleWater()));
 		glslShaders[n]->SetFlag("SMF_SKY_REFLECTIONS",          int(smfMap->GetSkyReflectModTexture() != 0));
 		glslShaders[n]->SetFlag("SMF_DETAIL_NORMALS",           int(smfMap->GetDetailNormalTexture() != 0));
@@ -163,6 +164,11 @@ bool SMFRenderStateGLSL::Init(const CSMFGroundDrawer* smfGroundDrawer) {
 		glslShaders[n]->SetUniform("detailNormalTex", 11);
 		glslShaders[n]->SetUniform("lightEmissionTex", 12);
 		glslShaders[n]->SetUniform("parallaxHeightTex", 13);
+
+		glslShaders[n]->SetUniform("splatDetailNormalTex1",15);//idx 35
+		glslShaders[n]->SetUniform("splatDetailNormalTex2",16);//idx 36
+		glslShaders[n]->SetUniform("splatDetailNormalTex3",17);//idx 37
+		glslShaders[n]->SetUniform("splatDetailNormalTex4",18);//idx 38
 		glslShaders[n]->SetUniform("infoTexIntensityMul", 1.0f);
 		glslShaders[n]->SetUniform("normalTexGen", 1.0f / ((smfMap->normalTexSize.x - 1) * SQUARE_SIZE), 1.0f / ((smfMap->normalTexSize.y - 1) * SQUARE_SIZE));
 		glslShaders[n]->SetUniform("specularTexGen", 1.0f / (gs->mapx * SQUARE_SIZE), 1.0f / (gs->mapy * SQUARE_SIZE));
@@ -445,6 +451,10 @@ void SMFRenderStateGLSL::Enable(const CSMFGroundDrawer* smfGroundDrawer, const D
 	glActiveTexture(GL_TEXTURE12); glBindTexture(GL_TEXTURE_2D, smfMap->GetLightEmissionTexture());
 	glActiveTexture(GL_TEXTURE13); glBindTexture(GL_TEXTURE_2D, smfMap->GetParallaxHeightTexture());
 	glActiveTexture(GL_TEXTURE14); glBindTexture(GL_TEXTURE_2D, smfGroundDrawer->GetActiveInfoTexture());
+	glActiveTexture(GL_TEXTURE15); glBindTexture(GL_TEXTURE_2D, smfMap->GetSplatDetailNormalTexture1());
+	glActiveTexture(GL_TEXTURE16); glBindTexture(GL_TEXTURE_2D, smfMap->GetSplatDetailNormalTexture2());
+	glActiveTexture(GL_TEXTURE17); glBindTexture(GL_TEXTURE_2D, smfMap->GetSplatDetailNormalTexture3());
+	glActiveTexture(GL_TEXTURE18); glBindTexture(GL_TEXTURE_2D, smfMap->GetSplatDetailNormalTexture4());
 
 	glActiveTexture(GL_TEXTURE0);
 }
@@ -452,6 +462,10 @@ void SMFRenderStateGLSL::Enable(const CSMFGroundDrawer* smfGroundDrawer, const D
 void SMFRenderStateGLSL::Disable(const CSMFGroundDrawer*, const DrawPass::e&) {
 	glslShaders[GLSL_SHADER_CURRENT]->Disable();
 
+	glActiveTexture(GL_TEXTURE18); glBindTexture(GL_TEXTURE_2D, 0);
+	glActiveTexture(GL_TEXTURE17); glBindTexture(GL_TEXTURE_2D, 0);
+	glActiveTexture(GL_TEXTURE16); glBindTexture(GL_TEXTURE_2D, 0);
+	glActiveTexture(GL_TEXTURE15); glBindTexture(GL_TEXTURE_2D, 0);
 	glActiveTexture(GL_TEXTURE14); glBindTexture(GL_TEXTURE_2D, 0);
 	glActiveTexture(GL_TEXTURE13); glBindTexture(GL_TEXTURE_2D, 0);
 	glActiveTexture(GL_TEXTURE12); glBindTexture(GL_TEXTURE_2D, 0);


### PR DESCRIPTION
Works similarly to the previous SSMF splatting, but instead of sampling a combined texture of 4 different single-channel diffuse detail textures, it samples four separate normal textures.
The textures must contain the normal maps in the RGB channel (standard normal maps), with a diffuse luminance in the alpha  channel.
The system uses the same splatDistrTex as regular SSMF.

Usage:
	Specify splatDetailNormalTex1 .. splatDetailNormalTex4 in the MAP resources section.
	splatDetailTex will be unused if the above are present.

Yes this is DSD: http://beherith.eat-peet.net/stuff/detail_normals.png

![detailnormals](https://cloud.githubusercontent.com/assets/109391/4337155/c5dd5bf6-400c-11e4-9e4b-ca897f30f909.jpg)