### PR TITLE
Fix modrules experience scaling values being overridden by hardcoded values

### DIFF
--- a/rts/Sim/Units/Unit.cpp
+++ b/rts/Sim/Units/Unit.cpp
@@ -283,10 +283,6 @@ void CUnit::InitStatic()
 
 	//! SlowUpdate runs every 16th simframe (a second has GAME_SPEED=30 gameframes!)
 	empDeclineRate = 2.0f * (float)UNIT_SLOWUPDATE_RATE / (float)GAME_SPEED / 40.0f;
-	expMultiplier  = 1.0f;
-	expPowerScale  = 1.0f;
-	expHealthScale = 0.7f;
-	expReloadScale = 0.4f;
 	expGrade       = 0.0f;
 
 	CCobInstance::InitVars(teamHandler->ActiveTeams(), teamHandler->ActiveAllyTeams());


### PR DESCRIPTION
Modrules already set these things and handle the default values.
Setting them in Unit.cpp again to hardcoded values overrided the modrules.