### PR TITLE
fix /noSpectatorChat command behaviour ( mantis #4240 )

### DIFF
--- a/rts/Game/Game.cpp
+++ b/rts/Game/Game.cpp
@@ -1795,7 +1795,11 @@ void CGame::HandleChatMsg(const ChatMessage& msg)
 		else if (msg.destination == ChatMessage::TO_EVERYONE) {
 			const bool specsOnly = noSpectatorChat && (player && player->spectator);
 			if (gu->spectating || !specsOnly) {
-				LOG("%s%s", label.c_str(), s.c_str());
+				if (specsOnly) {
+					LOG("%sSpectators: %s", label.c_str(), s.c_str());
+				} else {
+					LOG("%s%s", label.c_str(), s.c_str());
+				}
 				Channels::UserInterface->PlaySample(chatSound, 5);
 			}
 		}


### PR DESCRIPTION
When the NoSpectatorChat mode is enabled, it was not clear from spectators point of view that the players couldn't see their messages (these messages appeared to spectators as normal messages sent to all clients).
Now these messages appear as messages sent to spectators only.
