### PR TITLE
movingAccuracy was entirely disregarded

### DIFF
--- a/rts/Sim/Weapons/WeaponDef.cpp
+++ b/rts/Sim/Weapons/WeaponDef.cpp
@@ -110,7 +110,7 @@ WEAPONTAG(float, proximityPriority).defaultValue(1.0f);
 TAGFUNCTION(AccuracyToSin, float, math::sin(x * PI / 0xafff)) // should really be tan but TA seem to cap it somehow, should also be 7fff or ffff theoretically but neither seems good
 WEAPONTAG(float, accuracy).defaultValue(0.0f).tagFunction(AccuracyToSin);
 WEAPONTAG(float, sprayAngle).defaultValue(0.0f).tagFunction(AccuracyToSin);
-WEAPONTAG(float, movingAccuracy).externalName("accuracy").defaultValue(0.0f).tagFunction(AccuracyToSin);
+WEAPONTAG(float, movingAccuracy).fallbackName("accuracy").defaultValue(0.0f).tagFunction(AccuracyToSin);
 WEAPONTAG(float, targetMoveError).defaultValue(0.0f);
 WEAPONTAG(float, leadLimit).defaultValue(-1.0f);
 WEAPONTAG(float, leadBonus).defaultValue(0.0f);


### PR DESCRIPTION
Due to having externalName("accuracy")