### PR TITLE
add cmake option DEBUG_LUANAN to enable lua check for nans in a release build

### DIFF
--- a/doc/changelog.txt
+++ b/doc/changelog.txt
@@ -174,7 +174,7 @@ CMake:
  ! remove DEBUG2 & DEBUG3, replaced with just DEBUG
  - enable "Identical Code Folding" with ld.gold
  - disable unused ASSIMP formats at compiletime
-
+ - add cmake option DEBUG_LUANAN to enable lua check for nans in a release build
 
 
 -- 98.0 ---------------------------------------------------------

--- a/rts/lib/lua/CMakeLists.txt
+++ b/rts/lib/lua/CMakeLists.txt
@@ -7,6 +7,11 @@ INCLUDE_DIRECTORIES(BEFORE ../streflop include)
 FIND_PACKAGE_STATIC(GLEW 1.5.1 REQUIRED) #FIXME: LuaUser.cpp requires glew...
 INCLUDE_DIRECTORIES(${GLEW_INCLUDE_DIR})
 
+option(DEBUG_LUANAN "check for nans in lua" FALSE)
+if(DEBUG_LUANAN)
+	add_definitions(-DDEBUG_LUANAN)
+endif()
+
 SET(luaSources
 		"src/lapi.cpp"
 		"src/lauxlib.cpp"

--- a/rts/lib/lua/include/LuaInclude.h
+++ b/rts/lib/lua/include/LuaInclude.h
@@ -80,7 +80,7 @@ static inline int lua_toint(lua_State* L, int idx)
 static inline float lua_tofloat(lua_State* L, int idx)
 {
 	const float n = lua_tonumber(L, idx);
-#ifdef DEBUG
+#if defined(DEBUG) || defined(DEBUG_LUANAN)
 	// Note:
 	// luaL_argerror must be called from inside of lua, else it calls exit()
 	// so it can't be used in LuaParser::Get...() and similar


### PR DESCRIPTION
thoughts about this?

i'm unsure if this change is good or bad:

pro:
- allows to test for nans in lua code with release builds (debug is horrible slow)
- only rts/lib/lua has to be recompiled when enabled

con:
- when a nan is found it insta-desyncs which maybe leads to more confusion
- compile setting (runtime setting would be nicer, but slow)
- new compile setting = more complexity

(+things i can't think about atm)

maybe the better solution is to make the used lua a shared lib so functions can be replaced with the LD_PRELOAD trick?