### PR TITLE
Fix User target being set for all weapons

### DIFF
--- a/rts/Sim/Units/Unit.cpp
+++ b/rts/Sim/Units/Unit.cpp
@@ -1666,7 +1666,6 @@ bool CUnit::AttackUnit(CUnit* targetUnit, bool isUserTarget, bool wantManualFire
 		//
 		// NOTE: "&&" because we have a separate userAttackGround (!)
 		w->targetType = Target_None;
-		w->haveUserTarget = (targetUnit != NULL && isUserTarget);
 
 		if (targetUnit == NULL)
 			continue;


### PR DESCRIPTION
haveUserTarget is already set in
https://github.com/spring/spring/blob/868b2a0bdcbae486553838509ee97ad4dc5808ac/rts/Sim/Weapons/Weapon.cpp#L622
or
https://github.com/spring/spring/blob/868b2a0bdcbae486553838509ee97ad4dc5808ac/rts/Sim/Weapons/Weapon.cpp#L654

When set also in the change location, all weapons automatically get haveUserTarget status even if they target a different target (since they can't target the user one).