### PR TITLE
Add flag to draw exploded pieces recursively

### DIFF
--- a/doc/changelog.txt
+++ b/doc/changelog.txt
@@ -82,6 +82,7 @@ Lua:
  - add new call-in: UnitStunned(unitID, unitDefID, unitTeam, stunned) -- called whenever a unit changes its stun status
  - add Set/GetProjectileIsIntercepted
  - add GetProjectileTimeToLive, GetProjectileOwnerID and GetProjectileTeamID.
+ - add SFX.RECURSIVE flag to Explode(), allowing to draw the piece and all its children.
  ! remove Spring.UpdateInfoTexture
  ! fix Spring.GetKeyState & Spring.PressedKeys expecting SDL2 keycodes while whole lua gets SDL1 ones
  ! Spring.PressedKeys now also returns keynames

--- a/rts/Lua/LuaConstCOB.cpp
+++ b/rts/Lua/LuaConstCOB.cpp
@@ -127,6 +127,7 @@ bool LuaConstSFX::PushEntries(lua_State* L)
 	LuaPushNamedNumber(L, "NONE",  PF_NONE); // BITMAP_ONLY
 	LuaPushNamedNumber(L, "NO_CEG_TRAIL", PF_NoCEGTrail);
 	LuaPushNamedNumber(L, "NO_HEATCLOUD", PF_NoHeatCloud);
+	LuaPushNamedNumber(L, "RECURSIVE", PF_Recursive);
 
 	// For Spring.UnitScript.EmitSfx
 	LuaPushNamedNumber(L, "VTOL",            SFX_VTOL);

--- a/rts/Rendering/ProjectileDrawer.cpp
+++ b/rts/Rendering/ProjectileDrawer.cpp
@@ -767,7 +767,11 @@ bool CProjectileDrawer::DrawProjectileModel(const CProjectile* p, bool shadowPas
 			glRotatef(pp->spinAngle, pp->spinVec.x, pp->spinVec.y, pp->spinVec.z);
 
 			if (!(/*p->luaDraw &&*/ eventHandler.DrawProjectile(p))) {
-				glCallList(pp->dispList);
+				if (pp->explFlags & PF_Recursive) {
+					pp->omp->DrawStatic();
+				} else {
+					glCallList(pp->dispList);
+				}
 			}
 		glPopMatrix();
 	}

--- a/rts/Sim/Projectiles/PieceProjectile.h
+++ b/rts/Sim/Projectiles/PieceProjectile.h
@@ -15,6 +15,7 @@ const int PF_Fire       = (1 << 4); // 16
 const int PF_NONE       = (1 << 5); // 32
 const int PF_NoCEGTrail = (1 << 6); // 64
 const int PF_NoHeatCloud= (1 << 7); // 128
+const int PF_Recursive  = (1 << 8); // 256
 
 class CSmokeTrailProjectile;
 struct S3DModelPiece;

--- a/rts/Sim/Units/Scripts/UnitScript.cpp
+++ b/rts/Sim/Units/Scripts/UnitScript.cpp
@@ -819,6 +819,7 @@ void CUnitScript::Explode(int piece, int flags)
 	if ((flags & PF_Smoke) && projectileHandler->particleSaturation < 1.0f) { newflags |= PF_Smoke; }
 	if ((flags & PF_Fire) && projectileHandler->particleSaturation < 0.95f) { newflags |= PF_Fire; }
 	if (flags & PF_NoCEGTrail) { newflags |= PF_NoCEGTrail; }
+	if (flags & PF_Recursive) { newflags |= PF_Recursive; }
 
 	new CPieceProjectile(unit, pieces[piece], absPos, explSpeed, newflags, 0.5f);
 #endif


### PR DESCRIPTION
if SFX.RECURSIVE is used in Explode(), the flying piece will be drawn together with its children.
(otherwise nothing is affected)