### PR TITLE
- hopefully fixes Win32 compilation

### DIFF
--- a/rts/System/Platform/Threading.cpp
+++ b/rts/System/Platform/Threading.cpp
@@ -377,9 +377,9 @@ namespace Threading {
 			*ppCtlsReturn = *ppThreadCtls;
 		}
 
-		boost::unique_lock<boost::mutex> lock (pThreadCtls->mutSuspend);
 
 #ifndef WIN32
+		boost::unique_lock<boost::mutex> lock (pThreadCtls->mutSuspend);
 		boost::thread localthread(boost::bind(Threading::ThreadStart, taskFunc, ppThreadCtls));
 
 		// Wait so that we know the thread is running and fully initialized before returning.


### PR DESCRIPTION
The variable mutSuspend is _not_ required for WIN32. References to it should be moved within the #ifndef WIN32 block, as I have done here.
