### PR TITLE
fix /noSpecDraw command behaviour ( mantis #4241 )

### DIFF
--- a/rts/Game/SyncedGameCommands.cpp
+++ b/rts/Game/SyncedGameCommands.cpp
@@ -69,9 +69,9 @@ public:
 			"Allows/Disallows spectators to draw on the map") {}
 
 	bool Execute(const SyncedAction& action) const {
-		bool disabled;
-		InverseOrSetBool(disabled, action.GetArgs());
-		inMapDrawer->SetSpecMapDrawingAllowed(!disabled);
+		bool allowSpecMapDrawing = inMapDrawer->GetSpecMapDrawingAllowed();
+		InverseOrSetBool(allowSpecMapDrawing, action.GetArgs(), true);
+		inMapDrawer->SetSpecMapDrawingAllowed(allowSpecMapDrawing);
 		return true;
 	}
 };

--- a/rts/Net/GameServer.cpp
+++ b/rts/Net/GameServer.cpp
@@ -2174,7 +2174,7 @@ void CGameServer::PushAction(const Action& action, bool fromAutoHost)
 		Broadcast(boost::shared_ptr<const RawPacket>(msg.Pack()));
 	}
 	else if (action.command == "nospecdraw") {
-		InverseOrSetBool(allowSpecDraw, action.extra);
+		InverseOrSetBool(allowSpecDraw, action.extra, true);
 		// sent it because clients have to do stuff when this changes
 		CommandMessage msg(action, SERVER_PLAYER);
 		Broadcast(boost::shared_ptr<const RawPacket>(msg.Pack()));


### PR DESCRIPTION
The noSpecDraw command was working backward in server code.
The noSpecDraw command with no parameter was always disabling spectator drawing in synced commands code (instead of switching between enabled/disabled)

=> it was impossible to re-enable spectator drawing once it had been disabled
