### PR TITLE
Tag to fix burst bug

### DIFF
--- a/doc/changelog.txt
+++ b/doc/changelog.txt
@@ -52,6 +52,9 @@ System:
  - OverheadCamera: make angle 100% stable when doing `mousewheel down then up`
  ! remove los view w/o radar a.k.a. [;] (can be emulated with Spring.SetLosViewColors)
 
+Weapons:
+ - add burstTargetLock (salvoTargetLock in lua, default false) tag to prevent weapons from changing targets during a burst (fixes #4678)
+
 Sim:
  - fix harvesting
  - fix #4591: builders `randomly` remove build orders from queue

--- a/rts/Lua/LuaWeaponDefs.cpp
+++ b/rts/Lua/LuaWeaponDefs.cpp
@@ -472,6 +472,7 @@ static bool InitParamMap()
 	ADD_INT("salvoSize",    wd.salvosize);
 	ADD_INT("projectiles",  wd.projectilespershot);
 	ADD_FLOAT("salvoDelay", wd.salvodelay);
+	ADD_BOOL("salvoTargetLock", wd.salvoTargetLock);
 	ADD_FLOAT("reload",     wd.reload);
 	ADD_FLOAT("beamtime",   wd.beamtime);
 	ADD_BOOL("beamburst",   wd.beamburst);

--- a/rts/Sim/Weapons/Weapon.cpp
+++ b/rts/Sim/Weapons/Weapon.cpp
@@ -1059,6 +1059,9 @@ bool CWeapon::GetTargetBorderPos(const CUnit* targetUnit, const float3& rawTarge
 
 bool CWeapon::TryTarget(const float3& tgtPos, bool userTarget, const CUnit* targetUnit) const
 {
+	if (weaponDef->salvoTargetLock && salvoLeft && tgtPos != targetPos)
+		return false;
+	
 	if (!TestTarget(tgtPos, userTarget, targetUnit))
 		return false;
 

--- a/rts/Sim/Weapons/WeaponDef.cpp
+++ b/rts/Sim/Weapons/WeaponDef.cpp
@@ -61,6 +61,7 @@ WEAPONTAG(float, weaponacceleration).defaultValue(0.0f).scaleValue(1.0f / (GAME_
 WEAPONTAG(float, reload).externalName("reloadTime").defaultValue(1.0f);
 WEAPONTAG(float, salvodelay).externalName("burstRate").defaultValue(0.1f);
 WEAPONTAG(int, salvosize).externalName("burst").defaultValue(1);
+WEAPONTAG(bool, salvoTargetLock).externalName("burstTargetLock").defaultValue(false).description("Can the unit change targets during a burst?");
 WEAPONTAG(int, projectilespershot).externalName("projectiles").defaultValue(1);
 
 // Bounce

--- a/rts/Sim/Weapons/WeaponDef.h
+++ b/rts/Sim/Weapons/WeaponDef.h
@@ -72,6 +72,7 @@ public:
 
 	int salvosize;
 	float salvodelay;
+	bool salvoTargetLock;
 	float reload;
 	float beamtime;
 	bool beamburst;


### PR DESCRIPTION
Add burstTargetLock (salvoTargetLock in lua, default false) tag to prevent weapons from changing targets during a burst (fixes #4678)