### PR TITLE
add attackSafetyDistance unitDef

### DIFF
--- a/rts/Lua/LuaUnitDefs.cpp
+++ b/rts/Lua/LuaUnitDefs.cpp
@@ -874,6 +874,7 @@ ADD_BOOL("canAttackWater",  canAttackWater); // CUSTOM
 	ADD_FLOAT("maxAileron",  ud.maxAileron);
 	ADD_FLOAT("maxElevator", ud.maxElevator);
 	ADD_FLOAT("maxRudder",   ud.maxRudder);
+	ADD_FLOAT("attackSafetyDistance", ud.attackSafetyDistance);
 
 	ADD_FLOAT("maxFuel",    ud.maxFuel);
 	ADD_FLOAT("refuelTime", ud.refuelTime);

--- a/rts/Sim/MoveTypes/StrafeAirMoveType.cpp
+++ b/rts/Sim/MoveTypes/StrafeAirMoveType.cpp
@@ -397,6 +397,7 @@ CStrafeAirMoveType::CStrafeAirMoveType(CUnit* owner):
 	maxAileron = owner->unitDef->maxAileron;
 	maxElevator = owner->unitDef->maxElevator;
 	maxRudder = owner->unitDef->maxRudder;
+	attackSafetyDistance = owner->unitDef->attackSafetyDistance;
 
 	useSmoothMesh = owner->unitDef->useSmoothMesh;
 
@@ -771,6 +772,13 @@ void CStrafeAirMoveType::UpdateAttack()
 	const float3 goalDir = (goalDist > 0.0f)?
 		(goalPos - pos) / goalDist:
 		ZeroVector;
+
+	// if goal too close, stop dive and resume flying at normal desired height
+	// to avoid colliding with target, evade blast, friendly and enemy fire, etc.
+	if (goalDist < attackSafetyDistance) {
+		UpdateFlying(wantedHeight, 1.0f);
+		return;
+	}
 
 	float goalDotRight = goalDir.dot(rightDir2D.Normalize2D());
 

--- a/rts/Sim/MoveTypes/StrafeAirMoveType.h
+++ b/rts/Sim/MoveTypes/StrafeAirMoveType.h
@@ -76,6 +76,7 @@ public:
 	float maxAileron;
 	float maxElevator;
 	float maxRudder;
+	float attackSafetyDistance;
 
 	/// used while landing
 	float crashAileron;

--- a/rts/Sim/Units/UnitDef.cpp
+++ b/rts/Sim/Units/UnitDef.cpp
@@ -197,6 +197,7 @@ UnitDef::UnitDef()
 	, maxAileron(0.0f)
 	, maxElevator(0.0f)
 	, maxRudder(0.0f)
+	, attackSafetyDistance(0.0f)
 	, crashDrag(0.0f)
 	, loadingRadius(0.0f)
 	, unloadSpread(0.0f)
@@ -491,6 +492,8 @@ UnitDef::UnitDef(const LuaTable& udTable, const std::string& unitName, int id)
 	maxAileron  = udTable.GetFloat("maxAileron",  0.015f); // turn speed around roll axis
 	maxElevator = udTable.GetFloat("maxElevator", 0.01f);  // turn speed around pitch axis
 	maxRudder   = udTable.GetFloat("maxRudder",   0.004f); // turn speed around yaw axis
+
+	attackSafetyDistance = udTable.GetFloat("attackSafetyDistance", 0.0f); // fighters abort dive toward target if within this distance and climb back to normal altitude
 
 	maxFuel = udTable.GetFloat("maxFuel", 0.0f); //max flight time in seconds before aircraft must return to base
 	refuelTime = udTable.GetFloat("refuelTime", 5.0f);

--- a/rts/Sim/Units/UnitDef.h
+++ b/rts/Sim/Units/UnitDef.h
@@ -278,6 +278,7 @@ public:
 	float maxAileron;
 	float maxElevator;
 	float maxRudder;
+	float attackSafetyDistance;
 	float crashDrag;
 
 	float loadingRadius;							///< for transports


### PR DESCRIPTION
- add attackSafetyDistance unitDef (default 0 = current behavior)

- fighters abort dive toward target if within attackSafetyDistance and climb back to normal altitude

- this helps prevent collisions with ground and ground units
