### PR TITLE
Add a new {Game, Team, Unit}RulesParam publicity level: 'hidden'.

### DIFF
--- a/doc/changelog.txt
+++ b/doc/changelog.txt
@@ -82,6 +82,7 @@ Lua:
  - add new call-in: UnitStunned(unitID, unitDefID, unitTeam, stunned) -- called whenever a unit changes its stun status
  - add Set/GetProjectileIsIntercepted
  - add GetProjectileTimeToLive, GetProjectileOwnerID and GetProjectileTeamID.
+ - add new {Game, Team, Unit}RulesParam publicity level: 'hidden' - can only be read with full read access
  ! remove Spring.UpdateInfoTexture
  ! fix Spring.GetKeyState & Spring.PressedKeys expecting SDL2 keycodes while whole lua gets SDL1 ones
  ! Spring.PressedKeys now also returns keynames

--- a/rts/Lua/LuaRulesParams.h
+++ b/rts/Lua/LuaRulesParams.h
@@ -11,18 +11,20 @@
 namespace LuaRulesParams
 {
 	enum {
-		RULESPARAMLOS_PRIVATE = 1,  //! only readable by the ally (default)
-		RULESPARAMLOS_ALLIED  = 2,  //! readable for ally + ingame allied
-		RULESPARAMLOS_INLOS   = 4,  //! readable if the unit is in LOS
-		RULESPARAMLOS_INRADAR = 8,  //! readable if the unit is in AirLOS
-		RULESPARAMLOS_PUBLIC  = 16, //! readable for all
+		RULESPARAMLOS_HIDDEN  = 1,  //! only readable with full read access
+		RULESPARAMLOS_PRIVATE = 2,  //! only readable by the ally (default)
+		RULESPARAMLOS_ALLIED  = 4,  //! readable for ally + ingame allied
+		RULESPARAMLOS_INLOS   = 8,  //! readable if the unit is in LOS
+		RULESPARAMLOS_INRADAR = 16,  //! readable if the unit is in AirLOS
+		RULESPARAMLOS_PUBLIC  = 32, //! readable for all
 
 		//! note: that the following constants include all states beneath it (e.g. PRIVATE_MASK includes PUBLIC,ALLIED,INLOS,...)
-		RULESPARAMLOS_PRIVATE_MASK = 31,
-		RULESPARAMLOS_ALLIED_MASK  = 30,
-		RULESPARAMLOS_INLOS_MASK   = 28,
-		RULESPARAMLOS_INRADAR_MASK = 24,
-		RULESPARAMLOS_PUBLIC_MASK  = 16
+		RULESPARAMLOS_HIDDEN_MASK  = 63,
+		RULESPARAMLOS_PRIVATE_MASK = 62,
+		RULESPARAMLOS_ALLIED_MASK  = 60,
+		RULESPARAMLOS_INLOS_MASK   = 56,
+		RULESPARAMLOS_INRADAR_MASK = 48,
+		RULESPARAMLOS_PUBLIC_MASK  = 32
 	};
 
 	struct Param {

--- a/rts/Lua/LuaSyncedCtrl.cpp
+++ b/rts/Lua/LuaSyncedCtrl.cpp
@@ -964,6 +964,9 @@ void SetRulesParam(lua_State* L, const char* caller, int offset,
 				/*else if (losType == "private") {
 					losMask |= LuaRulesParams::RULESPARAMLOS_PRIVATE; //! default
 				}*/
+				else if (losType == "hidden") {
+					losMask |= LuaRulesParams::RULESPARAMLOS_HIDDEN;
+				}
 			}
 		}
 

--- a/rts/Lua/LuaSyncedRead.cpp
+++ b/rts/Lua/LuaSyncedRead.cpp
@@ -891,8 +891,8 @@ int LuaSyncedRead::GetGameRulesParams(lua_State* L)
 	const LuaRulesParams::Params&  params    = CLuaHandleSynced::GetGameParams();
 	const LuaRulesParams::HashMap& paramsMap = CLuaHandleSynced::GetGameParamsMap();
 
-	//! always readable for all
-	const int losMask = LuaRulesParams::RULESPARAMLOS_PRIVATE_MASK;
+	//! either readable only with full read access, or by everyone
+	const int losMask = CLuaHandle::GetHandleFullRead(L) ? LuaRulesParams::RULESPARAMLOS_HIDDEN_MASK : LuaRulesParams::RULESPARAMLOS_PRIVATE_MASK;
 
 	return PushRulesParams(L, __FUNCTION__, params, paramsMap, losMask);
 }
@@ -903,8 +903,8 @@ int LuaSyncedRead::GetGameRulesParam(lua_State* L)
 	const LuaRulesParams::Params&  params    = CLuaHandleSynced::GetGameParams();
 	const LuaRulesParams::HashMap& paramsMap = CLuaHandleSynced::GetGameParamsMap();
 
-	//! always readable for all
-	const int losMask = LuaRulesParams::RULESPARAMLOS_PRIVATE_MASK;
+	//! either readable only with full read access, or by everyone
+	const int losMask = CLuaHandle::GetHandleFullRead(L) ? LuaRulesParams::RULESPARAMLOS_HIDDEN_MASK : LuaRulesParams::RULESPARAMLOS_PRIVATE_MASK;
 
 	return GetRulesParam(L, __FUNCTION__, 1, params, paramsMap, losMask);
 }
