### PR TITLE
AI weapon state

### DIFF
--- a/AI/Wrappers/Cpp/CMakeLists.txt
+++ b/AI/Wrappers/Cpp/CMakeLists.txt
@@ -109,6 +109,7 @@ if    (BUILD_${myName}_AIWRAPPER)
 		${myGeneratedSourceDir}/AbstractVersion.cpp
 		${myGeneratedSourceDir}/AbstractWeaponDef.cpp
 		${myGeneratedSourceDir}/AbstractWeaponMount.cpp
+		${myGeneratedSourceDir}/AbstractWeapon.cpp
 		${myGeneratedSourceDir}/StubCamera.cpp
 		${myGeneratedSourceDir}/StubCheats.cpp
 		${myGeneratedSourceDir}/StubCommand.cpp
@@ -155,6 +156,7 @@ if    (BUILD_${myName}_AIWRAPPER)
 		${myGeneratedSourceDir}/StubVersion.cpp
 		${myGeneratedSourceDir}/StubWeaponDef.cpp
 		${myGeneratedSourceDir}/StubWeaponMount.cpp
+		${myGeneratedSourceDir}/StubWeapon.cpp
 		${myGeneratedSourceDir}/WrappCamera.cpp
 		${myGeneratedSourceDir}/WrappCheats.cpp
 		${myGeneratedSourceDir}/WrappCurrentCommand.cpp
@@ -204,7 +206,8 @@ if    (BUILD_${myName}_AIWRAPPER)
 		${myGeneratedSourceDir}/WrappUnitSupportedCommand.cpp
 		${myGeneratedSourceDir}/WrappVersion.cpp
 		${myGeneratedSourceDir}/WrappWeaponDef.cpp
-		${myGeneratedSourceDir}/WrappWeaponMount.cpp)
+		${myGeneratedSourceDir}/WrappWeaponMount.cpp
+		${myGeneratedSourceDir}/WrappWeapon.cpp)
 	set(myGeneratedSources
 		${myGeneratedCombineSources}
 		${myGeneratedWrapperSources})

