### PR TITLE
Fixed impactOnly weapons dealing damage to the owner of the shield. 

### DIFF
--- a/rts/Sim/Weapons/PlasmaRepulser.cpp
+++ b/rts/Sim/Weapons/PlasmaRepulser.cpp
@@ -180,7 +180,7 @@ void CPlasmaRepulser::Update()
 					curPower -= shieldDamage;
 				}
 
-				pro->Collision(owner);
+				pro->Collision();
 
 				if (defHitFrames > 0) {
 					hitFrames = defHitFrames;


### PR DESCRIPTION
This was done by treating explosions caused by shields as if the projectile exploded mid-air. Previously they were treated as if they collided with the owner of the shield. This change should improve the consistency.