### PR TITLE
Fix Lua.callRules, Lua.callUI for JavaOO

### DIFF
--- a/AI/Interfaces/Java/bin/jni_wrappCallback.awk
+++ b/AI/Interfaces/Java/bin/jni_wrappCallback.awk
@@ -215,7 +215,7 @@ function printNativeJNI() {
 					cPaNa = c_paramNames[p];
 					c_paramNames[p] = cPaNa "_native";
 					sub(" " jni_paramNames[p], " " c_paramNames[p], paramListNoTypes);
-					print("\t" "char " c_paramNames[p] "[10240];") >> outFile_nc;
+					print("\t" "char " c_paramNames[p] "[MAX_RESPONSE_SIZE];") >> outFile_nc;
 					retParamConversion = "\t" "jclass clazz = (*__env)->GetObjectClass(__env, " cPaNa ");" "\n";
 					retParamConversion = retParamConversion "\t" "jmethodID mid = (*__env)->GetMethodID(__env, clazz, \"append\", \"(Ljava/lang/String;)Ljava/lang/StringBuffer;\");" "\n"
 					retParamConversion = retParamConversion "\t" "jstring " cPaNa "_jStr = (*__env)->NewStringUTF(__env, " c_paramNames[p] ");" "\n";

--- a/AI/Wrappers/CUtils/bin/common.awk
+++ b/AI/Wrappers/CUtils/bin/common.awk
@@ -300,7 +300,7 @@ function convertJNIToSignatureType(jniType__common) {
 	signatureType__common = jniType__common;
 
 	isArray = sub(/Array/, "", signatureType__common);
-	
+
 	sub(/void/, "V", signatureType__common);
 
 	sub(/jboolean/, "Z", signatureType__common);
@@ -323,7 +323,7 @@ function convertJNIToSignatureType(jniType__common) {
 
 # Awaits this format:	int / float / bool[] / char*
 # Returns this format:	jint / jfloat / jbooleanArray / jstring
-function convertCToJNIType(cType__common) {
+function convertCToJNIType(cType__common, cName) {
 
 	jniType__common = cType__common;
 
@@ -335,7 +335,11 @@ function convertCToJNIType(cType__common) {
 	jniType__common = trim(jniType__common);
 
 	isComplex__common = 0;
-	isComplex__common += sub(/^char\*/,  "jstring",   jniType__common);
+	if (match(cName, /_outData$/)) {
+		isComplex__common += sub(/^char\*/, "jobject",  jniType__common);
+	} else {
+		isComplex__common += sub(/^char\*/, "jstring",  jniType__common);
+	}
 
 	isPrimitive__common = 0;
 	isPrimitive__common += sub(/bool/,          "jboolean", jniType__common);
@@ -367,7 +371,7 @@ function convertJNIToJavaType(jniType__common) {
 	javaType__common = jniType__common;
 
 	sub(/Array/, "[]", javaType__common);
-	
+
 	sub(/void/, "void", javaType__common);
 
 	sub(/jboolean/, "boolean", javaType__common);
@@ -379,8 +383,9 @@ function convertJNIToJavaType(jniType__common) {
 	sub(/jlong/,    "long",    javaType__common);
 	sub(/jshort/,   "short",   javaType__common);
 
-	sub(/jstring/, "String", javaType__common);
-	sub(/jobject/, "String", javaType__common);
+	sub(/jstring/,    "String",       javaType__common);
+	sub(/jobject\[]/, "String[]",     javaType__common);
+	sub(/jobject/,    "StringBuffer", javaType__common);
 
 	return javaType__common;
 }

--- a/AI/Wrappers/CUtils/bin/common.awk
+++ b/AI/Wrappers/CUtils/bin/common.awk
@@ -335,7 +335,7 @@ function convertCToJNIType(cType__common, cName) {
 	jniType__common = trim(jniType__common);
 
 	isComplex__common = 0;
-	if (match(cName, /_outData$/)) {
+	if (match(cName, /^ret_/)) {
 		isComplex__common += sub(/^char\*/, "jobject",  jniType__common);
 	} else {
 		isComplex__common += sub(/^char\*/, "jstring",  jniType__common);

--- a/AI/Wrappers/Cpp/bin/wrappCallback.awk
+++ b/AI/Wrappers/Cpp/bin/wrappCallback.awk
@@ -935,7 +935,6 @@ function printMember(fullName_m, memName_m, additionalIndices_m) {
 	hasRetParam = 0;
 	for (prm = 1; prm <= paramTypeNames_size; prm++) {
 		paNa = extractParamName(paramTypeNames[prm]);
-		paTy = extractParamType(paramTypeNames[prm]);
 		if (isRetParamName(paNa)) {
 			if (retType == "void") {
 				paTy = extractParamType(paramTypeNames[prm]);

--- a/AI/Wrappers/Cpp/bin/wrappCallback.awk
+++ b/AI/Wrappers/Cpp/bin/wrappCallback.awk
@@ -958,12 +958,12 @@ function printMember(fullName_m, memName_m, additionalIndices_m) {
 					conversionCode_post = conversionCode_post "\t\t" retParamType " " retVar_out_m "((unsigned char) " paNa "[0], (unsigned char) " paNa "[1], (unsigned char) " paNa "[2]);" "\n";
 					sub("(, )?short\\* " paNa, "", params);
 					retType = retParamType;
-				} else if (match(paTy, /const char\*/)) {
+				} else if (match(paTy, /char\*/)) {
 					retParamType = "std::string";
 					retVar_out_m = "internal_ret";
-					conversionCode_pre  = conversionCode_pre  "\t\t" "char " paNa "[10240];" "\n";
+					conversionCode_pre  = conversionCode_pre  "\t\t" "char " paNa "[MAX_RESPONSE_SIZE];" "\n";
 					conversionCode_post = conversionCode_post "\t\t" retParamType " " retVar_out_m "(" paNa ");" "\n";
-					sub("(, )?const char\\* " paNa, "", params);
+					sub("(, )?char\\* " paNa, "", params);
 					retType = retParamType;
 				} else {
 					print("FAILED converting return param: " paramTypeNames[prm] " / " fullName_m);

--- a/AI/Wrappers/JavaOO/CMakeLists.txt
+++ b/AI/Wrappers/JavaOO/CMakeLists.txt
@@ -127,7 +127,7 @@ if    (BUILD_${myName}_AIWRAPPER)
 		"Info"
 		"Line"
 		"Log"
-#		"Lua"
+		"Lua"
 		"Map"
 		"Mod"
 		"MoveData"

--- a/AI/Wrappers/JavaOO/bin/wrappCallback.awk
+++ b/AI/Wrappers/JavaOO/bin/wrappCallback.awk
@@ -746,6 +746,13 @@ function printMember(fullName_m, memName_m, additionalIndices_m) {
 					declaredVarsCode = "\t\t" retParamType " " retVar_out_m ";" "\n" declaredVarsCode;
 					sub("(, )?short\\[\\] " paNa, "", params);
 					retType = retParamType;
+				} else if (match(paTy, /StringBuffer/)) {
+					retParamType = "String";
+					retVar_out_m = "_ret";
+					conversionCode_pre  = conversionCode_pre  "\t\t" "StringBuffer " paNa " = new StringBuffer();" "\n";
+					conversionCode_post = conversionCode_post "\t\t" retParamType " " retVar_out_m " = " paNa ".toString();" "\n";
+					sub("(, )?StringBuffer " paNa, "", params);
+					retType = retParamType;
 				} else {
 					print("FAILED converting return param: " paramTypeNames[prm] " / " fullName_m);
 					exit(1);
@@ -1147,7 +1154,7 @@ function doWrappOO(funcFullName_dw, params_dw, metaComment_dw) {
 
 	doWrapp_dw = 1;
 
-	doWrapp_dw = doWrapp_dw && !match(funcFullName_dw, /Lua_callRules/) && !match(funcFullName_dw, /Lua_callUI/);
+	#doWrapp_dw = doWrapp_dw && !match(funcFullName_dw, /Lua_callRules/) && !match(funcFullName_dw, /Lua_callUI/);
 
 	return doWrapp_dw;
 }

--- a/AI/Wrappers/LegacyCpp/AIAICallback.cpp
+++ b/AI/Wrappers/LegacyCpp/AIAICallback.cpp
@@ -2082,20 +2082,12 @@ bool springLegacyAI::CAIAICallback::ReadFile(const char* filename, void* buffer,
 }
 
 
-#define AIAICALLBACK_CALL_LUA(HandleName, HANDLENAME)                                                                     \
-	const char* springLegacyAI::CAIAICallback::CallLua ## HandleName(const char* inData, int inSize, int* outSize) {      \
-		SCallLua ## HandleName ## Command cmd = {inData, inSize};                                                         \
-		sAICallback->Engine_handleCommand(skirmishAIId, COMMAND_TO_ID_ENGINE, -1, COMMAND_CALL_LUA_ ## HANDLENAME, &cmd); \
-                                                                                                                          \
-		if (outSize != NULL) {                                                                                            \
-			if (cmd.ret_outData != NULL) {                                                                                \
-				*outSize = strlen(cmd.ret_outData);                                                                       \
-			} else {                                                                                                      \
-				*outSize = -1;                                                                                            \
-			}                                                                                                             \
-		}                                                                                                                 \
-                                                                                                                          \
-		return cmd.ret_outData;                                                                                           \
+#define AIAICALLBACK_CALL_LUA(HandleName, HANDLENAME)  \
+	std::string springLegacyAI::CAIAICallback::CallLua ## HandleName(const char* inData, int inSize) {  \
+		char outData[MAX_RESPONSE_SIZE];  \
+		SCallLua ## HandleName ## Command cmd = {inData, inSize, outData};  \
+		sAICallback->Engine_handleCommand(skirmishAIId, COMMAND_TO_ID_ENGINE, -1, COMMAND_CALL_LUA_ ## HANDLENAME, &cmd);  \
+		return std::string(outData);  \
 	}
 
 AIAICALLBACK_CALL_LUA(Rules, RULES)

--- a/AI/Wrappers/LegacyCpp/AIAICallback.h
+++ b/AI/Wrappers/LegacyCpp/AIAICallback.h
@@ -237,8 +237,8 @@ public:
 	void GetCategoryName(int categoryFlag, char* name, int name_sizeMax);
 
 
-	const char* CallLuaRules(const char* inData, int inSize, int* outSize);
-	const char* CallLuaUI(const char* inData, int inSize, int* outSize);
+	std::string CallLuaRules(const char* inData, int inSize);
+	std::string CallLuaUI(const char* inData, int inSize);
 
 	std::map<std::string, std::string> GetMyInfo();
 	std::map<std::string, std::string> GetMyOptionValues();

--- a/AI/Wrappers/LegacyCpp/IAICallback.h
+++ b/AI/Wrappers/LegacyCpp/IAICallback.h
@@ -517,11 +517,9 @@ public:
 	/**
 	 * 1. 'inData' can be setup to NULL to skip passing in a string
 	 * 2. if inSize is less than 0, the data size is calculated using strlen()
-	 * 3. the return data is subject to lua garbage collection,
-	 *    copy it if you wish to continue using it
 	 */
-	virtual const char* CallLuaRules(const char* inData, int inSize = -1, int* outSize = NULL) = 0;
-	virtual const char* CallLuaUI(const char* inData, int inSize = -1, int* outSize = NULL) = 0;
+	virtual std::string CallLuaRules(const char* inData, int inSize = -1) = 0;
+	virtual std::string CallLuaUI(const char* inData, int inSize = -1) = 0;
 
 	virtual std::map<std::string, std::string> GetMyInfo() = 0;
 	virtual std::map<std::string, std::string> GetMyOptionValues() = 0;

--- a/rts/ExternalAI/Interface/AISCommands.h
+++ b/rts/ExternalAI/Interface/AISCommands.h
@@ -408,8 +408,8 @@ struct SCallLuaRulesCommand {
 	const char* inData;
 	/// If this is less than 0, the data size is calculated using strlen()
 	int inSize;
-	/// this is subject to Lua garbage collection, copy it if you wish to continue using it
-	const char* ret_outData;
+	/// Buffer for response, must be const size of MAX_RESPONSE_SIZE bytes
+	char* ret_outData;
 }; //$ COMMAND_CALL_LUA_RULES Lua_callRules
 
 struct SCallLuaUICommand {
@@ -417,8 +417,8 @@ struct SCallLuaUICommand {
 	const char* inData;
 	/// If this is less than 0, the data size is calculated using strlen()
 	int inSize;
-	/// this is subject to Lua garbage collection, copy it if you wish to continue using it
-	const char* ret_outData;
+	/// Buffer for response, must be const size of MAX_RESPONSE_SIZE bytes
+	char* ret_outData;
 }; //$ COMMAND_CALL_LUA_UI Lua_callUI
 
 struct SSendStartPosCommand {

--- a/rts/ExternalAI/Interface/aidefines.h
+++ b/rts/ExternalAI/Interface/aidefines.h
@@ -79,4 +79,7 @@
 
 #define SKIRMISH_AI_DATA_DIR "AI/Skirmish"
 
+// Size of buffer for response from lua UI/Rules, including '\0'
+#define MAX_RESPONSE_SIZE 10240
+
 #endif // AI_DEFINES_H

--- a/rts/ExternalAI/SSkirmishAICallbackImpl.cpp
+++ b/rts/ExternalAI/SSkirmishAICallbackImpl.cpp
@@ -512,19 +512,20 @@ EXPORT(int) skirmishAiCallback_Engine_handleCommand(int skirmishAIId, int toId, 
 			break;
 		}
 
-
-		// TODO: FIXME: should strcpy() this
-		// const char* outData = clb->CallLua ## HandleName ## (cmd->inData, cmd->inSize);
-		//
-		// if (outData != NULL)
-		//     strcpy((cmd->ret_outData = new char[strlen(outData) + 1]), outData);
-		// else
-		//     cmd->ret_outData = NULL;
-		//
-		#define SSAICALLBACK_CALL_LUA(HandleName, HANDLENAME) \
-			case COMMAND_CALL_LUA_ ## HANDLENAME: {       \
+		// @see AI/Wrappers/Cpp/bin/wrappCallback.awk, printMember
+		#define SSAICALLBACK_CALL_LUA(HandleName, HANDLENAME)  \
+			case COMMAND_CALL_LUA_ ## HANDLENAME: {  \
 				SCallLua ## HandleName ## Command* cmd = static_cast<SCallLua ## HandleName ## Command*>(commandData);  \
-				cmd->ret_outData = clb->CallLua ## HandleName(cmd->inData, cmd->inSize); \
+				const char* outData = clb->CallLua ## HandleName(cmd->inData, cmd->inSize);  \
+				if (cmd->ret_outData != NULL) {  \
+					if (outData != NULL) {  \
+						size_t len = min(strlen(outData), MAX_RESPONSE_SIZE - 1);  \
+						strncpy(cmd->ret_outData, outData, len);  \
+						cmd->ret_outData[len] = '\0';  \
+					} else {  \
+						cmd->ret_outData[0] = '\0';  \
+					}  \
+				}  \
 			} break;
 
 		SSAICALLBACK_CALL_LUA(Rules, RULES)


### PR DESCRIPTION
[Lua<->AI communication](https://springrts.com/phpbb/viewtopic.php?f=15&t=26298) now works in 3/4-duplex (no ret_outData in SLuaMessageEvent).

Purpose of [ret_outData](https://github.com/spring/spring/blob/d1c9887f8e8c8931f5a71d73a82d05ac5c48e222/rts/ExternalAI/Interface/AISCommands.h#L412) from SCallLua(Rules|UI)Command was changed so now it points to a buffer where response should be copied, i.e. caller is responsible for providing proper buffer (or NULL).

I see 1 (dis)?advantage: buffer for ret_outData must have const size MAX_RESPONSE_SIZE=10240 chars (defined in aidefines.h). An alternative would be an additional "int outSizeMax" param in SCallLua(Rules|UI)Command. But that will require more hassle with heap memory opposed to stack in awk scripts, and such generated interface will annoy with additional param outSizeMax.

Tested Lua::CallUI with ZK + LegacyCpp, Cpp, JavaOO AIs.