### PR TITLE
Fixed LightningCannon trouble with hiting targets.

### DIFF
--- a/rts/Sim/Weapons/LightningCannon.cpp
+++ b/rts/Sim/Weapons/LightningCannon.cpp
@@ -31,7 +31,7 @@ CLightningCannon::CLightningCannon(CUnit* owner, const WeaponDef* def)
 void CLightningCannon::FireImpl(const bool scriptCall)
 {
 	float3 curPos = weaponMuzzlePos;
-	float3 curDir = wantedDir;
+	float3 curDir = currentTargetPos - weaponMuzzlePos;
 	float3 newDir = curDir;
 
 	curDir +=


### PR DESCRIPTION
This fixes issues that LightningCannons have with hitting their target.The bug most obviously affects shieldfelon and armzeus from ZK.

The fix is similar to the fix for Rifle: https://github.com/spring/spring/commit/71b7fc3b7afb8132fdaf8da7b3b952110750562f