@@ -1279,12 +1279,15 @@ int LuaSyncedRead::GetTeamRulesParams(lua_State* L)
 		return 0;
 	}
 
-	int losMask = LuaRulesParams::RULESPARAMLOS_PUBLIC;
+	int losMask = LuaRulesParams::RULESPARAMLOS_PUBLIC_MASK;
 
-	if (IsAlliedTeam(L, team->teamNum) || game->IsGameOver()) {
+	if (CLuaHandle::GetHandleFullRead(L)) {
+		losMask |= LuaRulesParams::RULESPARAMLOS_HIDDEN_MASK;
+	}
+	if (IsAlliedTeam(L, team->teamNum)) {
 		losMask |= LuaRulesParams::RULESPARAMLOS_PRIVATE_MASK;
 	}
-	else if (teamHandler->AlliedTeams(team->teamNum, CLuaHandle::GetHandleReadTeam(L)) || ((CLuaHandle::GetHandleReadAllyTeam(L) < 0) && CLuaHandle::GetHandleFullRead(L))) {
+	else if (teamHandler->AlliedTeams(team->teamNum, CLuaHandle::GetHandleReadTeam(L))) {
 		losMask |= LuaRulesParams::RULESPARAMLOS_ALLIED_MASK;
 	}
 
@@ -1302,12 +1305,15 @@ int LuaSyncedRead::GetTeamRulesParam(lua_State* L)
 		return 0;
 	}
 
-	int losMask = LuaRulesParams::RULESPARAMLOS_PUBLIC;
+	int losMask = LuaRulesParams::RULESPARAMLOS_PUBLIC_MASK;
 
-	if (IsAlliedTeam(L, team->teamNum) || game->IsGameOver()) {
+	if (CLuaHandle::GetHandleFullRead(L)) {
+		losMask |= LuaRulesParams::RULESPARAMLOS_HIDDEN_MASK;
+	}
+	else if (IsAlliedTeam(L, team->teamNum)) {
 		losMask |= LuaRulesParams::RULESPARAMLOS_PRIVATE_MASK;
 	}
-	else if (teamHandler->AlliedTeams(team->teamNum, CLuaHandle::GetHandleReadTeam(L)) || ((CLuaHandle::GetHandleReadAllyTeam(L) < 0) && CLuaHandle::GetHandleFullRead(L))) {
+	else if (teamHandler->AlliedTeams(team->teamNum, CLuaHandle::GetHandleReadTeam(L))) {
 		losMask |= LuaRulesParams::RULESPARAMLOS_ALLIED_MASK;
 	}
 
@@ -4216,10 +4222,13 @@ int LuaSyncedRead::GetUnitRulesParams(lua_State* L)
 
 	int losMask = LuaRulesParams::RULESPARAMLOS_PUBLIC_MASK;
 
-	if (IsAllyUnit(L, unit) || game->IsGameOver()) {
+	if (CLuaHandle::GetHandleFullRead(L)) {
+		losMask |= LuaRulesParams::RULESPARAMLOS_HIDDEN_MASK;
+	}
+	else if (IsAllyUnit(L, unit)) {
 		losMask |= LuaRulesParams::RULESPARAMLOS_PRIVATE_MASK;
 	}
-	else if (teamHandler->AlliedTeams(unit->team, CLuaHandle::GetHandleReadTeam(L)) || ((CLuaHandle::GetHandleReadAllyTeam(L) < 0) && CLuaHandle::GetHandleFullRead(L))) {
+	else if (teamHandler->AlliedTeams(unit->team, CLuaHandle::GetHandleReadTeam(L))) {
 		losMask |= LuaRulesParams::RULESPARAMLOS_ALLIED_MASK;
 	}
 	else if (CLuaHandle::GetHandleReadAllyTeam(L) < 0) {
@@ -4248,10 +4257,13 @@ int LuaSyncedRead::GetUnitRulesParam(lua_State* L)
 
 	int losMask = LuaRulesParams::RULESPARAMLOS_PUBLIC_MASK;
 
-	if (IsAllyUnit(L, unit) || game->IsGameOver()) {
+	if (CLuaHandle::GetHandleFullRead(L)) {
+		losMask |= LuaRulesParams::RULESPARAMLOS_HIDDEN_MASK;
+	}
+	else if (IsAllyUnit(L, unit)) {
 		losMask |= LuaRulesParams::RULESPARAMLOS_PRIVATE_MASK;
 	}
-	else if (teamHandler->AlliedTeams(unit->team, CLuaHandle::GetHandleReadTeam(L)) || ((CLuaHandle::GetHandleReadAllyTeam(L) < 0) && CLuaHandle::GetHandleFullRead(L))) {
+	else if (teamHandler->AlliedTeams(unit->team, CLuaHandle::GetHandleReadTeam(L))) {
 		losMask |= LuaRulesParams::RULESPARAMLOS_ALLIED_MASK;
 	}
 	else if (CLuaHandle::GetHandleReadAllyTeam(L) < 0) {


### PR DESCRIPTION
It can only be read with full read access (i.e. by LuaRules and spectators, but not any ingame players).
