### PR TITLE
Lua lock changes

### DIFF
--- a/rts/lib/lua/include/LuaUser.cpp
+++ b/rts/lib/lua/include/LuaUser.cpp
@@ -29,10 +29,10 @@ static boost::recursive_mutex* GetLuaMutex(lua_State* L)
 void LuaCheckIfMain(lua_State* L)
 {
 
-	if (!Threading::IsMainThread()) 
-    {
-        LOG_L(L_ERROR, "attempt to access lua locking not from main thread"); 
-    }
+	if (!Threading::IsMainThread())
+	{
+		LOG_L(L_ERROR, "attempt to access lua locking not from main thread"); 
+	}
 }
 
 void LuaCreateMutex(lua_State* L)

--- a/rts/lib/lua/include/LuaUser.cpp
+++ b/rts/lib/lua/include/LuaUser.cpp
@@ -26,6 +26,14 @@ static boost::recursive_mutex* GetLuaMutex(lua_State* L)
 }
 
 
+void LuaCheckIfMain(lua_State* L)
+{
+
+	if (!Threading::IsMainThread()) 
+    {
+        LOG_L(L_ERROR, "attempt to access lua locking not from main thread"); 
+    }
+}
 
 void LuaCreateMutex(lua_State* L)
 {

--- a/rts/lib/lua/include/LuaUser.h
+++ b/rts/lib/lua/include/LuaUser.h
@@ -12,6 +12,8 @@ extern void LuaMutexLock(lua_State* L);
 extern void LuaMutexUnlock(lua_State* L);
 extern void LuaMutexYield(lua_State* L);
 
+extern void LuaCheckIfMain(lua_State* L);
+
 extern const char* spring_lua_getName(lua_State* L);
 
 struct SLuaInfo {

--- a/rts/lib/lua/include/luaconf.h
+++ b/rts/lib/lua/include/luaconf.h
@@ -734,10 +734,10 @@
 //SPRING
 #ifndef BUILDING_AI
 	#define LUA_USER_H "LuaUser.h"
-    
+
 //#ifndef NDEBUG
-    #define lua_lock(L)			LuaCheckIfMain(L)
-    #define lua_unlock(L)			LuaCheckIfMain(L)
+	#define lua_lock(L)			LuaCheckIfMain(L)
+	#define lua_unlock(L)			LuaCheckIfMain(L)
 //#endif
 
 #endif

--- a/rts/lib/lua/include/luaconf.h
+++ b/rts/lib/lua/include/luaconf.h
@@ -732,28 +732,28 @@
 ** extra when a thread is created/deleted/resumed/yielded.
 */
 //SPRING
-#ifndef BUILDING_AI
-	#define LUA_USER_H "LuaUser.h"
-	#define luai_userstateopen(L)		LuaCreateMutex(L)
-	#define luai_userstateclose(L)		LuaDestroyMutex(L)
-	#define luai_userstatethread(L,L1)	LuaLinkMutex(L,L1)
-	#define luai_userstatefree(L)		LuaDestroyMutex(L)
-	#define luai_userstateresume(L,n)	((void)L)
-	#define luai_userstateyield(L,n)	((void)L)
-	// Don't use internal locking system yet, cause it makes _each_ c++ call to a lua function safe.
-	// But not a group of them, so it's possible that multiple threads modify the stack of a single lua_State and breaking each other.
-	// Solution might be to use coroutines for each c++ thread, cause they got their own stacks and so cannot break each other.
-	//#define luai_userstateyield(L,n)	LuaMutexYield(L)
-	#define lua_lock(L)			LuaMutexLock(L)
-	#define lua_unlock(L)			LuaMutexUnlock(L)
-#else
+// #ifndef BUILDING_AI
+	// #define LUA_USER_H "LuaUser.h"
+	// #define luai_userstateopen(L)		LuaCreateMutex(L)
+	// #define luai_userstateclose(L)		LuaDestroyMutex(L)
+	// #define luai_userstatethread(L,L1)	LuaLinkMutex(L,L1)
+	// #define luai_userstatefree(L)		LuaDestroyMutex(L)
+	// #define luai_userstateresume(L,n)	((void)L)
+	// #define luai_userstateyield(L,n)	((void)L)
+	// // Don't use internal locking system yet, cause it makes _each_ c++ call to a lua function safe.
+	// // But not a group of them, so it's possible that multiple threads modify the stack of a single lua_State and breaking each other.
+	// // Solution might be to use coroutines for each c++ thread, cause they got their own stacks and so cannot break each other.
+	// //#define luai_userstateyield(L,n)	LuaMutexYield(L)
+	// #define lua_lock(L)			LuaMutexLock(L)
+	// #define lua_unlock(L)			LuaMutexUnlock(L)
+// #else
 	#define luai_userstateopen(L)		((void)L)
 	#define luai_userstateclose(L)		((void)L)
 	#define luai_userstatethread(L,L1)	((void)L)
 	#define luai_userstatefree(L)		((void)L)
 	#define luai_userstateresume(L,n)	((void)L)
 	#define luai_userstateyield(L,n)	((void)L)
-#endif
+// #endif
 
 /*
 @@ LUA_INTFRMLEN is the length modifier for integer conversions

--- a/rts/lib/lua/include/luaconf.h
+++ b/rts/lib/lua/include/luaconf.h
@@ -732,28 +732,23 @@
 ** extra when a thread is created/deleted/resumed/yielded.
 */
 //SPRING
-// #ifndef BUILDING_AI
-	// #define LUA_USER_H "LuaUser.h"
-	// #define luai_userstateopen(L)		LuaCreateMutex(L)
-	// #define luai_userstateclose(L)		LuaDestroyMutex(L)
-	// #define luai_userstatethread(L,L1)	LuaLinkMutex(L,L1)
-	// #define luai_userstatefree(L)		LuaDestroyMutex(L)
-	// #define luai_userstateresume(L,n)	((void)L)
-	// #define luai_userstateyield(L,n)	((void)L)
-	// // Don't use internal locking system yet, cause it makes _each_ c++ call to a lua function safe.
-	// // But not a group of them, so it's possible that multiple threads modify the stack of a single lua_State and breaking each other.
-	// // Solution might be to use coroutines for each c++ thread, cause they got their own stacks and so cannot break each other.
-	// //#define luai_userstateyield(L,n)	LuaMutexYield(L)
-	// #define lua_lock(L)			LuaMutexLock(L)
-	// #define lua_unlock(L)			LuaMutexUnlock(L)
-// #else
-	#define luai_userstateopen(L)		((void)L)
-	#define luai_userstateclose(L)		((void)L)
-	#define luai_userstatethread(L,L1)	((void)L)
-	#define luai_userstatefree(L)		((void)L)
-	#define luai_userstateresume(L,n)	((void)L)
-	#define luai_userstateyield(L,n)	((void)L)
-// #endif
+#ifndef BUILDING_AI
+	#define LUA_USER_H "LuaUser.h"
+    
+//#ifndef NDEBUG
+    #define lua_lock(L)			LuaCheckIfMain(L)
+    #define lua_unlock(L)			LuaCheckIfMain(L)
+//#endif
+
+#endif
+
+
+#define luai_userstateopen(L)		((void)L)
+#define luai_userstateclose(L)		((void)L)
+#define luai_userstatethread(L,L1)	((void)L)
+#define luai_userstatefree(L)		((void)L)
+#define luai_userstateresume(L,n)	((void)L)
+#define luai_userstateyield(L,n)	((void)L)
 
 /*
 @@ LUA_INTFRMLEN is the length modifier for integer conversions


### PR DESCRIPTION
I've currently put a test instead of the lock checking if it's called from the main thread and logging an error if it isn't.
I haven't seen any error yet in both windows and linux.
We may want to surround the #define s with #ifndef NDEBUG so it isn't tested on releases.