### PR TITLE
Revert "Java-AIInterface: actually look for the class-name! (thanks to p...

### DIFF
--- a/AI/Interfaces/Java/src/main/native/JavaBridge.c
+++ b/AI/Interfaces/Java/src/main/native/JavaBridge.c
@@ -1164,8 +1164,6 @@ bool java_initSkirmishAIClass(
 	for (sai = 0; sai < skirmishAiImpl_size; ++sai) {
 		if (skirmishAiImpl_className[sai] == NULL) {
 			firstFree = sai;
-		} else if (strcmp(skirmishAiImpl_className[sai], className) == 0) {
-			break;
 		}
 	}
 	// sai is now either the instantiated one, or a free one


### PR DESCRIPTION
This (again) broke the ability to host multiple Java AI's of the same classname that was fixed sometime during 97-dev.  What was it meant to fix?

This reverts commit 21b94b1823f436a04fadc32b18a9fab409f186a4.