### PR TITLE
fix #4784 Improve unitsync error messages n case of duplicated files

### DIFF
--- a/rts/System/FileSystem/ArchiveScanner.cpp
+++ b/rts/System/FileSystem/ArchiveScanner.cpp
@@ -566,7 +566,7 @@ void CArchiveScanner::ScanArchive(const std::string& fullName, bool doChecksum)
 			} else {
 				if (aii->second.updated) {
 					const std::string filename = aii->first;
-					LOG_L(L_ERROR, "Found a \"%s\" already in \"%s\", ignoring one in \"%s\"", filename.c_str(), aii->second.path.c_str(), fpath.c_str());
+					LOG_L(L_ERROR, "Found a \"%s\" already in \"%s\", ignoring.", fullName.c_str(), (aii->second.path + aii->second.origName).c_str());
 					if (IsBaseContent(filename)) {
 						throw user_error(std::string("duplicate base content detected:\n\t") + aii->second.path + std::string("\n\t") + fpath
 							+ std::string("\nPlease fix your configuration/installation as this can cause desyncs!"));


### PR DESCRIPTION
Message will be like that: 
Error: Found a "/home/revenant/.spring/maps/deltasiegedry.sd7" already in "/home/revenant/.spring/maps/DeltaSiegeDry.sd7", ignoring second one

instead of (not very helpful in my case): 
Error: Found a "tempest.sd7" already in "/home/revenant/.spring/maps/", ignoring one in "/home/revenant/.spring/maps/"