### PR TITLE
added lua override for infomaps

### DIFF
--- a/rts/Map/MapInfo.cpp
+++ b/rts/Map/MapInfo.cpp
@@ -333,9 +333,9 @@ void CMapInfo::ReadSMF()
 
 	smf.grassShadingTexName = mapResTable.GetString("grassShadingTex", "");
 
-	smf.skyReflectModTexName = mapResTable.GetString("skyReflectModTex", "");
-	smf.detailNormalTexName = mapResTable.GetString("detailNormalTex", "");
-	smf.lightEmissionTexName = mapResTable.GetString("lightEmissionTex", "");
+	smf.skyReflectModTexName  = mapResTable.GetString("skyReflectModTex", "");
+	smf.detailNormalTexName   = mapResTable.GetString("detailNormalTex", "");
+	smf.lightEmissionTexName  = mapResTable.GetString("lightEmissionTex", "");
 	smf.parallaxHeightTexName = mapResTable.GetString("parallaxHeightTex", "");
 
 	if (!smf.detailTexName.empty()) {
@@ -346,13 +346,13 @@ void CMapInfo::ReadSMF()
 		smf.detailTexName = "bitmaps/" + smf.detailTexName;
 	}
 
-	if (!smf.specularTexName.empty()) { smf.specularTexName = "maps/" + smf.specularTexName; }
-	if (!smf.splatDetailTexName.empty()) { smf.splatDetailTexName = "maps/" + smf.splatDetailTexName; }
-	if (!smf.splatDistrTexName.empty()) { smf.splatDistrTexName = "maps/" + smf.splatDistrTexName; }
-	if (!smf.grassShadingTexName.empty()) { smf.grassShadingTexName = "maps/" + smf.grassShadingTexName; }
-	if (!smf.skyReflectModTexName.empty()) { smf.skyReflectModTexName = "maps/" + smf.skyReflectModTexName; }
-	if (!smf.detailNormalTexName.empty()) { smf.detailNormalTexName = "maps/" + smf.detailNormalTexName; }
-	if (!smf.lightEmissionTexName.empty()) { smf.lightEmissionTexName = "maps/" + smf.lightEmissionTexName; }
+	if (!smf.specularTexName.empty()      ) { smf.specularTexName       = "maps/" + smf.specularTexName; }
+	if (!smf.splatDetailTexName.empty()   ) { smf.splatDetailTexName    = "maps/" + smf.splatDetailTexName; }
+	if (!smf.splatDistrTexName.empty()    ) { smf.splatDistrTexName     = "maps/" + smf.splatDistrTexName; }
+	if (!smf.grassShadingTexName.empty()  ) { smf.grassShadingTexName   = "maps/" + smf.grassShadingTexName; }
+	if (!smf.skyReflectModTexName.empty() ) { smf.skyReflectModTexName  = "maps/" + smf.skyReflectModTexName; }
+	if (!smf.detailNormalTexName.empty()  ) { smf.detailNormalTexName   = "maps/" + smf.detailNormalTexName; }
+	if (!smf.lightEmissionTexName.empty() ) { smf.lightEmissionTexName  = "maps/" + smf.lightEmissionTexName; }
 	if (!smf.parallaxHeightTexName.empty()) { smf.parallaxHeightTexName = "maps/" + smf.parallaxHeightTexName; }
 
 	// smf overrides
@@ -360,17 +360,17 @@ void CMapInfo::ReadSMF()
 
 	smf.minHeightOverride = smfTable.KeyExists("minHeight");
 	smf.maxHeightOverride = smfTable.KeyExists("maxHeight");
-	smf.minHeight = smfTable.GetFloat("minHeight", 0.0f);
-	smf.maxHeight = smfTable.GetFloat("maxHeight", 0.0f);
+	smf.minHeight         = smfTable.GetFloat("minHeight", 0.0f);
+	smf.maxHeight         = smfTable.GetFloat("maxHeight", 0.0f);
 
-	smf.minimapTexName = smfTable.GetString("minimapTex", "");
+	smf.minimapTexName  = smfTable.GetString("minimapTex", "");
 	smf.metalmapTexName = smfTable.GetString("metalmapTex", "");
-	smf.typemapTexName = smfTable.GetString("typemapTex", "");
+	smf.typemapTexName  = smfTable.GetString("typemapTex", "");
 	smf.grassmapTexName = smfTable.GetString("grassmapTex", "");
 
-	if (!smf.minimapTexName.empty()) { smf.minimapTexName = "maps/" + smf.minimapTexName; }
+	if (!smf.minimapTexName.empty() ) { smf.minimapTexName  = "maps/" + smf.minimapTexName; }
 	if (!smf.metalmapTexName.empty()) { smf.metalmapTexName = "maps/" + smf.metalmapTexName; }
-	if (!smf.typemapTexName.empty()) { smf.typemapTexName = "maps/" + smf.typemapTexName; }
+	if (!smf.typemapTexName.empty() ) { smf.typemapTexName  = "maps/" + smf.typemapTexName; }
 	if (!smf.grassmapTexName.empty()) { smf.grassmapTexName = "maps/" + smf.grassmapTexName; }
 
 	std::stringstream ss;

--- a/rts/Map/MapInfo.cpp
+++ b/rts/Map/MapInfo.cpp
@@ -364,7 +364,14 @@ void CMapInfo::ReadSMF()
 	smf.maxHeight = smfTable.GetFloat("maxHeight", 0.0f);
 
 	smf.minimapTexName = smfTable.GetString("minimapTex", "");
+	smf.metalmapTexName = smfTable.GetString("metalmapTex", "");
+	smf.typemapTexName = smfTable.GetString("typemapTex", "");
+	smf.grassmapTexName = smfTable.GetString("grassmapTex", "");
+
 	if (!smf.minimapTexName.empty()) { smf.minimapTexName = "maps/" + smf.minimapTexName; }
+	if (!smf.metalmapTexName.empty()) { smf.metalmapTexName = "maps/" + smf.metalmapTexName; }
+	if (!smf.typemapTexName.empty()) { smf.typemapTexName = "maps/" + smf.typemapTexName; }
+	if (!smf.grassmapTexName.empty()) { smf.grassmapTexName = "maps/" + smf.grassmapTexName; }
 
 	std::stringstream ss;
 

--- a/rts/Map/MapInfo.h
+++ b/rts/Map/MapInfo.h
@@ -182,11 +182,11 @@ public:
 		std::string lightEmissionTexName;
 		std::string parallaxHeightTexName;
 
-        // SMF overrides
+		// SMF overrides
 		std::string minimapTexName;
-        std::string typemapTexName;
-        std::string metalmapTexName;
-        std::string grassmapTexName;
+		std::string typemapTexName;
+		std::string metalmapTexName;
+		std::string grassmapTexName;
 
 
 		float minHeight;

--- a/rts/Map/MapInfo.h
+++ b/rts/Map/MapInfo.h
@@ -182,7 +182,12 @@ public:
 		std::string lightEmissionTexName;
 		std::string parallaxHeightTexName;
 
+        // SMF overrides
 		std::string minimapTexName;
+        std::string typemapTexName;
+        std::string metalmapTexName;
+        std::string grassmapTexName;
+
 
 		float minHeight;
 		bool  minHeightOverride;


### PR DESCRIPTION
added three more tags for the smf section of the mapinfo.lua file to override the type,metal and grass infomaps from greyscale images. if the file is missing or invalid dimensions a content_error exception will be thrown with an informative error message