--- a/AI/Wrappers/Cpp/bin/wrappCallback.awk
+++ b/AI/Wrappers/Cpp/bin/wrappCallback.awk
@@ -1022,7 +1022,7 @@ function printMember(fullName_m, memName_m, additionalIndices_m) {
 
 			_retVar_out_new = retVar_out_m "_out";
 			_wrappGetInst_params = "";
-			if (clsName_m == myRootClass || (clsName_m == "WeaponMount" && _fullClsName == "WeaponDef")) {
+			if (clsName_m == myRootClass || (((clsName_m == "WeaponMount") || (clsName_m == "Weapon")) && _fullClsName == "WeaponDef")) {
 				_wrappGetInst_params = "skirmishAIId"; # FIXME: HACK; do not know why needed :/ (should use parents list of params instead of self,or vice-versa?)
 			}
 			_hasRetInd = 0;
@@ -1034,7 +1034,7 @@ function printMember(fullName_m, memName_m, additionalIndices_m) {
 				# Very hacky! too unmotivated for propper fix, sorry.
 				# propper fix would involve getting the parent of the wrapped
 				# class and using its additional indices
-				if (functionName_m != "UnitDef_WeaponMount_getWeaponDef") {
+				if ((functionName_m != "UnitDef_WeaponMount_getWeaponDef") && (functionName_m != "Unit_Weapon_getWeaponDef")) {
 					_wrappGetInst_params = _wrappGetInst_params ", " addInds_m[ai];
 				}
 			}

--- a/AI/Wrappers/Cpp/bin/wrappCallback.awk
+++ b/AI/Wrappers/Cpp/bin/wrappCallback.awk
@@ -1034,7 +1034,7 @@ function printMember(fullName_m, memName_m, additionalIndices_m) {
 				# Very hacky! too unmotivated for propper fix, sorry.
 				# propper fix would involve getting the parent of the wrapped
 				# class and using its additional indices
-				if ((functionName_m != "UnitDef_WeaponMount_getWeaponDef") && (functionName_m != "Unit_Weapon_getWeaponDef")) {
+				if ((functionName_m != "UnitDef_WeaponMount_getWeaponDef") && (functionName_m != "Unit_Weapon_getDef")) {
 					_wrappGetInst_params = _wrappGetInst_params ", " addInds_m[ai];
 				}
 			}

--- a/AI/Wrappers/JavaOO/CMakeLists.txt
+++ b/AI/Wrappers/JavaOO/CMakeLists.txt
@@ -152,6 +152,7 @@ if    (BUILD_${myName}_AIWRAPPER)
 		"Version"
 		"WeaponDef"
 		"WeaponMount"
+		"Weapon"
 		)
 	set(myGeneratedCallbackSources )
 	foreach    (className ${myGenClbClasses})

--- a/AI/Wrappers/JavaOO/bin/wrappCallback.awk
+++ b/AI/Wrappers/JavaOO/bin/wrappCallback.awk
@@ -825,7 +825,7 @@ function printMember(fullName_m, memName_m, additionalIndices_m) {
 				# Very hacky! too unmotivated for propper fix, sorry.
 				# propper fix would involve getting the parent of the wrapped
 				# class and using its additional indices
-				if ((functionName_m != "UnitDef_WeaponMount_getWeaponDef") && (functionName_m != "Unit_Weapon_getWeaponDef")) {
+				if ((functionName_m != "UnitDef_WeaponMount_getWeaponDef") && (functionName_m != "Unit_Weapon_getDef")) {
 					_wrappGetInst_params = _wrappGetInst_params ", " addInds_m[ai];
 				}
 			}

--- a/AI/Wrappers/JavaOO/bin/wrappCallback.awk
+++ b/AI/Wrappers/JavaOO/bin/wrappCallback.awk
@@ -825,7 +825,7 @@ function printMember(fullName_m, memName_m, additionalIndices_m) {
 				# Very hacky! too unmotivated for propper fix, sorry.
 				# propper fix would involve getting the parent of the wrapped
 				# class and using its additional indices
-				if (functionName_m != "UnitDef_WeaponMount_getWeaponDef") {
+				if ((functionName_m != "UnitDef_WeaponMount_getWeaponDef") && (functionName_m != "Unit_Weapon_getWeaponDef")) {
 					_wrappGetInst_params = _wrappGetInst_params ", " addInds_m[ai];
 				}
 			}

--- a/doc/changelog.txt
+++ b/doc/changelog.txt
@@ -97,6 +97,9 @@ Buildbot/Installer:
  ! merged spring-headless / spring-dedicated into linux static builds / windows installer
  ! remove broken maven support
 
+AI:
+ ! add Weapon state object
+
 -- 98.0 ---------------------------------------------------------
 Major:
  - vaporized PathFinder's runtime precache cpu usage

--- a/rts/ExternalAI/Interface/SSkirmishAICallback.h
+++ b/rts/ExternalAI/Interface/SSkirmishAICallback.h
@@ -2430,27 +2430,13 @@ struct SSkirmishAICallback {
 // BEGINN OBJECT Weapon
 	int               (CALLING_CONV *Unit_Weapon_getWeaponDef)(int skirmishAIId, int unitId, int weaponId); //$ REF:RETURN->WeaponDef
 
+	/** Next tick the weapon can fire again. */
 	int               (CALLING_CONV *Unit_Weapon_getReloadFrame)(int skirmishAIId, int unitId, int weaponId);
 
-	float             (CALLING_CONV *Unit_Weapon_getReloadTime)(int skirmishAIId, int unitId, int weaponId);
-
-	float             (CALLING_CONV *Unit_Weapon_getAccuracy)(int skirmishAIId, int unitId, int weaponId);
-
-	float             (CALLING_CONV *Unit_Weapon_getSprayAngle)(int skirmishAIId, int unitId, int weaponId);
+	/** Time between succesive fires in ticks. */
+	int               (CALLING_CONV *Unit_Weapon_getReloadTime)(int skirmishAIId, int unitId, int weaponId);
 
 	float             (CALLING_CONV *Unit_Weapon_getRange)(int skirmishAIId, int unitId, int weaponId);
-
-	float             (CALLING_CONV *Unit_Weapon_getProjectileSpeed)(int skirmishAIId, int unitId, int weaponId);
-
-	int               (CALLING_CONV *Unit_Weapon_getBurst)(int skirmishAIId, int unitId, int weaponId);
-
-	int               (CALLING_CONV *Unit_Weapon_getBurstRate)(int skirmishAIId, int unitId, int weaponId);
-
-	int               (CALLING_CONV *Unit_Weapon_getProjectiles)(int skirmishAIId, int unitId, int weaponId);
-
-	void              (CALLING_CONV *Unit_Weapon_getSalvoError)(int skirmishAIId, int unitId, int weaponId, float* return_posF3_out);
-
-	float             (CALLING_CONV *Unit_Weapon_getTargetMoveError)(int skirmishAIId, int unitId, int weaponId);
 
 // END OBJECT Weapon
 

--- a/rts/ExternalAI/Interface/SSkirmishAICallback.h
+++ b/rts/ExternalAI/Interface/SSkirmishAICallback.h
@@ -1408,6 +1408,8 @@ struct SSkirmishAICallback {
 	/** Number of the last frame this unit received an order from a player. */
 	int               (CALLING_CONV *Unit_getLastUserOrderFrame)(int skirmishAIId, int unitId);
 
+	int               (CALLING_CONV *Unit_getWeapons)(int skirmishAIId, int unitId); //$ FETCHER:MULTI:NUM:Weapon
+
 // END OBJECT Unit
 
 
@@ -2423,6 +2425,34 @@ struct SSkirmishAICallback {
 	int               (CALLING_CONV *WeaponDef_getCustomParams)(int skirmishAIId, int weaponDefId, const char** keys, const char** values); //$ MAP
 
 // END OBJECT WeaponDef
+
+
+// BEGINN OBJECT Weapon
+	int               (CALLING_CONV *Unit_Weapon_getWeaponDef)(int skirmishAIId, int unitId, int weaponId); //$ REF:RETURN->WeaponDef
+
+	int               (CALLING_CONV *Unit_Weapon_getReloadFrame)(int skirmishAIId, int unitId, int weaponId);
+
+	float             (CALLING_CONV *Unit_Weapon_getReloadTime)(int skirmishAIId, int unitId, int weaponId);
+
+	float             (CALLING_CONV *Unit_Weapon_getAccuracy)(int skirmishAIId, int unitId, int weaponId);
+
+	float             (CALLING_CONV *Unit_Weapon_getSprayAngle)(int skirmishAIId, int unitId, int weaponId);
+
+	float             (CALLING_CONV *Unit_Weapon_getRange)(int skirmishAIId, int unitId, int weaponId);
+
+	float             (CALLING_CONV *Unit_Weapon_getProjectileSpeed)(int skirmishAIId, int unitId, int weaponId);
+
+	int               (CALLING_CONV *Unit_Weapon_getBurst)(int skirmishAIId, int unitId, int weaponId);
+
+	int               (CALLING_CONV *Unit_Weapon_getBurstRate)(int skirmishAIId, int unitId, int weaponId);
+
+	int               (CALLING_CONV *Unit_Weapon_getProjectiles)(int skirmishAIId, int unitId, int weaponId);
+
+	void              (CALLING_CONV *Unit_Weapon_getSalvoError)(int skirmishAIId, int unitId, int weaponId, float* return_posF3_out);
+
+	float             (CALLING_CONV *Unit_Weapon_getTargetMoveError)(int skirmishAIId, int unitId, int weaponId);
+
+// END OBJECT Weapon
 
 	bool              (CALLING_CONV *Debug_GraphDrawer_isEnabled)(int skirmishAIId);
 

--- a/rts/ExternalAI/Interface/SSkirmishAICallback.h
+++ b/rts/ExternalAI/Interface/SSkirmishAICallback.h
@@ -1410,6 +1410,7 @@ struct SSkirmishAICallback {
 
 	int               (CALLING_CONV *Unit_getWeapons)(int skirmishAIId, int unitId); //$ FETCHER:MULTI:NUM:Weapon
 
+	int               (CALLING_CONV *Unit_getWeapon)(int skirmishAIId, int unitId, int weaponMountId); //$ REF:weaponMountId->WeaponMount REF:RETURN->Weapon
 // END OBJECT Unit
 
 
@@ -2428,7 +2429,7 @@ struct SSkirmishAICallback {
 
 
 // BEGINN OBJECT Weapon
-	int               (CALLING_CONV *Unit_Weapon_getWeaponDef)(int skirmishAIId, int unitId, int weaponId); //$ REF:RETURN->WeaponDef
+	int               (CALLING_CONV *Unit_Weapon_getDef)(int skirmishAIId, int unitId, int weaponId); //$ REF:RETURN->WeaponDef
 
 	/** Next tick the weapon can fire again. */
 	int               (CALLING_CONV *Unit_Weapon_getReloadFrame)(int skirmishAIId, int unitId, int weaponId);

--- a/rts/ExternalAI/SSkirmishAICallbackImpl.cpp
+++ b/rts/ExternalAI/SSkirmishAICallbackImpl.cpp
@@ -3852,6 +3852,18 @@ EXPORT(int) skirmishAiCallback_Unit_getWeapons(int skirmishAIId, int unitId) {
 	return 0;
 }
 
+EXPORT(int) skirmishAiCallback_Unit_getWeapon(int skirmishAIId, int unitId, int weaponMountId) {
+	const CUnit* unit = getUnit(unitId);
+	if (!unit || ((size_t)weaponMountId >= unit->weapons.size())) {
+		return -1;
+	}
+
+	if (isAlliedUnit(skirmishAIId, unit) || skirmishAiCallback_Cheats_isEnabled(skirmishAIId)) {
+		return weaponMountId;
+	}
+	return -1;
+}
+
 //########### END Unit
 
 EXPORT(int) skirmishAiCallback_getEnemyUnits(int skirmishAIId, int* unitIds, int unitIds_sizeMax) {
@@ -4845,7 +4857,7 @@ EXPORT(int) skirmishAiCallback_WeaponDef_getCustomParams(int skirmishAIId, int w
 
 
 //########### BEGINN Weapon
-EXPORT(int) skirmishAiCallback_Unit_Weapon_getWeaponDef(int skirmishAIId, int unitId, int weaponId) {
+EXPORT(int) skirmishAiCallback_Unit_Weapon_getDef(int skirmishAIId, int unitId, int weaponId) {
 	const CUnit* unit = getUnit(unitId);
 	if (!unit || ((size_t)weaponId >= unit->weapons.size())) {
 		return -1;
@@ -5401,6 +5413,7 @@ static void skirmishAiCallback_init(SSkirmishAICallback* callback) {
 	callback->Unit_getBuildingFacing = &skirmishAiCallback_Unit_getBuildingFacing;
 	callback->Unit_getLastUserOrderFrame = &skirmishAiCallback_Unit_getLastUserOrderFrame;
 	callback->Unit_getWeapons = &skirmishAiCallback_Unit_getWeapons;
+	callback->Unit_getWeapon = &skirmishAiCallback_Unit_getWeapon;
 	callback->Team_hasAIController = &skirmishAiCallback_Team_hasAIController;
 	callback->getEnemyTeams = &skirmishAiCallback_getEnemyTeams;
 	callback->getAllyTeams = &skirmishAiCallback_getAllyTeams;
@@ -5653,7 +5666,7 @@ static void skirmishAiCallback_init(SSkirmishAICallback* callback) {
 	callback->WeaponDef_getDynDamageRange = &skirmishAiCallback_WeaponDef_getDynDamageRange;
 	callback->WeaponDef_isDynDamageInverted = &skirmishAiCallback_WeaponDef_isDynDamageInverted;
 	callback->WeaponDef_getCustomParams = &skirmishAiCallback_WeaponDef_getCustomParams;
-	callback->Unit_Weapon_getWeaponDef = &skirmishAiCallback_Unit_Weapon_getWeaponDef;
+	callback->Unit_Weapon_getDef = &skirmishAiCallback_Unit_Weapon_getDef;
 	callback->Unit_Weapon_getReloadFrame = &skirmishAiCallback_Unit_Weapon_getReloadFrame;
 	callback->Unit_Weapon_getReloadTime = &skirmishAiCallback_Unit_Weapon_getReloadTime;
 	callback->Unit_Weapon_getRange = &skirmishAiCallback_Unit_Weapon_getRange;

--- a/rts/ExternalAI/SSkirmishAICallbackImpl.cpp
+++ b/rts/ExternalAI/SSkirmishAICallbackImpl.cpp
@@ -4863,32 +4863,14 @@ EXPORT(int) skirmishAiCallback_Unit_Weapon_getReloadFrame(int skirmishAIId, int 
 	return unit->weapons[weaponId]->reloadStatus;
 }
 
-EXPORT(float) skirmishAiCallback_Unit_Weapon_getReloadTime(int skirmishAIId, int unitId, int weaponId) {
+EXPORT(int) skirmishAiCallback_Unit_Weapon_getReloadTime(int skirmishAIId, int unitId, int weaponId) {
 	const CUnit* unit = getUnit(unitId);
 	if (!unit || ((size_t)weaponId >= unit->weapons.size())) {
-		return -1.0f;
+		return -1;
 	}
 
 	const CWeapon* weapon = unit->weapons[weaponId];
-	return (weapon->reloadTime / unit->reloadSpeed) / GAME_SPEED;
-}
-
-EXPORT(float) skirmishAiCallback_Unit_Weapon_getAccuracy(int skirmishAIId, int unitId, int weaponId) {
-	const CUnit* unit = getUnit(unitId);
-	if (!unit || ((size_t)weaponId >= unit->weapons.size())) {
-		return -1.0f;
-	}
-
-	return unit->weapons[weaponId]->AccuracyExperience();
-}
-
-EXPORT(float) skirmishAiCallback_Unit_Weapon_getSprayAngle(int skirmishAIId, int unitId, int weaponId) {
-	const CUnit* unit = getUnit(unitId);
-	if (!unit || ((size_t)weaponId >= unit->weapons.size())) {
-		return -1.0f;
-	}
-
-	return unit->weapons[weaponId]->SprayAngleExperience();
+	return weapon->reloadTime / unit->reloadSpeed;
 }
 
 EXPORT(float) skirmishAiCallback_Unit_Weapon_getRange(int skirmishAIId, int unitId, int weaponId) {
@@ -4898,60 +4880,6 @@ EXPORT(float) skirmishAiCallback_Unit_Weapon_getRange(int skirmishAIId, int unit
 	}
 
 	return unit->weapons[weaponId]->range;
-}
-
-EXPORT(float) skirmishAiCallback_Unit_Weapon_getProjectileSpeed(int skirmishAIId, int unitId, int weaponId) {
-	const CUnit* unit = getUnit(unitId);
-	if (!unit || ((size_t)weaponId >= unit->weapons.size())) {
-		return -1.0f;
-	}
-
-	return unit->weapons[weaponId]->projectileSpeed;
-}
-
-EXPORT(int) skirmishAiCallback_Unit_Weapon_getBurst(int skirmishAIId, int unitId, int weaponId) {
-	const CUnit* unit = getUnit(unitId);
-	if (!unit || ((size_t)weaponId >= unit->weapons.size())) {
-		return -1;
-	}
-
-	return unit->weapons[weaponId]->salvoSize;
-}
-
-EXPORT(int) skirmishAiCallback_Unit_Weapon_getBurstRate(int skirmishAIId, int unitId, int weaponId) {
-	const CUnit* unit = getUnit(unitId);
-	if (!unit || ((size_t)weaponId >= unit->weapons.size())) {
-		return -1;
-	}
-
-	return unit->weapons[weaponId]->salvoDelay / GAME_SPEED;
-}
-
-EXPORT(int) skirmishAiCallback_Unit_Weapon_getProjectiles(int skirmishAIId, int unitId, int weaponId) {
-	const CUnit* unit = getUnit(unitId);
-	if (!unit || ((size_t)weaponId >= unit->weapons.size())) {
-		return -1;
-	}
-
-	return unit->weapons[weaponId]->projectilesPerShot;
-}
-
-EXPORT(void) skirmishAiCallback_Unit_Weapon_getSalvoError(int skirmishAIId, int unitId, int weaponId, float* return_posF3_out) {
-	const CUnit* unit = getUnit(unitId);
-	if (!unit || ((size_t)weaponId >= unit->weapons.size())) {
-		(-RgtVector).copyInto(return_posF3_out);
-	}
-
-	unit->weapons[weaponId]->SalvoErrorExperience().copyInto(return_posF3_out);
-}
-
-EXPORT(float) skirmishAiCallback_Unit_Weapon_getTargetMoveError(int skirmishAIId, int unitId, int weaponId) {
-	const CUnit* unit = getUnit(unitId);
-	if (!unit || ((size_t)weaponId >= unit->weapons.size())) {
-		return -1.0f;
-	}
-
-	return unit->weapons[weaponId]->MoveErrorExperience();
 }
 
 //########### END Weapon
@@ -5728,15 +5656,7 @@ static void skirmishAiCallback_init(SSkirmishAICallback* callback) {
 	callback->Unit_Weapon_getWeaponDef = &skirmishAiCallback_Unit_Weapon_getWeaponDef;
 	callback->Unit_Weapon_getReloadFrame = &skirmishAiCallback_Unit_Weapon_getReloadFrame;
 	callback->Unit_Weapon_getReloadTime = &skirmishAiCallback_Unit_Weapon_getReloadTime;
-	callback->Unit_Weapon_getAccuracy = &skirmishAiCallback_Unit_Weapon_getAccuracy;
-	callback->Unit_Weapon_getSprayAngle = &skirmishAiCallback_Unit_Weapon_getSprayAngle;
 	callback->Unit_Weapon_getRange = &skirmishAiCallback_Unit_Weapon_getRange;
-	callback->Unit_Weapon_getProjectileSpeed = &skirmishAiCallback_Unit_Weapon_getProjectileSpeed;
-	callback->Unit_Weapon_getBurst = &skirmishAiCallback_Unit_Weapon_getBurst;
-	callback->Unit_Weapon_getBurstRate = &skirmishAiCallback_Unit_Weapon_getBurstRate;
-	callback->Unit_Weapon_getProjectiles = &skirmishAiCallback_Unit_Weapon_getProjectiles;
-	callback->Unit_Weapon_getSalvoError = &skirmishAiCallback_Unit_Weapon_getSalvoError;
-	callback->Unit_Weapon_getTargetMoveError = &skirmishAiCallback_Unit_Weapon_getTargetMoveError;
 	callback->Debug_GraphDrawer_isEnabled = &skirmishAiCallback_Debug_GraphDrawer_isEnabled;
 }
 

--- a/rts/ExternalAI/SSkirmishAICallbackImpl.cpp
+++ b/rts/ExternalAI/SSkirmishAICallbackImpl.cpp
@@ -29,6 +29,7 @@
 #include "Sim/Features/FeatureDef.h"
 #include "Sim/Features/FeatureHandler.h"
 #include "Sim/Weapons/WeaponDefHandler.h"
+#include "Sim/Weapons/Weapon.h"
 #include "Sim/Misc/CategoryHandler.h"
 #include "Sim/Misc/Resource.h"
 #include "Sim/Misc/ResourceHandler.h"
@@ -2177,7 +2178,7 @@ EXPORT(float) skirmishAiCallback_Economy_getStorage(int skirmishAIId,
 
 EXPORT(float) skirmishAiCallback_Economy_getPull(int skirmishAIId, int resourceId) {
 
-    int teamId = skirmishAIId_teamId[skirmishAIId];
+	int teamId = skirmishAIId_teamId[skirmishAIId];
 
 	if (resourceId == resourceHandler->GetMetalId()) {
 		return teamHandler->Team(teamId)->resPrevPull.metal;
@@ -2190,7 +2191,7 @@ EXPORT(float) skirmishAiCallback_Economy_getPull(int skirmishAIId, int resourceI
 
 EXPORT(float) skirmishAiCallback_Economy_getShare(int skirmishAIId, int resourceId) {
 
-    int teamId = skirmishAIId_teamId[skirmishAIId];
+	int teamId = skirmishAIId_teamId[skirmishAIId];
 
 	if (resourceId == resourceHandler->GetMetalId()) {
 		return teamHandler->Team(teamId)->resShare.metal;
@@ -2203,7 +2204,7 @@ EXPORT(float) skirmishAiCallback_Economy_getShare(int skirmishAIId, int resource
 
 EXPORT(float) skirmishAiCallback_Economy_getSent(int skirmishAIId, int resourceId) {
 
-    int teamId = skirmishAIId_teamId[skirmishAIId];
+	int teamId = skirmishAIId_teamId[skirmishAIId];
 
 	if (resourceId == resourceHandler->GetMetalId()) {
 		return teamHandler->Team(teamId)->resPrevSent.metal;
@@ -2216,7 +2217,7 @@ EXPORT(float) skirmishAiCallback_Economy_getSent(int skirmishAIId, int resourceI
 
 EXPORT(float) skirmishAiCallback_Economy_getReceived(int skirmishAIId, int resourceId) {
 
-    int teamId = skirmishAIId_teamId[skirmishAIId];
+	int teamId = skirmishAIId_teamId[skirmishAIId];
 
 	if (resourceId == resourceHandler->GetMetalId()) {
 		return teamHandler->Team(teamId)->resPrevReceived.metal;
@@ -2224,12 +2225,12 @@ EXPORT(float) skirmishAiCallback_Economy_getReceived(int skirmishAIId, int resou
 		return teamHandler->Team(teamId)->resPrevReceived.energy;
 	}
 
-    return -1.0f;
+	return -1.0f;
 }
 
 EXPORT(float) skirmishAiCallback_Economy_getExcess(int skirmishAIId, int resourceId) {
 
-    int teamId = skirmishAIId_teamId[skirmishAIId];
+	int teamId = skirmishAIId_teamId[skirmishAIId];
 
 	if (resourceId == resourceHandler->GetMetalId()) {
 		return teamHandler->Team(teamId)->resPrevExcess.metal;
@@ -3843,6 +3844,14 @@ EXPORT(int) skirmishAiCallback_Unit_getLastUserOrderFrame(int skirmishAIId, int 
 	return unitHandler->units[unitId]->commandAI->lastUserCommand;
 }
 
+EXPORT(int) skirmishAiCallback_Unit_getWeapons(int skirmishAIId, int unitId) {
+	const CUnit* unit = getUnit(unitId);
+	if (unit && (isAlliedUnit(skirmishAIId, unit) || skirmishAiCallback_Cheats_isEnabled(skirmishAIId))) {
+		return unit->weapons.size();
+	}
+	return 0;
+}
+
 //########### END Unit
 
 EXPORT(int) skirmishAiCallback_getEnemyUnits(int skirmishAIId, int* unitIds, int unitIds_sizeMax) {
@@ -4835,6 +4844,119 @@ EXPORT(int) skirmishAiCallback_WeaponDef_getCustomParams(int skirmishAIId, int w
 //########### END WeaponDef
 
 
+//########### BEGINN Weapon
+EXPORT(int) skirmishAiCallback_Unit_Weapon_getWeaponDef(int skirmishAIId, int unitId, int weaponId) {
+	const CUnit* unit = getUnit(unitId);
+	if (!unit || ((size_t)weaponId >= unit->weapons.size())) {
+		return -1;
+	}
+
+	return unit->weapons[weaponId]->weaponDef->id;
+}
+
+EXPORT(int) skirmishAiCallback_Unit_Weapon_getReloadFrame(int skirmishAIId, int unitId, int weaponId) {
+	const CUnit* unit = getUnit(unitId);
+	if (!unit || ((size_t)weaponId >= unit->weapons.size())) {
+		return -1;
+	}
+
+	return unit->weapons[weaponId]->reloadStatus;
+}
+
+EXPORT(float) skirmishAiCallback_Unit_Weapon_getReloadTime(int skirmishAIId, int unitId, int weaponId) {
+	const CUnit* unit = getUnit(unitId);
+	if (!unit || ((size_t)weaponId >= unit->weapons.size())) {
+		return -1.0f;
+	}
+
+	const CWeapon* weapon = unit->weapons[weaponId];
+	return (weapon->reloadTime / unit->reloadSpeed) / GAME_SPEED;
+}
+
+EXPORT(float) skirmishAiCallback_Unit_Weapon_getAccuracy(int skirmishAIId, int unitId, int weaponId) {
+	const CUnit* unit = getUnit(unitId);
+	if (!unit || ((size_t)weaponId >= unit->weapons.size())) {
+		return -1.0f;
+	}
+
+	return unit->weapons[weaponId]->AccuracyExperience();
+}
+
+EXPORT(float) skirmishAiCallback_Unit_Weapon_getSprayAngle(int skirmishAIId, int unitId, int weaponId) {
+	const CUnit* unit = getUnit(unitId);
+	if (!unit || ((size_t)weaponId >= unit->weapons.size())) {
+		return -1.0f;
+	}
+
+	return unit->weapons[weaponId]->SprayAngleExperience();
+}
+
+EXPORT(float) skirmishAiCallback_Unit_Weapon_getRange(int skirmishAIId, int unitId, int weaponId) {
+	const CUnit* unit = getUnit(unitId);
+	if (!unit || ((size_t)weaponId >= unit->weapons.size())) {
+		return -1.0f;
+	}
+
+	return unit->weapons[weaponId]->range;
+}
+
+EXPORT(float) skirmishAiCallback_Unit_Weapon_getProjectileSpeed(int skirmishAIId, int unitId, int weaponId) {
+	const CUnit* unit = getUnit(unitId);
+	if (!unit || ((size_t)weaponId >= unit->weapons.size())) {
+		return -1.0f;
+	}
+
+	return unit->weapons[weaponId]->projectileSpeed;
+}
+
+EXPORT(int) skirmishAiCallback_Unit_Weapon_getBurst(int skirmishAIId, int unitId, int weaponId) {
+	const CUnit* unit = getUnit(unitId);
+	if (!unit || ((size_t)weaponId >= unit->weapons.size())) {
+		return -1;
+	}
+
+	return unit->weapons[weaponId]->salvoSize;
+}
+
+EXPORT(int) skirmishAiCallback_Unit_Weapon_getBurstRate(int skirmishAIId, int unitId, int weaponId) {
+	const CUnit* unit = getUnit(unitId);
+	if (!unit || ((size_t)weaponId >= unit->weapons.size())) {
+		return -1;
+	}
+
+	return unit->weapons[weaponId]->salvoDelay / GAME_SPEED;
+}
+
+EXPORT(int) skirmishAiCallback_Unit_Weapon_getProjectiles(int skirmishAIId, int unitId, int weaponId) {
+	const CUnit* unit = getUnit(unitId);
+	if (!unit || ((size_t)weaponId >= unit->weapons.size())) {
+		return -1;
+	}
+
+	return unit->weapons[weaponId]->projectilesPerShot;
+}
+
+EXPORT(void) skirmishAiCallback_Unit_Weapon_getSalvoError(int skirmishAIId, int unitId, int weaponId, float* return_posF3_out) {
+	const CUnit* unit = getUnit(unitId);
+	if (!unit || ((size_t)weaponId >= unit->weapons.size())) {
+		(-RgtVector).copyInto(return_posF3_out);
+	}
+
+	unit->weapons[weaponId]->SalvoErrorExperience().copyInto(return_posF3_out);
+}
+
+EXPORT(float) skirmishAiCallback_Unit_Weapon_getTargetMoveError(int skirmishAIId, int unitId, int weaponId) {
+	const CUnit* unit = getUnit(unitId);
+	if (!unit || ((size_t)weaponId >= unit->weapons.size())) {
+		return -1.0f;
+	}
+
+	return unit->weapons[weaponId]->MoveErrorExperience();
+}
+
+//########### END Weapon
+
+
 EXPORT(bool) skirmishAiCallback_Debug_GraphDrawer_isEnabled(int skirmishAIId) {
 	return skirmishAIId_callback[skirmishAIId]->IsDebugDrawerEnabled();
 }
@@ -5350,6 +5472,7 @@ static void skirmishAiCallback_init(SSkirmishAICallback* callback) {
 	callback->Unit_isNeutral = &skirmishAiCallback_Unit_isNeutral;
 	callback->Unit_getBuildingFacing = &skirmishAiCallback_Unit_getBuildingFacing;
 	callback->Unit_getLastUserOrderFrame = &skirmishAiCallback_Unit_getLastUserOrderFrame;
+	callback->Unit_getWeapons = &skirmishAiCallback_Unit_getWeapons;
 	callback->Team_hasAIController = &skirmishAiCallback_Team_hasAIController;
 	callback->getEnemyTeams = &skirmishAiCallback_getEnemyTeams;
 	callback->getAllyTeams = &skirmishAiCallback_getAllyTeams;
@@ -5602,6 +5725,18 @@ static void skirmishAiCallback_init(SSkirmishAICallback* callback) {
 	callback->WeaponDef_getDynDamageRange = &skirmishAiCallback_WeaponDef_getDynDamageRange;
 	callback->WeaponDef_isDynDamageInverted = &skirmishAiCallback_WeaponDef_isDynDamageInverted;
 	callback->WeaponDef_getCustomParams = &skirmishAiCallback_WeaponDef_getCustomParams;
+	callback->Unit_Weapon_getWeaponDef = &skirmishAiCallback_Unit_Weapon_getWeaponDef;
+	callback->Unit_Weapon_getReloadFrame = &skirmishAiCallback_Unit_Weapon_getReloadFrame;
+	callback->Unit_Weapon_getReloadTime = &skirmishAiCallback_Unit_Weapon_getReloadTime;
+	callback->Unit_Weapon_getAccuracy = &skirmishAiCallback_Unit_Weapon_getAccuracy;
+	callback->Unit_Weapon_getSprayAngle = &skirmishAiCallback_Unit_Weapon_getSprayAngle;
+	callback->Unit_Weapon_getRange = &skirmishAiCallback_Unit_Weapon_getRange;
+	callback->Unit_Weapon_getProjectileSpeed = &skirmishAiCallback_Unit_Weapon_getProjectileSpeed;
+	callback->Unit_Weapon_getBurst = &skirmishAiCallback_Unit_Weapon_getBurst;
+	callback->Unit_Weapon_getBurstRate = &skirmishAiCallback_Unit_Weapon_getBurstRate;
+	callback->Unit_Weapon_getProjectiles = &skirmishAiCallback_Unit_Weapon_getProjectiles;
+	callback->Unit_Weapon_getSalvoError = &skirmishAiCallback_Unit_Weapon_getSalvoError;
+	callback->Unit_Weapon_getTargetMoveError = &skirmishAiCallback_Unit_Weapon_getTargetMoveError;
 	callback->Debug_GraphDrawer_isEnabled = &skirmishAiCallback_Debug_GraphDrawer_isEnabled;
 }
 

--- a/rts/ExternalAI/SSkirmishAICallbackImpl.h
+++ b/rts/ExternalAI/SSkirmishAICallbackImpl.h
@@ -802,6 +802,8 @@ EXPORT(int              ) skirmishAiCallback_Unit_getBuildingFacing(int skirmish
 
 EXPORT(int              ) skirmishAiCallback_Unit_getLastUserOrderFrame(int skirmishAIId, int unitId);
 
+EXPORT(int              ) skirmishAiCallback_Unit_getWeapons(int skirmishAIId, int unitId);
+
 // END OBJECT Unit
 
 
@@ -1342,6 +1344,34 @@ EXPORT(bool             ) skirmishAiCallback_WeaponDef_isDynDamageInverted(int s
 EXPORT(int              ) skirmishAiCallback_WeaponDef_getCustomParams(int skirmishAIId, int weaponDefId, const char** keys, const char** values);
 
 // END OBJECT WeaponDef
+
+
+// BEGINN OBJECT Weapon
+EXPORT(int              ) skirmishAiCallback_Unit_Weapon_getWeaponDef(int skirmishAIId, int unitId, int weaponId);
+
+EXPORT(int              ) skirmishAiCallback_Unit_Weapon_getReloadFrame(int skirmishAIId, int unitId, int weaponId);
+
+EXPORT(float            ) skirmishAiCallback_Unit_Weapon_getReloadTime(int skirmishAIId, int unitId, int weaponId);
+
+EXPORT(float            ) skirmishAiCallback_Unit_Weapon_getAccuracy(int skirmishAIId, int unitId, int weaponId);
+
+EXPORT(float            ) skirmishAiCallback_Unit_Weapon_getSprayAngle(int skirmishAIId, int unitId, int weaponId);
+
+EXPORT(float            ) skirmishAiCallback_Unit_Weapon_getRange(int skirmishAIId, int unitId, int weaponId);
+
+EXPORT(float            ) skirmishAiCallback_Unit_Weapon_getProjectileSpeed(int skirmishAIId, int unitId, int weaponId);
+
+EXPORT(int              ) skirmishAiCallback_Unit_Weapon_getBurst(int skirmishAIId, int unitId, int weaponId);
+
+EXPORT(int              ) skirmishAiCallback_Unit_Weapon_getBurstRate(int skirmishAIId, int unitId, int weaponId);
+
+EXPORT(int              ) skirmishAiCallback_Unit_Weapon_getProjectiles(int skirmishAIId, int unitId, int weaponId);
+
+EXPORT(void             ) skirmishAiCallback_Unit_Weapon_getSalvoError(int skirmishAIId, int unitId, int weaponId, float* return_posF3_out);
+
+EXPORT(float            ) skirmishAiCallback_Unit_Weapon_getTargetMoveError(int skirmishAIId, int unitId, int weaponId);
+
+// END OBJECT Weapon
 
 EXPORT(bool             ) skirmishAiCallback_Debug_GraphDrawer_isEnabled(int skirmishAIId);
 

--- a/rts/ExternalAI/SSkirmishAICallbackImpl.h
+++ b/rts/ExternalAI/SSkirmishAICallbackImpl.h
@@ -804,6 +804,8 @@ EXPORT(int              ) skirmishAiCallback_Unit_getLastUserOrderFrame(int skir
 
 EXPORT(int              ) skirmishAiCallback_Unit_getWeapons(int skirmishAIId, int unitId);
 
+EXPORT(int              ) skirmishAiCallback_Unit_getWeapon(int skirmishAIId, int unitId, int weaponMountId);
+
 // END OBJECT Unit
 
 
@@ -1347,7 +1349,7 @@ EXPORT(int              ) skirmishAiCallback_WeaponDef_getCustomParams(int skirm
 
 
 // BEGINN OBJECT Weapon
-EXPORT(int              ) skirmishAiCallback_Unit_Weapon_getWeaponDef(int skirmishAIId, int unitId, int weaponId);
+EXPORT(int              ) skirmishAiCallback_Unit_Weapon_getDef(int skirmishAIId, int unitId, int weaponId);
 
 EXPORT(int              ) skirmishAiCallback_Unit_Weapon_getReloadFrame(int skirmishAIId, int unitId, int weaponId);
 

--- a/rts/ExternalAI/SSkirmishAICallbackImpl.h
+++ b/rts/ExternalAI/SSkirmishAICallbackImpl.h
@@ -1351,25 +1351,9 @@ EXPORT(int              ) skirmishAiCallback_Unit_Weapon_getWeaponDef(int skirmi
 
 EXPORT(int              ) skirmishAiCallback_Unit_Weapon_getReloadFrame(int skirmishAIId, int unitId, int weaponId);
 
-EXPORT(float            ) skirmishAiCallback_Unit_Weapon_getReloadTime(int skirmishAIId, int unitId, int weaponId);
-
-EXPORT(float            ) skirmishAiCallback_Unit_Weapon_getAccuracy(int skirmishAIId, int unitId, int weaponId);
-
-EXPORT(float            ) skirmishAiCallback_Unit_Weapon_getSprayAngle(int skirmishAIId, int unitId, int weaponId);
+EXPORT(int              ) skirmishAiCallback_Unit_Weapon_getReloadTime(int skirmishAIId, int unitId, int weaponId);
 
 EXPORT(float            ) skirmishAiCallback_Unit_Weapon_getRange(int skirmishAIId, int unitId, int weaponId);
-
-EXPORT(float            ) skirmishAiCallback_Unit_Weapon_getProjectileSpeed(int skirmishAIId, int unitId, int weaponId);
-
-EXPORT(int              ) skirmishAiCallback_Unit_Weapon_getBurst(int skirmishAIId, int unitId, int weaponId);
-
-EXPORT(int              ) skirmishAiCallback_Unit_Weapon_getBurstRate(int skirmishAIId, int unitId, int weaponId);
-
-EXPORT(int              ) skirmishAiCallback_Unit_Weapon_getProjectiles(int skirmishAIId, int unitId, int weaponId);
-
-EXPORT(void             ) skirmishAiCallback_Unit_Weapon_getSalvoError(int skirmishAIId, int unitId, int weaponId, float* return_posF3_out);
-
-EXPORT(float            ) skirmishAiCallback_Unit_Weapon_getTargetMoveError(int skirmishAIId, int unitId, int weaponId);
 
 // END OBJECT Weapon
 


### PR DESCRIPTION
This is basically a stub from [lua](https://github.com/spring/spring/blob/d7ebbb065cf8dcb6218ac2614a9830634623a8d7/rts/Lua/LuaSyncedRead.cpp#L3233), except that ally check done only once in skirmishAiCallback_Unit_getWeapon(s) while creating Weapon objects.

[Related discussion.](https://springrts.com/phpbb/viewtopic.php?f=15&t=33559)

Weapon usage example:
```C
Unit* u = ...;
auto wps = std::move(u->GetWeapons());
for (Weapon* wp : wps) {
  if (wp->GetReloadFrame() <= currentFrame) printf("Ready to fire\n");
  delete wp;
}
...
WeaponMount* wpMnt = ...;
Weapon* wp = u->GetWeapon(wpMnt);
if (wp->GetReloadFrame() <= currentFrame) printf("Ready to fire\n");
delete wp;
```