### PR TITLE
Remove restTime movetype interaction inconsistency

### DIFF
--- a/rts/Sim/MoveTypes/HoverAirMoveType.cpp
+++ b/rts/Sim/MoveTypes/HoverAirMoveType.cpp
@@ -415,8 +415,6 @@ void CHoverAirMoveType::UpdateFlying()
 	// Direction to where we would like to be
 	float3 goalVec = goalPos - pos;
 
-	owner->restTime = 0;
-
 	// don't change direction for waypoints we just flew over and missed slightly
 	if (flyState != FLY_LANDING && owner->commandAI->HasMoreMoveCommands()) {
 		float3 goalDir = goalVec;

--- a/rts/Sim/MoveTypes/StrafeAirMoveType.cpp
+++ b/rts/Sim/MoveTypes/StrafeAirMoveType.cpp
@@ -480,7 +480,6 @@ bool CStrafeAirMoveType::Update()
 
 	switch (aircraftState) {
 		case AIRCRAFT_FLYING: {
-			owner->restTime = 0;
 
 			const CCommandQueue& cmdQue = owner->commandAI->commandQue;
 


### PR DESCRIPTION
Unit restTime is currently reset when the unit is shot, or when an air unit moves. Ground units can currently move without resetting restTime. This patch makes air units also able to move without resetting restTime, to keep consistency with ground units.

As a side note, FPSed planes don't reset restTime even if moving.