### PR TITLE
Added firetolerance tag

### DIFF
--- a/rts/Sim/Weapons/Weapon.cpp
+++ b/rts/Sim/Weapons/Weapon.cpp
@@ -398,8 +398,8 @@ bool CWeapon::CanFire(bool ignoreAngleGood, bool ignoreTargetType, bool ignoreRe
 	if (!weaponDef->fireSubmersed && weaponMuzzlePos.y <= 0.0f)
 		return false;
 
-	// sanity check to force new aim, default 90 degrees
-	if (maxForwardAngleDif > -1.0f) {
+	// sanity check to force new aim
+	if (maxAngleAtCanFireCheck > -1.0f) {
 		if (!ignoreRequestedDir && wantedDir.dot(lastRequestedDir) <= maxAngleAtCanFireCheck)
 			return false;
 	}

--- a/rts/Sim/Weapons/Weapon.cpp
+++ b/rts/Sim/Weapons/Weapon.cpp
@@ -77,6 +77,7 @@ CR_REG_METADATA(CWeapon, (
 
 	CR_MEMBER(slavedTo),
 	CR_MEMBER(maxForwardAngleDif),
+	CR_MEMBER(maxAngleAtCanFireCheck),
 	CR_MEMBER(maxMainDirAngleDif),
 	CR_MEMBER(hasCloseTarget),
 	CR_MEMBER(targetBorder),
@@ -157,6 +158,7 @@ CWeapon::CWeapon(CUnit* owner, const WeaponDef* def):
 
 	slavedTo(NULL),
 	maxForwardAngleDif(0.0f),
+	maxAngleAtCanFireCheck(0.0f),
 	maxMainDirAngleDif(-1.0f),
 	targetBorder(0.f),
 	cylinderTargeting(0.f),
@@ -396,9 +398,11 @@ bool CWeapon::CanFire(bool ignoreAngleGood, bool ignoreTargetType, bool ignoreRe
 	if (!weaponDef->fireSubmersed && weaponMuzzlePos.y <= 0.0f)
 		return false;
 
-	// ~20 degree sanity check to force new aim
-	if (!ignoreRequestedDir && wantedDir.dot(lastRequestedDir) <= 0.94f)
-		return false;
+	// sanity check to force new aim, default 90 degrees
+	if (maxForwardAngleDif > -1.0f) {
+		if (!ignoreRequestedDir && wantedDir.dot(lastRequestedDir) <= maxAngleAtCanFireCheck)
+			return false;
+	}
 
 	if ((owner->unitDef->maxFuel != 0) && (owner->currentFuel <= 0.0f) && (fuelUsage != 0.0f))
 		return false;

--- a/rts/Sim/Weapons/Weapon.h
+++ b/rts/Sim/Weapons/Weapon.h
@@ -172,6 +172,7 @@ public:
 	CWeapon* slavedTo;            // use this weapon to choose target
 
 	float maxForwardAngleDif;     // for onlyForward/!turret weapons, max. angle between owner->frontdir and (targetPos - owner->pos) (derived from UnitDefWeapon::maxAngleDif)
+	float maxAngleAtCanFireCheck; // angle which prevents a weapon from firing in CanFire. fixes issues with units firing backwards when their target changes before a script's AimWeapon (derived from UnitDefWeapon::fireTolerance)
 	float maxMainDirAngleDif;     // for !onlyForward/turret weapons, max. angle from <mainDir> the weapon can aim (derived from WeaponDef::tolerance)
 
 	float targetBorder;           // if nonzero, units will TryTarget wrt. edge of scaled collision volume instead of centre

--- a/rts/Sim/Weapons/WeaponDef.cpp
+++ b/rts/Sim/Weapons/WeaponDef.cpp
@@ -91,6 +91,7 @@ WEAPONTAG(float, cylinderTargeting).fallbackName("cylinderTargetting").defaultVa
 WEAPONTAG(bool, turret).defaultValue(false).description("Does the unit aim within an arc (up-to and including full 360° turret traverse) or always aim along the owner's heading?");
 WEAPONTAG(bool, fixedLauncher).defaultValue(false);
 WEAPONTAG(float, maxAngle).externalName("tolerance").defaultValue(3000.0f).scaleValue(180.0f / COBSCALEHALF);
+WEAPONTAG(float, maxFireAngle).externalName("firetolerance").defaultValue(16384.0f).scaleValue(180.0f / COBSCALEHALF);
 WEAPONTAG(int, highTrajectory).defaultValue(2);
 WEAPONTAG(float, trajectoryHeight).defaultValue(0.0f);
 WEAPONTAG(bool, tracks).defaultValue(false);

--- a/rts/Sim/Weapons/WeaponDef.cpp
+++ b/rts/Sim/Weapons/WeaponDef.cpp
@@ -91,7 +91,7 @@ WEAPONTAG(float, cylinderTargeting).fallbackName("cylinderTargetting").defaultVa
 WEAPONTAG(bool, turret).defaultValue(false).description("Does the unit aim within an arc (up-to and including full 360° turret traverse) or always aim along the owner's heading?");
 WEAPONTAG(bool, fixedLauncher).defaultValue(false);
 WEAPONTAG(float, maxAngle).externalName("tolerance").defaultValue(3000.0f).scaleValue(180.0f / COBSCALEHALF);
-WEAPONTAG(float, maxFireAngle).externalName("firetolerance").defaultValue(16384.0f).scaleValue(180.0f / COBSCALEHALF);
+WEAPONTAG(float, maxFireAngle).externalName("firetolerance").defaultValue(32768.0f).scaleValue(180.0f / COBSCALEHALF);
 WEAPONTAG(int, highTrajectory).defaultValue(2);
 WEAPONTAG(float, trajectoryHeight).defaultValue(0.0f);
 WEAPONTAG(bool, tracks).defaultValue(false);

--- a/rts/Sim/Weapons/WeaponDef.h
+++ b/rts/Sim/Weapons/WeaponDef.h
@@ -83,6 +83,7 @@ public:
 	int numBounce;
 
 	float maxAngle;
+	float maxFireAngle;
 
 	float uptime;
 	int flighttime;

--- a/rts/Sim/Weapons/WeaponLoader.cpp
+++ b/rts/Sim/Weapons/WeaponLoader.cpp
@@ -132,6 +132,7 @@ CWeapon* CWeaponLoader::InitWeapon(CUnit* owner, CWeapon* weapon, const UnitDefW
 
 	weapon->onlyForward = weaponDef->onlyForward;
 	weapon->maxForwardAngleDif = math::cos(DEG2RAD(weaponDef->maxAngle));
+	weapon->maxAngleAtCanFireCheck = math::cos(DEG2RAD(weaponDef->maxFireAngle));
 	weapon->maxMainDirAngleDif = defWeapon->maxMainDirAngleDif;
 	weapon->mainDir = defWeapon->mainDir;
 


### PR DESCRIPTION
For ticket http://springrts.com/mantis/view.php?id=4641
Default is 90 degrees.
Burst weapons ignore this after the burst begins. Luckily that is a rare case.