### PR TITLE
[AI] Add Map::GetWaterDamage

### DIFF
--- a/rts/ExternalAI/Interface/SSkirmishAICallback.h
+++ b/rts/ExternalAI/Interface/SSkirmishAICallback.h
@@ -1876,6 +1876,8 @@ struct SSkirmishAICallback {
 
 	float             (CALLING_CONV *Map_getGravity)(int skirmishAIId);
 
+	float             (CALLING_CONV *Map_getWaterDamage)(int skirmishAIId);
+
 
 	/**
 	 * Returns all points drawn with this AIs team color,

--- a/rts/ExternalAI/SSkirmishAICallbackImpl.cpp
+++ b/rts/ExternalAI/SSkirmishAICallbackImpl.cpp
@@ -1912,6 +1912,10 @@ EXPORT(float) skirmishAiCallback_Map_getGravity(int skirmishAIId) {
 	return skirmishAIId_callback[skirmishAIId]->GetGravity();
 }
 
+EXPORT(float) skirmishAiCallback_Map_getWaterDamage(int skirmishAIId) {
+	return mapInfo->water.damage;
+}
+
 
 
 EXPORT(bool) skirmishAiCallback_Map_isPossibleToBuildAt(int skirmishAIId, int unitDefId,
@@ -5276,6 +5280,7 @@ static void skirmishAiCallback_init(SSkirmishAICallback* callback) {
 	callback->Map_getCurWind = &skirmishAiCallback_Map_getCurWind;
 	callback->Map_getTidalStrength = &skirmishAiCallback_Map_getTidalStrength;
 	callback->Map_getGravity = &skirmishAiCallback_Map_getGravity;
+	callback->Map_getWaterDamage = &skirmishAiCallback_Map_getWaterDamage;
 	callback->Map_getPoints = &skirmishAiCallback_Map_getPoints;
 	callback->Map_Point_getPosition = &skirmishAiCallback_Map_Point_getPosition;
 	callback->Map_Point_getColor = &skirmishAiCallback_Map_Point_getColor;

--- a/rts/ExternalAI/SSkirmishAICallbackImpl.cpp
+++ b/rts/ExternalAI/SSkirmishAICallbackImpl.cpp
@@ -1913,7 +1913,7 @@ EXPORT(float) skirmishAiCallback_Map_getGravity(int skirmishAIId) {
 }
 
 EXPORT(float) skirmishAiCallback_Map_getWaterDamage(int skirmishAIId) {
-	return mapInfo->water.damage * ((float)GAME_SPEED / UNIT_SLOWUPDATE_RATE);
+	return mapInfo->water.damage;
 }
 
 

--- a/rts/ExternalAI/SSkirmishAICallbackImpl.cpp
+++ b/rts/ExternalAI/SSkirmishAICallbackImpl.cpp
@@ -1913,7 +1913,7 @@ EXPORT(float) skirmishAiCallback_Map_getGravity(int skirmishAIId) {
 }
 
 EXPORT(float) skirmishAiCallback_Map_getWaterDamage(int skirmishAIId) {
-	return mapInfo->water.damage;
+	return mapInfo->water.damage * ((float)GAME_SPEED / UNIT_SLOWUPDATE_RATE);
 }
 
 

--- a/rts/ExternalAI/SSkirmishAICallbackImpl.h
+++ b/rts/ExternalAI/SSkirmishAICallbackImpl.h
@@ -960,6 +960,8 @@ EXPORT(float            ) skirmishAiCallback_Map_getTidalStrength(int skirmishAI
 
 EXPORT(float            ) skirmishAiCallback_Map_getGravity(int skirmishAIId);
 
+EXPORT(float            ) skirmishAiCallback_Map_getWaterDamage(int skirmishAIId);
+
 EXPORT(int              ) skirmishAiCallback_Map_getPoints(int skirmishAIId, bool includeAllies);
 
 EXPORT(void             ) skirmishAiCallback_Map_Point_getPosition(int skirmishAIId, int pointId, float* return_posF3_out);

--- a/rts/Map/MapInfo.cpp
+++ b/rts/Map/MapInfo.cpp
@@ -223,7 +223,7 @@ void CMapInfo::ReadWater()
 	water.fluidDensity = wt.GetFloat("fluidDensity", 960.0f * 0.25f);
 	water.repeatX = wt.GetFloat("repeatX", 0.0f);
 	water.repeatY = wt.GetFloat("repeatY", 0.0f);
-	water.damage  = wt.GetFloat("damage",  0.0f) * (16.0f / GAME_SPEED);
+	water.damage  = wt.GetFloat("damage",  0.0f) * ((float)UNIT_SLOWUPDATE_RATE / GAME_SPEED);
 
 	water.absorb    = wt.GetFloat3("absorb",    float3(0.0f, 0.0f, 0.0f));
 	water.baseColor = wt.GetFloat3("baseColor", float3(0.0f, 0.0f, 0.0f));

--- a/rts/Map/MapInfo.h
+++ b/rts/Map/MapInfo.h
@@ -137,7 +137,7 @@ public:
 		float  fluidDensity;      ///< in kg/m^3
 		float  repeatX;           ///< (calculated default is in IWater)
 		float  repeatY;           ///< (calculated default is in IWater)
-		float  damage;
+		float  damage;            ///< scaled by (UNIT_SLOWUPDATE_RATE / GAME_SPEED)
 		float3 absorb;
 		float3 baseColor;
 		float3 minColor;


### PR DESCRIPTION
Currently there is no nice way to identify if water is appropriate place for buildings, except for parsing map's .smd
http://springrts.com/mantis/view.php?id=4676

SIDENOTE: Does next code know that water.damage is already scaled by ((float)UNIT_SLOWUPDATE_RATE / GAME_SPEED)?
@see https://github.com/spring/spring/blob/36f68e956d0e6ca45b03d9dc27d717084c43503e/rts/Sim/MoveTypes/MoveDefHandler.cpp#L130-L132
I think water.damage for that part of code should be scaled back with (GAME_SPEED/UNIT_SLOWUPDATE_RATE).