### PR TITLE
Fix InfoTexture bugs

### DIFF
--- a/rts/Rendering/Env/AdvWater.cpp
+++ b/rts/Rendering/Env/AdvWater.cpp
@@ -353,4 +353,5 @@ void CAdvWater::UpdateWater(CGame* game)
 	camera->Update();
 	glPopAttrib();
 	glPopAttrib();
+	glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
 }

--- a/rts/Rendering/Env/DynWater.cpp
+++ b/rts/Rendering/Env/DynWater.cpp
@@ -1193,6 +1193,7 @@ void CDynWater::AddShipWakes()
 
 	glBindFramebufferEXT(GL_FRAMEBUFFER_EXT, 0);
 	glDisable(GL_BLEND);
+	glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
 
 	glDisable(GL_FRAGMENT_PROGRAM_ARB);
 	glDisable(GL_VERTEX_PROGRAM_ARB);
@@ -1278,6 +1279,7 @@ void CDynWater::AddExplosions()
 
 	glBindFramebufferEXT(GL_FRAMEBUFFER_EXT, 0);
 	glDisable(GL_BLEND);
+	glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
 
 	glDisable(GL_FRAGMENT_PROGRAM_ARB);
 	glDisable(GL_VERTEX_PROGRAM_ARB);

--- a/rts/Rendering/Shaders/LuaShaderContainer.cpp
+++ b/rts/Rendering/Shaders/LuaShaderContainer.cpp
@@ -94,7 +94,7 @@ static void ParseUniformSetupTables(Shader::IProgramObject* program, const LuaTa
 }
 
 
-static void CompileObject(
+static void CreateShaderObject(
 	Shader::IProgramObject* program,
 	const std::string& definitions,
 	const std::string& sources,
@@ -184,9 +184,9 @@ bool LoadFromLua(Shader::IProgramObject* program, const std::string& filename)
 	if (vertSrcs.str().empty() && fragSrcs.str().empty() && geomSrcs.str().empty())
 		return false;
 
-	CompileObject(program, shdrDefs.str(), vertSrcs.str(), GL_VERTEX_SHADER);
-	CompileObject(program, shdrDefs.str(), geomSrcs.str(), GL_GEOMETRY_SHADER_EXT);
-	CompileObject(program, shdrDefs.str(), fragSrcs.str(), GL_FRAGMENT_SHADER);
+	CreateShaderObject(program, shdrDefs.str(), vertSrcs.str(), GL_VERTEX_SHADER);
+	CreateShaderObject(program, shdrDefs.str(), geomSrcs.str(), GL_GEOMETRY_SHADER_EXT);
+	CreateShaderObject(program, shdrDefs.str(), fragSrcs.str(), GL_FRAGMENT_SHADER);
 
 	//FIXME ApplyGeometryParameters(L, 1, prog); // done before linking
 

--- a/rts/Rendering/Shaders/Shader.cpp
+++ b/rts/Rendering/Shaders/Shader.cpp
@@ -492,6 +492,8 @@ namespace Shader {
 	void GLSLProgramObject::Release() {
 		IProgramObject::Release();
 		glDeleteProgram(objID);
+		ClearHash();
+		curFlagsHash = 0;
 		objID = 0;
 		objID = glCreateProgram();
 	}

--- a/rts/Rendering/Shaders/ShaderStates.h
+++ b/rts/Rendering/Shaders/ShaderStates.h
@@ -228,6 +228,13 @@ namespace Shader {
 
 		unsigned int GetHash();
 
+		void ClearHash()
+		{
+			lastHash = 0;
+			updates = 1;
+			lastUpdates = 0;
+		}
+
 		std::string GetString() const
 		{
 			std::ostringstream strbuf;


### PR DESCRIPTION
Clears flags cashe in GLSLProgramObject::Release() so that when you call LoadFromLua() shaders are recompiled properly.

This fixes InfoTextures not working with the error:
```
    [f=0000000] [Shader] Warning: [GLSL-PO::Link] program-object name: CInfoTextureCombiner, link-log:
    Link info
    ---------
    No shader objects attached.
     
    [f=0000000] Error: CInfoTextureCombiner-shader compilation error: Link info
    ---------
    No shader objects attached.
```