### PR TITLE
fixed maxRange not being updated when UpdateRange was called

### DIFF
--- a/rts/Sim/Units/Unit.cpp
+++ b/rts/Sim/Units/Unit.cpp
@@ -535,6 +535,14 @@ void CUnit::PostLoad()
 }
 
 
+void CUnit::RecalculateMaxRange()
+{
+	maxRange = 0.0f;
+	for (std::vector<CWeapon*>::iterator weaponIter = weapons.begin();weaponIter != weapons.end();weaponIter++){
+		maxRange = std::max(maxRange,(*weaponIter)->range);
+	}
+}
+
 //////////////////////////////////////////////////////////////////////
 //
 

--- a/rts/Sim/Units/Unit.h
+++ b/rts/Sim/Units/Unit.h
@@ -201,6 +201,8 @@ public:
 	void Drop(const float3& parentPos, const float3& parentDir, CUnit* parent);
 	void PostLoad();
 
+	void RecalculateMaxRange();
+
 protected:
 	void ChangeTeamReset();
 	void UpdateResources();

--- a/rts/Sim/Weapons/Cannon.cpp
+++ b/rts/Sim/Weapons/Cannon.cpp
@@ -47,11 +47,12 @@ void CCannon::Init()
 
 void CCannon::UpdateRange(float val)
 {
+	//call the parent class' function to assign since it updates the parent unit's maxRange
+	CWeapon::UpdateRange(val);
 	// clamp so as to not extend range if projectile
 	// speed is too low to reach the *updated* range
 	// note: new range can be zero (!) making range
 	// and height factors irrelevant
-	range = val;
 	rangeFactor = Clamp(range / GetRange2D(0.0f, 1.0f), 0.0f, 1.0f);
 
 	// some magical (but working) equations

--- a/rts/Sim/Weapons/LaserCannon.cpp
+++ b/rts/Sim/Weapons/LaserCannon.cpp
@@ -42,7 +42,9 @@ void CLaserCannon::UpdateRange(float val)
 	// (val / speed) is the total number of frames the projectile
 	// is allowed to do damage to objects, ttl decreases from N-1
 	// to 0 and collisions are checked at 0 inclusive
-	range = std::max(1.0f, std::floor(val / weaponDef->projectilespeed)) * weaponDef->projectilespeed;
+
+	//call the parent class' function to assign since it updates the parent unit's maxRange
+	CWeapon::UpdateRange(std::max(1.0f, std::floor(val / weaponDef->projectilespeed)) * weaponDef->projectilespeed);
 }
 
 

--- a/rts/Sim/Weapons/Weapon.cpp
+++ b/rts/Sim/Weapons/Weapon.cpp
@@ -1203,6 +1203,20 @@ float CWeapon::GetRange2D(float yDiff) const
 	return (root1 > 0.0f) ? math::sqrt(root1) : 0.0f;
 }
 
+void CWeapon::UpdateRange(float val)
+{
+	float previousVal = range;
+	range = val;
+	if (val >= owner->maxRange) {
+		//we can directly assign new range
+		owner->maxRange = val;
+	} else if (previousVal == owner->maxRange) {
+		//we're changing a weapon which has same range of unit's longest weapon range
+		//new unit's range can be different, recalculate
+		owner->RecalculateMaxRange();
+	}
+}
+
 
 void CWeapon::StopAttackingAllyTeam(int ally)
 {

--- a/rts/Sim/Weapons/Weapon.h
+++ b/rts/Sim/Weapons/Weapon.h
@@ -66,7 +66,7 @@ public:
 	float TargetWeight(const CUnit* unit) const;
 
 	virtual float GetRange2D(float yDiff) const;
-	virtual void UpdateRange(float val) { range = val; }
+	virtual void UpdateRange(float val);
 
 	void AutoTarget();
 	void AimReady(int value);

--- a/rts/Sim/Weapons/WeaponLoader.cpp
+++ b/rts/Sim/Weapons/WeaponLoader.cpp
@@ -45,7 +45,6 @@ void CWeaponLoader::LoadWeapons(CUnit* unit)
 	for (const UnitDefWeapon& defWeapon: defWeapons) {
 		CWeapon* weapon = LoadWeapon(unit, &defWeapon);
 		weapons.push_back(InitWeapon(unit, weapon, &defWeapon));
-		unit->maxRange = std::max(weapon->range, unit->maxRange);
 	}
 }
 


### PR DESCRIPTION
fixed maxRange not being updated when UpdateRange was called ( eg from lua's SetUnitWeaponState ) producing a series of problems such as ( but not limited to ):
- fight being oblivious to the new maxRange to seek for an enemy ( if new range was greater, fight would still use old limited maxRange and ram into enemies it could easily outrange )
- range display