### PR TITLE
Added Lua SyncedRead function to get ground slope value

### DIFF
--- a/rts/Lua/LuaSyncedRead.cpp
+++ b/rts/Lua/LuaSyncedRead.cpp
@@ -289,6 +289,7 @@ bool LuaSyncedRead::PushEntries(lua_State* L)
 	REGISTER_LUA_CFUNC(GetGroundHeight);
 	REGISTER_LUA_CFUNC(GetGroundOrigHeight);
 	REGISTER_LUA_CFUNC(GetGroundNormal);
+	REGISTER_LUA_CFUNC(GetGroundSlope);
 	REGISTER_LUA_CFUNC(GetGroundInfo);
 	REGISTER_LUA_CFUNC(GetGroundBlocked);
 	REGISTER_LUA_CFUNC(GetGroundExtremes);
@@ -4737,6 +4738,15 @@ int LuaSyncedRead::GetGroundNormal(lua_State* L)
 	lua_pushnumber(L, normal.y);
 	lua_pushnumber(L, normal.z);
 	return 3;
+}
+
+
+int LuaSyncedRead::GetGroundSlope(lua_State* L)
+{
+	const float x = luaL_checkfloat(L, 1);
+	const float z = luaL_checkfloat(L, 2);
+	lua_pushnumber(L, CGround::GetSlope(x, z, CLuaHandle::GetHandleSynced(L)));
+	return 1;
 }
 
 

--- a/rts/Lua/LuaSyncedRead.h
+++ b/rts/Lua/LuaSyncedRead.h
@@ -199,6 +199,7 @@ class LuaSyncedRead {
 		static int GetGroundHeight(lua_State* L);
 		static int GetGroundOrigHeight(lua_State* L);
 		static int GetGroundNormal(lua_State* L);
+		static int GetGroundSlope(lua_State* L);
 		static int GetGroundInfo(lua_State* L);
 		static int GetGroundBlocked(lua_State* L);
 		static int GetGroundExtremes(lua_State* L);


### PR DESCRIPTION
As 1.0 - <Y component of Spring.GetGroundNormal(x,z)> is not really equal to slopeMap[x,z].
See https://springrts.com/phpbb/viewtopic.php?f=23&t=33232