### PR TITLE
Remove assert from PlayerHandler.cpp

### DIFF
--- a/rts/Game/Players/PlayerHandler.cpp
+++ b/rts/Game/Players/PlayerHandler.cpp
@@ -36,8 +36,6 @@ void CPlayerHandler::ResetState()
 
 void CPlayerHandler::LoadFromSetup(const CGameSetup* setup)
 {
-	assert(players.empty());
-
 	const std::vector<PlayerBase>& playerData = setup->GetPlayerStartingDataCont();
 
 	const int oldSize = players.size();


### PR DESCRIPTION
This assert fires for no reason if you watch a demo through a script, since the local player is added before LoadFromSetup is called through the demo messages.

Since Spring.Reload() already works I think this can be safely deleted.