### PR TITLE
Weapon loader cleanup

### DIFF
--- a/rts/Game/GameHelper.cpp
+++ b/rts/Game/GameHelper.cpp
@@ -635,10 +635,10 @@ void CGameHelper::GenerateWeaponTargets(const CWeapon* weapon, const CUnit* last
 	const CUnit* attacker = weapon->owner;
 	const float radius    = weapon->range;
 	const float3& pos     = attacker->pos;
-	const float heightMod = weapon->heightMod;
 	const float aHeight   = weapon->weaponPos.y;
 
 	const WeaponDef* weaponDef = weapon->weaponDef;
+	const float heightMod = weaponDef->heightmod;
 
 	// how much damage the weapon deals over 1 second
 	const float secDamage = weaponDef->damages.GetDefaultDamage() * weapon->salvoSize / weapon->reloadTime * GAME_SPEED;

--- a/rts/Rendering/GL/glExtra.cpp
+++ b/rts/Rendering/GL/glExtra.cpp
@@ -74,6 +74,7 @@ void glBallisticCircle(const float3& center, const float radius,
 	va->EnlargeArrays(resolution, 0, VA_SIZE_0);
 
 	float3* vertices = va->GetTypedVertexArray<float3>(resolution);
+	const float heightMod = weapon ? weapon->weaponDef->heightmod : 1.0f;
 
 	for_mt(0, resolution, [&](const int i) {
 		const float radians = (2.0f * PI) * (float)i / (float)resolution;
@@ -86,7 +87,6 @@ void glBallisticCircle(const float3& center, const float radius,
 		pos.y = CGround::GetHeightAboveWater(pos.x, pos.z, false);
 		float heightDiff = (pos.y - center.y) * 0.5f;
 		rad -= heightDiff * slope;
-		const float heightMod = weapon->weaponDef->heightmod;
 		float adjRadius = weapon ? weapon->GetRange2D(heightDiff * heightMod) : rad;
 		float adjustment = rad * 0.5f;
 		float ydiff = 0;

--- a/rts/Rendering/GL/glExtra.cpp
+++ b/rts/Rendering/GL/glExtra.cpp
@@ -5,6 +5,7 @@
 #include "VertexArray.h"
 #include "Map/Ground.h"
 #include "Sim/Weapons/Weapon.h"
+#include "Sim/Weapons/WeaponDef.h"
 #include "System/ThreadPool.h"
 
 /**
@@ -85,7 +86,8 @@ void glBallisticCircle(const float3& center, const float radius,
 		pos.y = CGround::GetHeightAboveWater(pos.x, pos.z, false);
 		float heightDiff = (pos.y - center.y) * 0.5f;
 		rad -= heightDiff * slope;
-		float adjRadius = weapon ? weapon->GetRange2D(heightDiff * weapon->heightMod) : rad;
+		const float heightMod = weapon->weaponDef->heightmod;
+		float adjRadius = weapon ? weapon->GetRange2D(heightDiff * heightMod) : rad;
 		float adjustment = rad * 0.5f;
 		float ydiff = 0;
 		for(int j = 0; j < rdiv && math::fabs(adjRadius - rad) + ydiff > .01 * rad; j++){
@@ -101,7 +103,7 @@ void glBallisticCircle(const float3& center, const float radius,
 			ydiff = math::fabs(pos.y - newY);
 			pos.y = newY;
 			heightDiff = (pos.y - center.y);
-			adjRadius = weapon ? weapon->GetRange2D(heightDiff * weapon->heightMod) : rad;
+			adjRadius = weapon ? weapon->GetRange2D(heightDiff * heightMod) : rad;
 		}
 		pos.x = center.x + (sinR * adjRadius);
 		pos.z = center.z + (cosR * adjRadius);

--- a/rts/Sim/Units/CommandAI/MobileCAI.cpp
+++ b/rts/Sim/Units/CommandAI/MobileCAI.cpp
@@ -775,7 +775,7 @@ void CMobileCAI::ExecuteAttack(Command &c)
 			if (tryTargetRotate || tryTargetHeading)
 				break;
 
-			edgeFactor = math::fabs(w->targetBorder);
+			edgeFactor = math::fabs(w->weaponDef->targetBorder);
 		}
 
 		// if w->AttackUnit() returned true then we are already

--- a/rts/Sim/Weapons/BeamLaser.cpp
+++ b/rts/Sim/Weapons/BeamLaser.cpp
@@ -301,16 +301,16 @@ void CBeamLaser::FireInternal(float3 curDir)
 		curDir.SafeNormalize();
 
 		// increase range if targets are searched for in a cylinder
-		if (cylinderTargeting > 0.01f) {
-			const float verticalDist = owner->radius * cylinderTargeting * curDir.y;
+		if (weaponDef->cylinderTargeting > 0.01f) {
+			const float verticalDist = owner->radius * weaponDef->cylinderTargeting * curDir.y;
 			const float maxLengthModSq = maxLength * maxLength + verticalDist * verticalDist;
 
 			maxLength = math::sqrt(maxLengthModSq);
 		}
 
 		// adjust range if targetting edge of hitsphere
-		if (targetType == Target_Unit && targetUnit != NULL && targetBorder != 0.0f) {
-			maxLength += (targetUnit->radius * targetBorder);
+		if (targetType == Target_Unit && targetUnit != NULL && weaponDef->targetBorder != 0.0f) {
+			maxLength += (targetUnit->radius * weaponDef->targetBorder);
 		}
 	} else {
 		// restrict the range when sweeping
@@ -379,14 +379,14 @@ void CBeamLaser::FireInternal(float3 curDir)
 	if (hitUnit != NULL) {
 		hitUnit->SetLastAttackedPiece(hitColQuery.GetHitPiece(), gs->frameNum);
 
-		if (targetBorder > 0.0f) {
-			actualRange += (hitUnit->radius * targetBorder);
+		if (weaponDef->targetBorder > 0.0f) {
+			actualRange += (hitUnit->radius * weaponDef->targetBorder);
 		}
 	}
 
 	if (curLength < maxLength) {
 		// make it possible to always hit with some minimal intensity (melee weapons have use for that)
-		const float hitIntensity = std::max(minIntensity, 1.0f - curLength / (actualRange * 2.0f));
+		const float hitIntensity = std::max(weaponDef->minIntensity, 1.0f - curLength / (actualRange * 2.0f));
 
 		const DamageArray& baseDamages = CWeaponDefHandler::DynamicDamages(weaponDef, weaponMuzzlePos, curPos);
 		const DamageArray damages = baseDamages * (hitIntensity * salvoDamageMult);

--- a/rts/Sim/Weapons/BeamLaser.cpp
+++ b/rts/Sim/Weapons/BeamLaser.cpp
@@ -180,11 +180,11 @@ void CBeamLaser::UpdateSweep()
 	if (reloadStatus > gs->frameNum)
 		return;
 
-	if (teamHandler->Team(owner->team)->res.metal < metalFireCost) { return; }
-	if (teamHandler->Team(owner->team)->res.energy < energyFireCost) { return; }
+	if (teamHandler->Team(owner->team)->res.metal < weaponDef->metalcost) { return; }
+	if (teamHandler->Team(owner->team)->res.energy < weaponDef->energycost) { return; }
 
-	owner->UseEnergy(energyFireCost / salvoSize);
-	owner->UseMetal(metalFireCost / salvoSize);
+	owner->UseEnergy(weaponDef->energycost / salvoSize);
+	owner->UseMetal(weaponDef->metalcost / salvoSize);
 
 	FireInternal(sweepFireState.GetSweepCurrDir());
 

--- a/rts/Sim/Weapons/BeamLaser.cpp
+++ b/rts/Sim/Weapons/BeamLaser.cpp
@@ -398,8 +398,8 @@ void CBeamLaser::FireInternal(float3 curDir)
 			owner,
 			hitUnit,
 			hitFeature,
-			craterAreaOfEffect,
-			damageAreaOfEffect,
+			weaponDef->craterAreaOfEffect,
+			weaponDef->damageAreaOfEffect,
 			weaponDef->edgeEffectiveness,
 			weaponDef->explosionSpeed,
 			1.0f,                                             // gfxMod

--- a/rts/Sim/Weapons/LightningCannon.cpp
+++ b/rts/Sim/Weapons/LightningCannon.cpp
@@ -90,8 +90,8 @@ void CLightningCannon::FireImpl(bool scriptCall)
 		owner,
 		hitUnit,
 		hitFeature,
-		craterAreaOfEffect,
-		damageAreaOfEffect,
+		weaponDef->craterAreaOfEffect,
+		weaponDef->damageAreaOfEffect,
 		weaponDef->edgeEffectiveness,
 		weaponDef->explosionSpeed,
 		0.5f,                                             // gfxMod

--- a/rts/Sim/Weapons/StarburstLauncher.cpp
+++ b/rts/Sim/Weapons/StarburstLauncher.cpp
@@ -65,5 +65,5 @@ bool CStarburstLauncher::HaveFreeLineOfFire(const float3& pos, bool userTarget, 
 
 float CStarburstLauncher::GetRange2D(float yDiff) const
 {
-	return range + (yDiff * heightMod);
+	return range + (yDiff * weaponDef->heightmod);
 }

--- a/rts/Sim/Weapons/Weapon.cpp
+++ b/rts/Sim/Weapons/Weapon.cpp
@@ -59,7 +59,6 @@ CR_REG_METADATA(CWeapon, (
 	CR_MEMBER(onlyTargetCategory),
 	CR_MEMBER(incomingProjectiles),
 	CR_MEMBER(weaponDef),
-	CR_MEMBER(stockpileTime),
 	CR_MEMBER(buildPercent),
 	CR_MEMBER(numStockpiled),
 	CR_MEMBER(numStockpileQued),
@@ -141,7 +140,6 @@ CWeapon::CWeapon(CUnit* owner, const WeaponDef* def):
 	onlyTargetCategory(0xffffffff),
 
 	interceptTarget(NULL),
-	stockpileTime(1),
 	buildPercent(0),
 	numStockpiled(0),
 	numStockpileQued(0),
@@ -473,7 +471,7 @@ bool CWeapon::UpdateStockpile()
 {
 	if (weaponDef->stockpile) {
 		if (numStockpileQued > 0) {
-			const float p = 1.0f / stockpileTime;
+			const float p = 1.0f / weaponDef->stockpileTime;
 
 			if (teamHandler->Team(owner->team)->res.metal >= metalFireCost*p && teamHandler->Team(owner->team)->res.energy >= energyFireCost*p) {
 				owner->UseEnergy(energyFireCost * p);

--- a/rts/Sim/Weapons/Weapon.cpp
+++ b/rts/Sim/Weapons/Weapon.cpp
@@ -71,7 +71,6 @@ CR_REG_METADATA(CWeapon, (
 
 	CR_MEMBER(slavedTo),
 	CR_MEMBER(maxForwardAngleDif),
-	CR_MEMBER(maxAngleAtCanFireCheck),
 	CR_MEMBER(maxMainDirAngleDif),
 	CR_MEMBER(hasCloseTarget),
 	CR_MEMBER(targetBorder),
@@ -146,7 +145,6 @@ CWeapon::CWeapon(CUnit* owner, const WeaponDef* def):
 
 	slavedTo(NULL),
 	maxForwardAngleDif(0.0f),
-	maxAngleAtCanFireCheck(0.0f),
 	maxMainDirAngleDif(-1.0f),
 	targetBorder(0.f),
 	cylinderTargeting(0.f),
@@ -387,8 +385,8 @@ bool CWeapon::CanFire(bool ignoreAngleGood, bool ignoreTargetType, bool ignoreRe
 		return false;
 
 	// sanity check to force new aim
-	if (maxAngleAtCanFireCheck > -1.0f) {
-		if (!ignoreRequestedDir && wantedDir.dot(lastRequestedDir) <= maxAngleAtCanFireCheck)
+	if (weaponDef->maxFireAngle > -1.0f) {
+		if (!ignoreRequestedDir && wantedDir.dot(lastRequestedDir) <= weaponDef->maxFireAngle)
 			return false;
 	}
 

--- a/rts/Sim/Weapons/Weapon.cpp
+++ b/rts/Sim/Weapons/Weapon.cpp
@@ -31,7 +31,6 @@ CR_BIND_DERIVED(CWeapon, CObject, (NULL, NULL))
 CR_REG_METADATA(CWeapon, (
 	CR_MEMBER(owner),
 	CR_MEMBER(range),
-	CR_MEMBER(heightMod),
 	CR_MEMBER(reloadTime),
 	CR_MEMBER(reloadStatus),
 	CR_MEMBER(salvoLeft),
@@ -121,7 +120,6 @@ CWeapon::CWeapon(CUnit* owner, const WeaponDef* def):
 	reloadTime(1),
 	reloadStatus(0),
 	range(1),
-	heightMod(0),
 	projectileSpeed(1),
 	accuracyError(0),
 	sprayAngle(0),
@@ -1131,10 +1129,10 @@ bool CWeapon::TestRange(const float3& tgtPos, bool /*userTarget*/, const CUnit* 
 
 	if (targetUnit == NULL || cylinderTargeting < 0.01f) {
 		// check range in a sphere (with extra radius <heightDiff * heightMod>)
-		weaponRange = GetRange2D(heightDiff * heightMod);
+		weaponRange = GetRange2D(heightDiff * weaponDef->heightmod);
 	} else {
 		// check range in a cylinder (with height <cylinderTargeting * range>)
-		if ((cylinderTargeting * range) > (math::fabsf(heightDiff) * heightMod)) {
+		if ((cylinderTargeting * range) > (math::fabsf(heightDiff) * weaponDef->heightmod)) {
 			weaponRange = GetRange2D(0.0f);
 		}
 	}

--- a/rts/Sim/Weapons/Weapon.cpp
+++ b/rts/Sim/Weapons/Weapon.cpp
@@ -54,8 +54,6 @@ CR_REG_METADATA(CWeapon, (
 	CR_MEMBER(haveUserTarget),
 	CR_MEMBER(onlyForward),
 	CR_MEMBER(muzzleFlareSize),
-	CR_MEMBER(craterAreaOfEffect),
-	CR_MEMBER(damageAreaOfEffect),
 
 	CR_MEMBER(badTargetCategory),
 	CR_MEMBER(onlyTargetCategory),
@@ -112,8 +110,6 @@ CWeapon::CWeapon(CUnit* owner, const WeaponDef* def):
 	weaponDef(def),
 	weaponNum(-1),
 	haveUserTarget(false),
-	craterAreaOfEffect(1.0f),
-	damageAreaOfEffect(1.0f),
 	muzzleFlareSize(1),
 	useWeaponPosForAim(0),
 	hasCloseTarget(false),
@@ -1172,7 +1168,7 @@ bool CWeapon::HaveFreeLineOfFire(const float3& pos, bool userTarget, const CUnit
 		const float3 gpos = weaponMuzzlePos + dir * gdst;
 
 		// true iff ground does not block the ray of length <length> from <pos> along <dir>
-		if ((gdst > 0.0f) && (gpos.SqDistance(pos) > Square(damageAreaOfEffect)))
+		if ((gdst > 0.0f) && (gpos.SqDistance(pos) > Square(weaponDef->damageAreaOfEffect)))
 			return false;
 	}
 
@@ -1261,7 +1257,7 @@ void CWeapon::Init()
 	relWeaponMuzzlePos = owner->script->GetPiecePos(owner->script->QueryWeapon(weaponNum));
 	weaponMuzzlePos = owner->GetObjectSpacePos(relWeaponMuzzlePos);
 
-	muzzleFlareSize = std::min(damageAreaOfEffect * 0.2f, std::min(1500.f, weaponDef->damages[0]) * 0.003f);
+	muzzleFlareSize = std::min(weaponDef->damageAreaOfEffect * 0.2f, std::min(1500.f, weaponDef->damages[0]) * 0.003f);
 
 	if (weaponDef->interceptor)
 		interceptHandler.AddInterceptorWeapon(this);

--- a/rts/Sim/Weapons/Weapon.h
+++ b/rts/Sim/Weapons/Weapon.h
@@ -156,7 +156,6 @@ public:
 	// projectile that we currently target for interception
 	CWeaponProjectile* interceptTarget;
 
-	int stockpileTime;            // how long it takes to stockpile 1 missile
 	float buildPercent;           // how far we have come on building current missile if stockpiling
 	int numStockpiled;            // how many missiles we have stockpiled
 	int numStockpileQued;         // how many weapons the user have added to our que

--- a/rts/Sim/Weapons/Weapon.h
+++ b/rts/Sim/Weapons/Weapon.h
@@ -164,7 +164,6 @@ public:
 	CWeapon* slavedTo;            // use this weapon to choose target
 
 	float maxForwardAngleDif;     // for onlyForward/!turret weapons, max. angle between owner->frontdir and (targetPos - owner->pos) (derived from UnitDefWeapon::maxAngleDif)
-	float maxAngleAtCanFireCheck; // angle which prevents a weapon from firing in CanFire. fixes issues with units firing backwards when their target changes before a script's AimWeapon (derived from UnitDefWeapon::fireTolerance)
 	float maxMainDirAngleDif;     // for !onlyForward/turret weapons, max. angle from <mainDir> the weapon can aim (derived from WeaponDef::tolerance)
 
 	float targetBorder;           // if nonzero, units will TryTarget wrt. edge of scaled collision volume instead of centre

--- a/rts/Sim/Weapons/Weapon.h
+++ b/rts/Sim/Weapons/Weapon.h
@@ -121,7 +121,6 @@ public:
 	int reloadStatus;						// next tick the weapon can fire again
 
 	float range;
-	float heightMod;						// how much extra range the weapon gain per height difference
 
 	float projectileSpeed;
 	float accuracyError;					// inaccuracy of whole salvo

--- a/rts/Sim/Weapons/Weapon.h
+++ b/rts/Sim/Weapons/Weapon.h
@@ -110,9 +110,6 @@ public:
 	int weaponNum;							// the weapons order among the owner weapons
 	bool haveUserTarget;
 
-	float craterAreaOfEffect;
-	float damageAreaOfEffect;
-
 	float muzzleFlareSize;					// size of muzzle flare if drawn
 	int useWeaponPosForAim;					// sometimes weapon pos is better to use than aimpos
 	bool hasCloseTarget;					// might need to update weapon pos more often when enemy is near

--- a/rts/Sim/Weapons/Weapon.h
+++ b/rts/Sim/Weapons/Weapon.h
@@ -166,9 +166,6 @@ public:
 	float maxForwardAngleDif;     // for onlyForward/!turret weapons, max. angle between owner->frontdir and (targetPos - owner->pos) (derived from UnitDefWeapon::maxAngleDif)
 	float maxMainDirAngleDif;     // for !onlyForward/turret weapons, max. angle from <mainDir> the weapon can aim (derived from WeaponDef::tolerance)
 
-	float targetBorder;           // if nonzero, units will TryTarget wrt. edge of scaled collision volume instead of centre
-	float cylinderTargeting;      // if greater than 0, range will be checked in a cylinder (height=range*cylinderTargeting) instead of a sphere
-	float minIntensity;           // for beamlasers - always hit with some minimum intensity (a damage coeffcient normally dependent on distance). do not confuse with intensity tag, it's completely unrelated.
 	float heightBoostFactor;      // controls cannon range height boost. default: -1 -- automatically calculate a more or less sane value
 
 	unsigned int avoidFlags;

--- a/rts/Sim/Weapons/Weapon.h
+++ b/rts/Sim/Weapons/Weapon.h
@@ -135,9 +135,6 @@ public:
 	float predict;							// how long time we predict it take for a projectile to reach target
 	float predictSpeedMod;					// how the weapon predicts the speed of the units goes -> 1 when experience increases
 
-	float metalFireCost;
-	float energyFireCost;
-
 	int fireSoundId;
 	float fireSoundVolume;
 

--- a/rts/Sim/Weapons/WeaponDef.cpp
+++ b/rts/Sim/Weapons/WeaponDef.cpp
@@ -140,7 +140,7 @@ WEAPONTAG(float, fireStarter).defaultValue(0.0f).minimumValue(0.0f).maximumValue
 WEAPONTAG(bool, paralyzer).defaultValue(false).description("Is the weapon a paralyzer? If true the weapon only stuns enemy units and does not cause damage in the form of lost hit-points.");
 WEAPONTAG(int, paralyzeTime,  damages.paralyzeDamageTime).defaultValue(10).minimumValue(0).description("Determines the maximum length of time in seconds that the target will be paralyzed. The timer is restarted every time the target is hit by the weapon. Cannot be less than 0.");
 WEAPONTAG(bool, stockpile).defaultValue(false).description("Does each round of the weapon have to be built and stockpiled by the player? Will only correctly function for the first of each stockpiled weapons a unit has.");
-WEAPONTAG(float, stockpileTime).fallbackName("reload").defaultValue(1.0f).description("The time in seconds taken to stockpile one round of the weapon.");
+WEAPONTAG(float, stockpileTime).fallbackName("reload").defaultValue(1.0f).scaleValue(GAME_SPEED).description("The time in seconds taken to stockpile one round of the weapon.");
 
 // Interceptor
 WEAPONTAG(int, targetable).defaultValue(0).description("Bitmask representing the types of weapon that can intercept this weapon. Each digit of binary that is set to one means that a weapon with the corresponding digit in its interceptor tag will intercept this weapon. Instant-hitting weapons such as [#BeamLaser], [#LightningCannon] and [#Rifle] cannot be targeted.");

--- a/rts/Sim/Weapons/WeaponDef.cpp
+++ b/rts/Sim/Weapons/WeaponDef.cpp
@@ -90,8 +90,8 @@ WEAPONTAG(float, targetBorder).defaultValue(0.0f).minimumValue(-1.0f).maximumVal
 WEAPONTAG(float, cylinderTargeting).fallbackName("cylinderTargetting").defaultValue(0.0f).minimumValue(0.0f).maximumValue(128.0f);
 WEAPONTAG(bool, turret).defaultValue(false).description("Does the unit aim within an arc (up-to and including full 360° turret traverse) or always aim along the owner's heading?");
 WEAPONTAG(bool, fixedLauncher).defaultValue(false);
-WEAPONTAG(float, maxAngle).externalName("tolerance").defaultValue(3000.0f).scaleValue(180.0f / COBSCALEHALF);
-WEAPONTAG(float, maxFireAngle).externalName("firetolerance").defaultValue(3640.0f).scaleValue(180.0f / COBSCALEHALF); // default value is 20degree
+WEAPONTAG(float, maxAngle).externalName("tolerance").defaultValue(3000.0f).scaleValue(TAANG2RAD);
+WEAPONDUMMYTAG(float, maxFireAngle).externalName("firetolerance").defaultValue(3640.0f).scaleValue(TAANG2RAD); // default value is 20degree
 WEAPONTAG(int, highTrajectory).defaultValue(2);
 WEAPONTAG(float, trajectoryHeight).defaultValue(0.0f);
 WEAPONTAG(bool, tracks).defaultValue(false);
@@ -296,7 +296,8 @@ WeaponDef::WeaponDef(const LuaTable& wdTable, const std::string& name_, int id_)
 	shieldRechargeDelay = int(wdTable.GetFloat("rechargeDelay", 0) * GAME_SPEED);
 	shieldArmorType = damageArrayHandler->GetTypeFromName(shieldArmorTypeName);
 	flighttime = int(wdTable.GetFloat("flighttime", 0.0f) * 32);
-
+	maxFireAngle = math::cos(wdTable.GetFloat("firetolerance", 3640.0f) * TAANG2RAD);
+	
 	//FIXME may be smarter to merge the collideXYZ tags with avoidXYZ and removing the collisionFlags tag (and move the code into CWeapon)?
 	collisionFlags = 0;
 	if (!wdTable.GetBool("collideEnemy",    true)) { collisionFlags |= Collision::NOENEMIES;    }

--- a/rts/Sim/Weapons/WeaponLoader.cpp
+++ b/rts/Sim/Weapons/WeaponLoader.cpp
@@ -108,7 +108,6 @@ CWeapon* CWeaponLoader::InitWeapon(CUnit* owner, CWeapon* weapon, const UnitDefW
 	const WeaponDef* weaponDef = defWeapon->def;
 
 	weapon->reloadTime = std::max(1, int(weaponDef->reload * GAME_SPEED));
-	weapon->heightMod = weaponDef->heightmod;
 	weapon->projectileSpeed = weaponDef->projectilespeed;
 
 	weapon->damageAreaOfEffect = weaponDef->damageAreaOfEffect;

--- a/rts/Sim/Weapons/WeaponLoader.cpp
+++ b/rts/Sim/Weapons/WeaponLoader.cpp
@@ -110,8 +110,6 @@ CWeapon* CWeaponLoader::InitWeapon(CUnit* owner, CWeapon* weapon, const UnitDefW
 	weapon->reloadTime = std::max(1, int(weaponDef->reload * GAME_SPEED));
 	weapon->projectileSpeed = weaponDef->projectilespeed;
 
-	weapon->damageAreaOfEffect = weaponDef->damageAreaOfEffect;
-	weapon->craterAreaOfEffect = weaponDef->craterAreaOfEffect;
 	weapon->accuracyError = weaponDef->accuracy;
 	weapon->sprayAngle = weaponDef->sprayAngle;
 

--- a/rts/Sim/Weapons/WeaponLoader.cpp
+++ b/rts/Sim/Weapons/WeaponLoader.cpp
@@ -113,8 +113,6 @@ CWeapon* CWeaponLoader::InitWeapon(CUnit* owner, CWeapon* weapon, const UnitDefW
 	weapon->accuracyError = weaponDef->accuracy;
 	weapon->sprayAngle = weaponDef->sprayAngle;
 
-	weapon->stockpileTime = int(weaponDef->stockpileTime * GAME_SPEED);
-
 	weapon->salvoSize = weaponDef->salvosize;
 	weapon->salvoDelay = int(weaponDef->salvodelay * GAME_SPEED);
 	weapon->projectilesPerShot = weaponDef->projectilespershot;

--- a/rts/Sim/Weapons/WeaponLoader.cpp
+++ b/rts/Sim/Weapons/WeaponLoader.cpp
@@ -25,8 +25,6 @@
 #include "System/Exceptions.h"
 #include "System/Log/ILog.h"
 
-#define DEG2RAD(a) ((a) * (3.141592653f / 180.0f))
-
 CWeaponLoader* CWeaponLoader::GetInstance()
 {
 	static CWeaponLoader instance;
@@ -121,8 +119,7 @@ CWeapon* CWeaponLoader::InitWeapon(CUnit* owner, CWeapon* weapon, const UnitDefW
 	weapon->fireSoundVolume = weaponDef->fireSound.getVolume(0);
 
 	weapon->onlyForward = weaponDef->onlyForward;
-	weapon->maxForwardAngleDif = math::cos(DEG2RAD(weaponDef->maxAngle));
-	weapon->maxAngleAtCanFireCheck = math::cos(DEG2RAD(weaponDef->maxFireAngle));
+	weapon->maxForwardAngleDif = math::cos(weaponDef->maxAngle);
 	weapon->maxMainDirAngleDif = defWeapon->maxMainDirAngleDif;
 	weapon->mainDir = defWeapon->mainDir;
 

--- a/rts/Sim/Weapons/WeaponLoader.cpp
+++ b/rts/Sim/Weapons/WeaponLoader.cpp
@@ -117,9 +117,6 @@ CWeapon* CWeaponLoader::InitWeapon(CUnit* owner, CWeapon* weapon, const UnitDefW
 	weapon->salvoDelay = int(weaponDef->salvodelay * GAME_SPEED);
 	weapon->projectilesPerShot = weaponDef->projectilespershot;
 
-	weapon->metalFireCost = weaponDef->metalcost;
-	weapon->energyFireCost = weaponDef->energycost;
-
 	weapon->fireSoundId = weaponDef->fireSound.getID(0);
 	weapon->fireSoundVolume = weaponDef->fireSound.getVolume(0);
 

--- a/rts/Sim/Weapons/WeaponLoader.cpp
+++ b/rts/Sim/Weapons/WeaponLoader.cpp
@@ -132,9 +132,6 @@ CWeapon* CWeaponLoader::InitWeapon(CUnit* owner, CWeapon* weapon, const UnitDefW
 	}
 
 	weapon->fuelUsage = defWeapon->fuelUsage;
-	weapon->targetBorder = weaponDef->targetBorder;
-	weapon->cylinderTargeting = weaponDef->cylinderTargeting;
-	weapon->minIntensity = weaponDef->minIntensity;
 	weapon->heightBoostFactor = weaponDef->heightBoostFactor;
 	weapon->collisionFlags = weaponDef->collisionFlags;
 


### PR DESCRIPTION
Some tags didn't need copying to the weapon class, since they are never changed, and don't rely on unit.