### PR TITLE
Add support for SSMF Detail Normal Textures

### DIFF
--- a/cont/base/maphelper/maphelper/mapdefaults.lua
+++ b/cont/base/maphelper/maphelper/mapdefaults.lua
@@ -103,6 +103,11 @@ local mapDefaults = {
     detailNormalTex   = '',
     lightEmissionTex  = '',
     parallaxHeightTex = '',
+    splatDetailNormalTex1 = '',
+    splatDetailNormalTex2 = '',
+    splatDetailNormalTex3 = '',
+    splatDetailNormalTex4 = '',
+    splatDetailNormalDiffuseAlpha= false,
   },
 
   defaultTerrainType = {

--- a/cont/base/maphelper/maphelper/parse_tdf_map.lua
+++ b/cont/base/maphelper/maphelper/parse_tdf_map.lua
@@ -207,6 +207,11 @@ return function(sourceText)
      detailNormalTex   = map.detailnormaltex,
      lightEmissionTex  = map.lightemissiontex,
      parallaxHeightTex = map.parallaxheighttex,
+     splatDetailNormalTex1 = map.splatdetailnormaltex1,
+     splatDetailNormalTex2 = map.splatdetailnormaltex2,
+     splatDetailNormalTex3 = map.splatdetailnormaltex3,
+     splatDetailNormalTex4 = map.splatdetailnormaltex4,
+     splatDetailNormalDiffuseAlpha = map.splatdetailnormaldiffusealpha,
   }
 
   ConvertTerrainTypes(map)

--- a/cont/base/springcontent/shaders/GLSL/SMFFragProg.glsl
+++ b/cont/base/springcontent/shaders/GLSL/SMFFragProg.glsl
@@ -320,20 +320,25 @@ void main() {
 		normal = normalize(mix(normal, stnMatrix * dtNormal, dtSample.a));
 	}
 	#endif
+	vec4 detailCol;
 	#ifndef SMF_DETAIL_NORMAL_TEXTURE_SPLATTING
-		vec4 detailCol = GetDetailTextureColor(specTexCoords);
+	{
+		detailCol = GetDetailTextureColor(specTexCoords);
+	}
 	#else 
+	{
 		float splatStrength = 0.0;
 		//the splatStrength param is needed to accurately mix normals, it is the sum of the splat distribution texture
 		vec4 detailNormal = GetDetailTextureNormal(specTexCoords, splatStrength); //second param is OUT
 		//convert the splat detail normal to world space, mix:
 		normal = mix(normal, normalize(stnMatrix * detailNormal.xyz), min(1.0, splatStrength));  
 		#ifdef SMF_DETAIL_NORMAL_DIFFUSE_ALPHA
-			vec4 detailCol = vec4(detailNormal.a);
+			detailCol = vec4(detailNormal.a);
 		#else
 			// The alpha channel of standard normal maps is not 127 by default, so we must clear them
-			vec4 detailCol = vec4(0.0);
+			detailCol = vec4(0.0);
 		#endif
+	}
 	#endif
 #ifndef DEFERRED_MODE
 	float cosAngleDiffuse = clamp(dot(lightDir.xyz, normal), 0.0, 1.0);

--- a/cont/base/springcontent/shaders/GLSL/SMFFragProg.glsl
+++ b/cont/base/springcontent/shaders/GLSL/SMFFragProg.glsl
@@ -1,4 +1,4 @@
-#version 120
+#version 130
 
 #ifdef NOSPRING
 	#define SMF_INTENSITY_MULT (210.0 / 255.0)
@@ -67,13 +67,22 @@ varying vec2 diffuseTexCoords;
 	uniform vec3 waterAbsorbColor;
 #endif
 
-#ifdef SMF_DETAIL_TEXTURE_SPLATTING
+#if defined(SMF_DETAIL_TEXTURE_SPLATTING) && !defined(SMF_DETAIL_NORMAL_TEXTURE_SPLATTING)
 	uniform sampler2D splatDetailTex;
 	uniform sampler2D splatDistrTex;
 	uniform vec4 splatTexMults;  // per-channel splat intensity multipliers
 	uniform vec4 splatTexScales; // defaults to SMF_DETAILTEX_RES per channel
 #endif
 
+#ifdef SMF_DETAIL_NORMAL_TEXTURE_SPLATTING
+	uniform sampler2D splatDetailNormalTex1;
+	uniform sampler2D splatDetailNormalTex2;
+	uniform sampler2D splatDetailNormalTex3;
+	uniform sampler2D splatDetailNormalTex4;
+	uniform sampler2D splatDistrTex;
+	uniform vec4 splatTexMults;  // per-channel splat intensity multipliers
+	uniform vec4 splatTexScales; // defaults to SMF_DETAILTEX_RES per channel
+#endif
 #ifdef SMF_SKY_REFLECTIONS
 	uniform samplerCube skyReflectTex;
 	uniform sampler2D skyReflectModTex;
@@ -126,27 +135,41 @@ vec3 GetFragmentNormal(vec2 uv) {
 #endif
 	return normal;
 }
-
+#ifndef SMF_DETAIL_NORMAL_TEXTURE_SPLATTING
 vec4 GetDetailTextureColor(vec2 uv) {
-#ifndef SMF_DETAIL_TEXTURE_SPLATTING
-	vec2 detailTexCoord = vertexWorldPos.xz * vec2(SMF_DETAILTEX_RES);
-	vec4 detailCol = (texture2D(detailTex, detailTexCoord) * 2.0) - 1.0;
-#else
-	vec4 splatTexCoord0 = vertexWorldPos.xzxz * splatTexScales.rrgg;
-	vec4 splatTexCoord1 = vertexWorldPos.xzxz * splatTexScales.bbaa;
-	vec4 splatDetails;
-		splatDetails.r = texture2D(splatDetailTex, splatTexCoord0.st).r;
-		splatDetails.g = texture2D(splatDetailTex, splatTexCoord0.pq).g;
-		splatDetails.b = texture2D(splatDetailTex, splatTexCoord1.st).b;
-		splatDetails.a = texture2D(splatDetailTex, splatTexCoord1.pq).a;
-		splatDetails   = (splatDetails * 2.0) - 1.0;
-
-	vec4 splatCofac = texture2D(splatDistrTex, uv) * splatTexMults;
-	vec4 detailCol = vec4(dot(splatDetails, splatCofac));
-#endif
-
+	#ifndef SMF_DETAIL_TEXTURE_SPLATTING
+		vec2 detailTexCoord = vertexWorldPos.xz * vec2(SMF_DETAILTEX_RES);
+		vec4 detailCol = (texture2D(detailTex, detailTexCoord) * 2.0) - 1.0;
+	#else
+		vec4 splatTexCoord0 = vertexWorldPos.xzxz * splatTexScales.rrgg;
+		vec4 splatTexCoord1 = vertexWorldPos.xzxz * splatTexScales.bbaa;
+		vec4 splatDetails;
+			splatDetails.r = texture2D(splatDetailTex, splatTexCoord0.st).r;
+			splatDetails.g = texture2D(splatDetailTex, splatTexCoord0.pq).g;
+			splatDetails.b = texture2D(splatDetailTex, splatTexCoord1.st).b;
+			splatDetails.a = texture2D(splatDetailTex, splatTexCoord1.pq).a;
+			splatDetails   = (splatDetails * 2.0) - 1.0;
+		vec4 splatCofac = texture2D(splatDistrTex, uv) * splatTexMults;
+		vec4 detailCol = vec4(dot(splatDetails, splatCofac));
+	#endif
 	return detailCol;
 }
+#else //SMF_DETAIL_NORMAL_TEXTURE_SPLATTING is defined
+vec4 GetDetailTextureNormal(vec2 uv, out float splatStrength) {
+	vec4 splatTexCoord0 = vertexWorldPos.xzxz * splatTexScales.rrgg;
+	vec4 splatTexCoord1 = vertexWorldPos.xzxz * splatTexScales.bbaa;
+	vec4 splatCofac = texture2D(splatDistrTex, uv) * splatTexMults;
+	splatStrength = dot(splatCofac, vec4(1.0));
+	vec4 detailNormal = vec4(0.0, 0.01, 0.0, 0.0); //because if all the splatcofacs are zero, 
+		//we will return a 0 vector which cannot be normalized. Better have it pointing up.
+		detailNormal += (texture2D(splatDetailNormalTex1, splatTexCoord0.st) * 2.0 - 1.0) * splatCofac.r;
+		detailNormal += (texture2D(splatDetailNormalTex2, splatTexCoord0.pq) * 2.0 - 1.0) * splatCofac.g;
+		detailNormal += (texture2D(splatDetailNormalTex3, splatTexCoord1.st) * 2.0 - 1.0) * splatCofac.b;
+		detailNormal += (texture2D(splatDetailNormalTex4, splatTexCoord1.pq) * 2.0 - 1.0) * splatCofac.a;
+	// detailNormal.xyz is intentionally not normalized, as it will be rotated by the map's normal vector and then normalized.
+	return detailNormal;
+}
+#endif
 
 vec4 GetShadeInt(float groundLightInt, float groundShadowCoeff, float groundDiffuseAlpha) {
 	vec4 groundShadeInt = vec4(0.0, 0.0, 0.0, 1.0);
@@ -217,7 +240,9 @@ vec3 DynamicLighting(vec3 normal, vec3 diffuseCol, vec3 specularCol, float specu
 		float lightDistance = length(lightVec);
 		float lightScale = float(lightDistance <= lightRadius);
 		float lightCosAngDiff = clamp(dot(normal, lightVec / lightDistance), 0.0, 1.0);
-		float lightCosAngSpec = clamp(dot(normal, normalize(halfVec)), 0.0, 1.0);
+		//clamp lightCosAngSpec from 0.001 because this will later be in a power function
+		//results are undefined if x==0 or if x==0 and y==0. 
+		float lightCosAngSpec = clamp(dot(normal, normalize(halfVec)), 0.001, 1.0);
 	#ifdef OGL_SPEC_ATTENUATION
 		float lightAttenuation =
 			(gl_LightSource[BASE_DYNAMIC_MAP_LIGHT + i].constantAttenuation) +
@@ -259,7 +284,7 @@ void main() {
 	vec3 cameraDir = vertexWorldPos.xyz - cameraPos;
 	vec3 normal = GetFragmentNormal(normTexCoords);
 
-	#if defined(SMF_DETAIL_NORMALS) || defined(SMF_PARALLAX_MAPPING)
+	#if defined(SMF_DETAIL_NORMALS) || defined(SMF_PARALLAX_MAPPING) || defined(SMF_DETAIL_NORMAL_TEXTURE_SPLATTING)
 		// detail-normals are (assumed to be) defined within STN space
 		// (for a regular vertex normal equal to <0, 1, 0>, the S- and
 		// T-tangents are aligned with Spring's +x and +z (!) axes)
@@ -295,14 +320,27 @@ void main() {
 		normal = normalize(mix(normal, stnMatrix * dtNormal, dtSample.a));
 	}
 	#endif
-
+	#ifndef SMF_DETAIL_NORMAL_TEXTURE_SPLATTING
+		vec4 detailCol = GetDetailTextureColor(specTexCoords);
+	#else 
+		float splatStrength = 0.0;
+		//the splatStrength param is needed to accurately mix normals, it is the sum of the splat distribution texture
+		vec4 detailNormal = GetDetailTextureNormal(specTexCoords, splatStrength); //second param is OUT
+		//convert the splat detail normal to world space, mix:
+		normal = mix(normal, normalize(stnMatrix * detailNormal.xyz), min(1.0, splatStrength));  
+		#ifdef SMF_DETAIL_NORMAL_DIFFUSE_ALPHA
+			vec4 detailCol = vec4(detailNormal.a);
+		#else
+			// The alpha channel of standard normal maps is not 127 by default, so we must clear them
+			vec4 detailCol = vec4(0.0);
+		#endif
+	#endif
 #ifndef DEFERRED_MODE
 	float cosAngleDiffuse = clamp(dot(lightDir.xyz, normal), 0.0, 1.0);
-	float cosAngleSpecular = clamp(dot(normalize(halfDir), normal), 0.0, 1.0);
+	float cosAngleSpecular = clamp(dot(normalize(halfDir), normal), 0.001, 1.0);
 #endif
 
 	vec4 diffuseCol = texture2D(diffuseTex, diffTexCoords);
-	vec4 detailCol = GetDetailTextureColor(specTexCoords);
 	vec4 specularCol = vec4(0.0, 0.0, 0.0, 1.0);
 	vec4 emissionCol = vec4(0.0, 0.0, 0.0, 0.0);
 

--- a/rts/Map/MapInfo.cpp
+++ b/rts/Map/MapInfo.cpp
@@ -330,6 +330,11 @@ void CMapInfo::ReadSMF()
 	smf.specularTexName    = mapResTable.GetString("specularTex", "");
 	smf.splatDetailTexName = mapResTable.GetString("splatDetailTex", "");
 	smf.splatDistrTexName  = mapResTable.GetString("splatDistrTex", "");
+	smf.splatDetailNormalTex1Name  = mapResTable.GetString("splatDetailNormalTex1", "");
+	smf.splatDetailNormalTex2Name  = mapResTable.GetString("splatDetailNormalTex2", "");
+	smf.splatDetailNormalTex3Name  = mapResTable.GetString("splatDetailNormalTex3", "");
+	smf.splatDetailNormalTex4Name  = mapResTable.GetString("splatDetailNormalTex4", "");
+	smf.splatDetailNormalDiffuseAlpha = mapResTable.GetBool("splatDetailNormalDiffuseAlpha", false);
 
 	smf.grassShadingTexName = mapResTable.GetString("grassShadingTex", "");
 
@@ -355,6 +360,10 @@ void CMapInfo::ReadSMF()
 	if (!smf.lightEmissionTexName.empty() ) { smf.lightEmissionTexName  = "maps/" + smf.lightEmissionTexName; }
 	if (!smf.parallaxHeightTexName.empty()) { smf.parallaxHeightTexName = "maps/" + smf.parallaxHeightTexName; }
 
+	if (!smf.splatDetailNormalTex1Name.empty()) { smf.splatDetailNormalTex1Name = "maps/" + smf.splatDetailNormalTex1Name; }
+	if (!smf.splatDetailNormalTex2Name.empty()) { smf.splatDetailNormalTex2Name = "maps/" + smf.splatDetailNormalTex2Name; }
+	if (!smf.splatDetailNormalTex3Name.empty()) { smf.splatDetailNormalTex3Name = "maps/" + smf.splatDetailNormalTex3Name; }
+	if (!smf.splatDetailNormalTex4Name.empty()) { smf.splatDetailNormalTex4Name = "maps/" + smf.splatDetailNormalTex4Name; }
 	// smf overrides
 	const LuaTable& smfTable = parser->GetRoot().SubTable("smf");
 

--- a/rts/Map/MapInfo.cpp
+++ b/rts/Map/MapInfo.cpp
@@ -65,7 +65,7 @@ CMapInfo::CMapInfo(const std::string& mapInfoFile, const string& mapName)
 	ReadSound();
 
 	//FIXME save all data in an array, so we can destroy the lua context (to save mem)?
-	//delete parser; 
+	//delete parser;
 }
 
 CMapInfo::~CMapInfo()
@@ -330,10 +330,10 @@ void CMapInfo::ReadSMF()
 	smf.specularTexName    = mapResTable.GetString("specularTex", "");
 	smf.splatDetailTexName = mapResTable.GetString("splatDetailTex", "");
 	smf.splatDistrTexName  = mapResTable.GetString("splatDistrTex", "");
-	smf.splatDetailNormalTex1Name  = mapResTable.GetString("splatDetailNormalTex1", "");
-	smf.splatDetailNormalTex2Name  = mapResTable.GetString("splatDetailNormalTex2", "");
-	smf.splatDetailNormalTex3Name  = mapResTable.GetString("splatDetailNormalTex3", "");
-	smf.splatDetailNormalTex4Name  = mapResTable.GetString("splatDetailNormalTex4", "");
+	smf.splatDetailNormalTexNames[0]  = mapResTable.GetString("splatDetailNormalTex1", "");
+	smf.splatDetailNormalTexNames[1]  = mapResTable.GetString("splatDetailNormalTex2", "");
+	smf.splatDetailNormalTexNames[2]  = mapResTable.GetString("splatDetailNormalTex3", "");
+	smf.splatDetailNormalTexNames[3]  = mapResTable.GetString("splatDetailNormalTex4", "");
 	smf.splatDetailNormalDiffuseAlpha = mapResTable.GetBool("splatDetailNormalDiffuseAlpha", false);
 
 	smf.grassShadingTexName = mapResTable.GetString("grassShadingTex", "");
@@ -360,10 +360,9 @@ void CMapInfo::ReadSMF()
 	if (!smf.lightEmissionTexName.empty() ) { smf.lightEmissionTexName  = "maps/" + smf.lightEmissionTexName; }
 	if (!smf.parallaxHeightTexName.empty()) { smf.parallaxHeightTexName = "maps/" + smf.parallaxHeightTexName; }
 
-	if (!smf.splatDetailNormalTex1Name.empty()) { smf.splatDetailNormalTex1Name = "maps/" + smf.splatDetailNormalTex1Name; }
-	if (!smf.splatDetailNormalTex2Name.empty()) { smf.splatDetailNormalTex2Name = "maps/" + smf.splatDetailNormalTex2Name; }
-	if (!smf.splatDetailNormalTex3Name.empty()) { smf.splatDetailNormalTex3Name = "maps/" + smf.splatDetailNormalTex3Name; }
-	if (!smf.splatDetailNormalTex4Name.empty()) { smf.splatDetailNormalTex4Name = "maps/" + smf.splatDetailNormalTex4Name; }
+	for (int i = 0; i < 4; i++){
+		if (!smf.splatDetailNormalTexNames[i].empty()) { smf.splatDetailNormalTexNames[i] = "maps/" + smf.splatDetailNormalTexNames[i]; }
+	}
 	// smf overrides
 	const LuaTable& smfTable = parser->GetRoot().SubTable("smf");
 

--- a/rts/Map/MapInfo.h
+++ b/rts/Map/MapInfo.h
@@ -182,13 +182,11 @@ public:
 		std::string lightEmissionTexName;
 		std::string parallaxHeightTexName;
 
-		std::string splatDetailNormalTex1Name; //Contains the splatted detail normal textures 1-4
-		std::string splatDetailNormalTex2Name;
-		std::string splatDetailNormalTex3Name;
-		std::string splatDetailNormalTex4Name;
-		//Controls wether the alpha channel of each splatted detail normal texture 
+		std::string splatDetailNormalTexNames[4]; //Contains the splatted detail normal textures 1-4
+
+		//Controls whether the alpha channel of each splatted detail normal texture
 		//contains a diffuse channel, which behaves like the old splatted detail textures
-		bool  splatDetailNormalDiffuseAlpha; 
+		bool  splatDetailNormalDiffuseAlpha;
 		// SMF overrides
 		std::string minimapTexName;
 		std::string typemapTexName;

--- a/rts/Map/MapInfo.h
+++ b/rts/Map/MapInfo.h
@@ -182,6 +182,13 @@ public:
 		std::string lightEmissionTexName;
 		std::string parallaxHeightTexName;
 
+		std::string splatDetailNormalTex1Name; //Contains the splatted detail normal textures 1-4
+		std::string splatDetailNormalTex2Name;
+		std::string splatDetailNormalTex3Name;
+		std::string splatDetailNormalTex4Name;
+		//Controls wether the alpha channel of each splatted detail normal texture 
+		//contains a diffuse channel, which behaves like the old splatted detail textures
+		bool  splatDetailNormalDiffuseAlpha; 
 		// SMF overrides
 		std::string minimapTexName;
 		std::string typemapTexName;

--- a/rts/Map/SMF/SMFReadMap.cpp
+++ b/rts/Map/SMF/SMFReadMap.cpp
@@ -41,6 +41,10 @@ CSMFReadMap::CSMFReadMap(std::string mapname)
 	, normalsTex(0)
 	, minimapTex(0)
 	, splatDetailTex(0)
+	, splatDetailNormalTex1(0)
+	, splatDetailNormalTex2(0)
+	, splatDetailNormalTex3(0)
+	, splatDetailNormalTex4(0)
 	, splatDistrTex(0)
 	, skyReflectModTex(0)
 	, detailNormalTex(0)
@@ -53,6 +57,13 @@ CSMFReadMap::CSMFReadMap(std::string mapname)
 
 	haveSpecularTexture = !(mapInfo->smf.specularTexName.empty());
 	haveSplatTexture = (!mapInfo->smf.splatDetailTexName.empty() && !mapInfo->smf.splatDistrTexName.empty());
+	haveSplatNormalTexture = (!mapInfo->smf.splatDistrTexName.empty() && (
+		!mapInfo->smf.splatDetailNormalTex1Name.empty() ||
+		!mapInfo->smf.splatDetailNormalTex2Name.empty() ||
+		!mapInfo->smf.splatDetailNormalTex3Name.empty() ||
+		!mapInfo->smf.splatDetailNormalTex4Name.empty()
+		));
+    haveDetailNormalDiffuseAlpha = mapInfo->smf.splatDetailNormalDiffuseAlpha;
 	minimapOverride = !(mapInfo->smf.minimapTexName.empty());
 
 	ParseHeader();
@@ -91,6 +102,10 @@ CSMFReadMap::~CSMFReadMap()
 	glDeleteTextures(1, &detailNormalTex  );
 	glDeleteTextures(1, &lightEmissionTex );
 	glDeleteTextures(1, &parallaxHeightTex);
+	glDeleteTextures(1, &splatDetailNormalTex1);
+	glDeleteTextures(1, &splatDetailNormalTex2);
+	glDeleteTextures(1, &splatDetailNormalTex3);
+	glDeleteTextures(1, &splatDetailNormalTex4);
 }
 
 
@@ -242,6 +257,66 @@ void CSMFReadMap::CreateSplatDetailTextures()
 
 	splatDetailTex = splatDetailTexBM.CreateTexture(true);
 	splatDistrTex = splatDistrTexBM.CreateTexture(true);
+
+	if (!haveSplatNormalTexture){
+        return;
+	}
+	//Only load the splat detail normals if any of them are defined and present
+
+	CBitmap splatDetailNormalTex1BM;
+
+	if (!splatDetailNormalTex1BM.Load(mapInfo->smf.splatDetailNormalTex1Name)) {
+		splatDetailNormalTex1BM.channels = 4;
+		splatDetailNormalTex1BM.Alloc(1, 1);
+		splatDetailNormalTex1BM.mem[0] = 127; //RGB is packed standard normal map
+		splatDetailNormalTex1BM.mem[1] = 127;
+		splatDetailNormalTex1BM.mem[2] = 255; //With a single upward (+Z) pointing vector
+		splatDetailNormalTex1BM.mem[3] = 127; //Alpha is diffuse as in old-style detail textures
+	}
+
+	splatDetailNormalTex1 = splatDetailNormalTex1BM.CreateTexture(true);
+
+
+	CBitmap splatDetailNormalTex2BM;
+
+	if (!splatDetailNormalTex2BM.Load(mapInfo->smf.splatDetailNormalTex2Name)) {
+		splatDetailNormalTex2BM.channels = 4;
+		splatDetailNormalTex2BM.Alloc(1, 1);
+		splatDetailNormalTex2BM.mem[0] = 127; //RGB is packed standard normal map
+		splatDetailNormalTex2BM.mem[1] = 127;
+		splatDetailNormalTex2BM.mem[2] = 255; //With a single upward (+Z) pointing vector
+		splatDetailNormalTex2BM.mem[3] = 127; //Alpha is diffuse as in old-style detail textures
+	}
+
+	splatDetailNormalTex2 = splatDetailNormalTex2BM.CreateTexture(true);
+
+
+	CBitmap splatDetailNormalTex3BM;
+
+	if (!splatDetailNormalTex3BM.Load(mapInfo->smf.splatDetailNormalTex3Name)) {
+		splatDetailNormalTex3BM.channels = 4;
+		splatDetailNormalTex3BM.Alloc(1, 1);
+		splatDetailNormalTex3BM.mem[0] = 127; //RGB is packed standard normal map
+		splatDetailNormalTex3BM.mem[1] = 127;
+		splatDetailNormalTex3BM.mem[2] = 255; //With a single upward (+Z) pointing vector
+		splatDetailNormalTex3BM.mem[3] = 127; //Alpha is diffuse as in old-style detail textures
+	}
+
+	splatDetailNormalTex3 = splatDetailNormalTex3BM.CreateTexture(true);
+
+	CBitmap splatDetailNormalTex4BM;
+
+	if (!splatDetailNormalTex4BM.Load(mapInfo->smf.splatDetailNormalTex4Name)) {
+		splatDetailNormalTex4BM.channels = 4;
+		splatDetailNormalTex4BM.Alloc(1, 1);
+		splatDetailNormalTex4BM.mem[0] = 127; //RGB is packed standard normal map
+		splatDetailNormalTex4BM.mem[1] = 127;
+		splatDetailNormalTex4BM.mem[2] = 255; //With a single upward (+Z) pointing vector
+		splatDetailNormalTex4BM.mem[3] = 127; //Alpha is diffuse as in old-style detail textures
+	}
+
+	splatDetailNormalTex4 = splatDetailNormalTex4BM.CreateTexture(true);
+
 }
 
 

--- a/rts/Map/SMF/SMFReadMap.cpp
+++ b/rts/Map/SMF/SMFReadMap.cpp
@@ -41,10 +41,6 @@ CSMFReadMap::CSMFReadMap(std::string mapname)
 	, normalsTex(0)
 	, minimapTex(0)
 	, splatDetailTex(0)
-	, splatDetailNormalTex1(0)
-	, splatDetailNormalTex2(0)
-	, splatDetailNormalTex3(0)
-	, splatDetailNormalTex4(0)
 	, splatDistrTex(0)
 	, skyReflectModTex(0)
 	, detailNormalTex(0)
@@ -57,13 +53,16 @@ CSMFReadMap::CSMFReadMap(std::string mapname)
 
 	haveSpecularTexture = !(mapInfo->smf.specularTexName.empty());
 	haveSplatTexture = (!mapInfo->smf.splatDetailTexName.empty() && !mapInfo->smf.splatDistrTexName.empty());
-	haveSplatNormalTexture = (!mapInfo->smf.splatDistrTexName.empty() && (
-		!mapInfo->smf.splatDetailNormalTex1Name.empty() ||
-		!mapInfo->smf.splatDetailNormalTex2Name.empty() ||
-		!mapInfo->smf.splatDetailNormalTex3Name.empty() ||
-		!mapInfo->smf.splatDetailNormalTex4Name.empty()
-		));
-    haveDetailNormalDiffuseAlpha = mapInfo->smf.splatDetailNormalDiffuseAlpha;
+
+	haveSplatNormalTexture = false;
+	//Detail Normal Splatting requires at least one splatDetailNormalTexture and a distribution texture
+	for (int i = 0; i < 4; i++){
+		splatDetailNormalTextures[i]=0;
+		haveSplatNormalTexture = haveSplatNormalTexture || !mapInfo->smf.splatDetailNormalTexNames[i].empty();
+	}
+	haveSplatNormalTexture = haveSplatNormalTexture && !mapInfo->smf.splatDistrTexName.empty();
+	haveDetailNormalDiffuseAlpha = mapInfo->smf.splatDetailNormalDiffuseAlpha;
+
 	minimapOverride = !(mapInfo->smf.minimapTexName.empty());
 
 	ParseHeader();
@@ -102,10 +101,9 @@ CSMFReadMap::~CSMFReadMap()
 	glDeleteTextures(1, &detailNormalTex  );
 	glDeleteTextures(1, &lightEmissionTex );
 	glDeleteTextures(1, &parallaxHeightTex);
-	glDeleteTextures(1, &splatDetailNormalTex1);
-	glDeleteTextures(1, &splatDetailNormalTex2);
-	glDeleteTextures(1, &splatDetailNormalTex3);
-	glDeleteTextures(1, &splatDetailNormalTex4);
+	for (int i = 0; i < 4; i++){
+		glDeleteTextures(1, &splatDetailNormalTextures[i]);
+	}
 }
 
 
@@ -259,63 +257,20 @@ void CSMFReadMap::CreateSplatDetailTextures()
 	splatDistrTex = splatDistrTexBM.CreateTexture(true);
 
 	if (!haveSplatNormalTexture){
-        return;
+		return;//Only load the splat detail normals if any of them are defined and present
 	}
-	//Only load the splat detail normals if any of them are defined and present
-
-	CBitmap splatDetailNormalTex1BM;
-
-	if (!splatDetailNormalTex1BM.Load(mapInfo->smf.splatDetailNormalTex1Name)) {
-		splatDetailNormalTex1BM.channels = 4;
-		splatDetailNormalTex1BM.Alloc(1, 1);
-		splatDetailNormalTex1BM.mem[0] = 127; //RGB is packed standard normal map
-		splatDetailNormalTex1BM.mem[1] = 127;
-		splatDetailNormalTex1BM.mem[2] = 255; //With a single upward (+Z) pointing vector
-		splatDetailNormalTex1BM.mem[3] = 127; //Alpha is diffuse as in old-style detail textures
+	for (int i = 0; i < 4; i++){
+		CBitmap splatDetailNormalTextureBM;
+		if (!splatDetailNormalTextureBM.Load(mapInfo->smf.splatDetailNormalTexNames[i])) {
+			splatDetailNormalTextureBM.channels = 4;
+			splatDetailNormalTextureBM.Alloc(1, 1);
+			splatDetailNormalTextureBM.mem[0] = 127; //RGB is packed standard normal map
+			splatDetailNormalTextureBM.mem[1] = 127;
+			splatDetailNormalTextureBM.mem[2] = 255; //With a single upward (+Z) pointing vector
+			splatDetailNormalTextureBM.mem[3] = 127; //Alpha is diffuse as in old-style detail textures
+		}
+		splatDetailNormalTextures[i] = splatDetailNormalTextureBM.CreateTexture(true);
 	}
-
-	splatDetailNormalTex1 = splatDetailNormalTex1BM.CreateTexture(true);
-
-
-	CBitmap splatDetailNormalTex2BM;
-
-	if (!splatDetailNormalTex2BM.Load(mapInfo->smf.splatDetailNormalTex2Name)) {
-		splatDetailNormalTex2BM.channels = 4;
-		splatDetailNormalTex2BM.Alloc(1, 1);
-		splatDetailNormalTex2BM.mem[0] = 127; //RGB is packed standard normal map
-		splatDetailNormalTex2BM.mem[1] = 127;
-		splatDetailNormalTex2BM.mem[2] = 255; //With a single upward (+Z) pointing vector
-		splatDetailNormalTex2BM.mem[3] = 127; //Alpha is diffuse as in old-style detail textures
-	}
-
-	splatDetailNormalTex2 = splatDetailNormalTex2BM.CreateTexture(true);
-
-
-	CBitmap splatDetailNormalTex3BM;
-
-	if (!splatDetailNormalTex3BM.Load(mapInfo->smf.splatDetailNormalTex3Name)) {
-		splatDetailNormalTex3BM.channels = 4;
-		splatDetailNormalTex3BM.Alloc(1, 1);
-		splatDetailNormalTex3BM.mem[0] = 127; //RGB is packed standard normal map
-		splatDetailNormalTex3BM.mem[1] = 127;
-		splatDetailNormalTex3BM.mem[2] = 255; //With a single upward (+Z) pointing vector
-		splatDetailNormalTex3BM.mem[3] = 127; //Alpha is diffuse as in old-style detail textures
-	}
-
-	splatDetailNormalTex3 = splatDetailNormalTex3BM.CreateTexture(true);
-
-	CBitmap splatDetailNormalTex4BM;
-
-	if (!splatDetailNormalTex4BM.Load(mapInfo->smf.splatDetailNormalTex4Name)) {
-		splatDetailNormalTex4BM.channels = 4;
-		splatDetailNormalTex4BM.Alloc(1, 1);
-		splatDetailNormalTex4BM.mem[0] = 127; //RGB is packed standard normal map
-		splatDetailNormalTex4BM.mem[1] = 127;
-		splatDetailNormalTex4BM.mem[2] = 255; //With a single upward (+Z) pointing vector
-		splatDetailNormalTex4BM.mem[3] = 127; //Alpha is diffuse as in old-style detail textures
-	}
-
-	splatDetailNormalTex4 = splatDetailNormalTex4BM.CreateTexture(true);
 
 }
 

--- a/rts/Map/SMF/SMFReadMap.h
+++ b/rts/Map/SMF/SMFReadMap.h
@@ -39,6 +39,10 @@ public:
 	unsigned int GetSpecularTexture() const { return specularTex; }
 	unsigned int GetGrassShadingTexture() const { return grassShadingTex; }
 	unsigned int GetSplatDetailTexture() const { return splatDetailTex; }
+	unsigned int GetSplatDetailNormalTexture1() const { return splatDetailNormalTex1; }
+	unsigned int GetSplatDetailNormalTexture2() const { return splatDetailNormalTex2; }
+	unsigned int GetSplatDetailNormalTexture3() const { return splatDetailNormalTex3; }
+	unsigned int GetSplatDetailNormalTexture4() const { return splatDetailNormalTex4; }
 	unsigned int GetSplatDistrTexture() const { return splatDistrTex; }
 	unsigned int GetSkyReflectModTexture() const { return skyReflectModTex; }
 	unsigned int GetDetailNormalTexture() const { return detailNormalTex; }
@@ -67,6 +71,8 @@ public:
 
 	bool HaveSpecularTexture() const { return haveSpecularTexture; }
 	bool HaveSplatTexture() const { return haveSplatTexture; }
+	bool HaveSplatNormalTexture() const { return haveSplatNormalTexture; }
+	bool HaveDetailNormalDiffuseAlpha() const { return haveDetailNormalDiffuseAlpha; }
 
 private:
 	void ParseHeader();
@@ -122,6 +128,10 @@ protected:
 	unsigned int normalsTex;        // holds vertex normals in RGBA32F internal format (GL_RGBA + GL_FLOAT)
 	unsigned int minimapTex;        // supplied by the map
 	unsigned int splatDetailTex;    // contains per-channel separate greyscale detail-textures (overrides detailTex)
+	unsigned int splatDetailNormalTex1;    // contains RGBA texture with RGB channels containing normals and alpha containing greyscale diffuse for splat detail normals (overrides detailTex)
+	unsigned int splatDetailNormalTex2;    // contains RGBA texture with RGB channels containing normals and alpha containing greyscale diffuse for splat detail normals (overrides detailTex)
+	unsigned int splatDetailNormalTex3;    // contains RGBA texture with RGB channels containing normals and alpha containing greyscale diffuse for splat detail normals (overrides detailTex)
+	unsigned int splatDetailNormalTex4;    // contains RGBA texture with RGB channels containing normals and alpha containing greyscale diffuse for splat detail normals (overrides detailTex)
 	unsigned int splatDistrTex;     // specifies the per-channel distribution of splatDetailTex (map-wide, overrides detailTex)
 	unsigned int grassShadingTex;   // specifies grass-blade modulation color (defaults to minimapTex)
 	unsigned int skyReflectModTex;  // modulates sky-reflection RGB intensities (must be the same size as specularTex)
@@ -131,6 +141,9 @@ protected:
 
 	bool haveSpecularTexture;
 	bool haveSplatTexture;
+	bool haveSplatNormalTexture;
+	bool haveDetailNormalDiffuseAlpha;
+
 	bool minimapOverride;
 
 	unsigned char waterHeightColors[1024 * 4];

--- a/rts/Map/SMF/SMFReadMap.h
+++ b/rts/Map/SMF/SMFReadMap.h
@@ -39,10 +39,7 @@ public:
 	unsigned int GetSpecularTexture() const { return specularTex; }
 	unsigned int GetGrassShadingTexture() const { return grassShadingTex; }
 	unsigned int GetSplatDetailTexture() const { return splatDetailTex; }
-	unsigned int GetSplatDetailNormalTexture1() const { return splatDetailNormalTex1; }
-	unsigned int GetSplatDetailNormalTexture2() const { return splatDetailNormalTex2; }
-	unsigned int GetSplatDetailNormalTexture3() const { return splatDetailNormalTex3; }
-	unsigned int GetSplatDetailNormalTexture4() const { return splatDetailNormalTex4; }
+	unsigned int GetSplatDetailNormalTexture(int i) const { return splatDetailNormalTextures[i]; }
 	unsigned int GetSplatDistrTexture() const { return splatDistrTex; }
 	unsigned int GetSkyReflectModTexture() const { return skyReflectModTex; }
 	unsigned int GetDetailNormalTexture() const { return detailNormalTex; }
@@ -128,10 +125,7 @@ protected:
 	unsigned int normalsTex;        // holds vertex normals in RGBA32F internal format (GL_RGBA + GL_FLOAT)
 	unsigned int minimapTex;        // supplied by the map
 	unsigned int splatDetailTex;    // contains per-channel separate greyscale detail-textures (overrides detailTex)
-	unsigned int splatDetailNormalTex1;    // contains RGBA texture with RGB channels containing normals and alpha containing greyscale diffuse for splat detail normals (overrides detailTex)
-	unsigned int splatDetailNormalTex2;    // contains RGBA texture with RGB channels containing normals and alpha containing greyscale diffuse for splat detail normals (overrides detailTex)
-	unsigned int splatDetailNormalTex3;    // contains RGBA texture with RGB channels containing normals and alpha containing greyscale diffuse for splat detail normals (overrides detailTex)
-	unsigned int splatDetailNormalTex4;    // contains RGBA texture with RGB channels containing normals and alpha containing greyscale diffuse for splat detail normals (overrides detailTex)
+	unsigned int splatDetailNormalTextures[4];    // contains RGBA texture with RGB channels containing normals and alpha containing greyscale diffuse for splat detail normals (overrides detailTex)
 	unsigned int splatDistrTex;     // specifies the per-channel distribution of splatDetailTex (map-wide, overrides detailTex)
 	unsigned int grassShadingTex;   // specifies grass-blade modulation color (defaults to minimapTex)
 	unsigned int skyReflectModTex;  // modulates sky-reflection RGB intensities (must be the same size as specularTex)

--- a/rts/Map/SMF/SMFRenderState.cpp
+++ b/rts/Map/SMF/SMFRenderState.cpp
@@ -113,6 +113,8 @@ bool SMFRenderStateGLSL::Init(const CSMFGroundDrawer* smfGroundDrawer) {
 		glslShaders[n]->SetFlag("SMF_VOID_GROUND",              mapInfo->map.voidGround);
 		glslShaders[n]->SetFlag("SMF_SPECULAR_LIGHTING",        smfMap->HaveSpecularTexture());
 		glslShaders[n]->SetFlag("SMF_DETAIL_TEXTURE_SPLATTING", smfMap->HaveSplatTexture());
+		glslShaders[n]->SetFlag("SMF_DETAIL_NORMAL_TEXTURE_SPLATTING",  smfMap->HaveSplatNormalTexture());
+		glslShaders[n]->SetFlag("SMF_DETAIL_NORMAL_DIFFUSE_ALPHA",      smfMap->HaveDetailNormalDiffuseAlpha());
 		glslShaders[n]->SetFlag("SMF_WATER_ABSORPTION",         smfMap->HasVisibleWater());
 		glslShaders[n]->SetFlag("SMF_SKY_REFLECTIONS",          (smfMap->GetSkyReflectModTexture() != 0));
 		glslShaders[n]->SetFlag("SMF_DETAIL_NORMALS",           (smfMap->GetDetailNormalTexture() != 0));
@@ -150,6 +152,10 @@ bool SMFRenderStateGLSL::Init(const CSMFGroundDrawer* smfGroundDrawer) {
 		glslShaders[n]->SetUniform("lightEmissionTex",  12);
 		glslShaders[n]->SetUniform("parallaxHeightTex", 13);
 		glslShaders[n]->SetUniform("infoTex",           14);
+		glslShaders[n]->SetUniform("splatDetailNormalTex1",15);
+		glslShaders[n]->SetUniform("splatDetailNormalTex2",16);
+		glslShaders[n]->SetUniform("splatDetailNormalTex3",17);
+		glslShaders[n]->SetUniform("splatDetailNormalTex4",18);
 
 		glslShaders[n]->SetUniform("mapSizePO2", float(mapDims.pwr2mapx * SQUARE_SIZE), float(mapDims.pwr2mapy * SQUARE_SIZE));
 		glslShaders[n]->SetUniform("mapSize",    float(mapDims.mapx * SQUARE_SIZE),     float(mapDims.mapy * SQUARE_SIZE));
@@ -446,6 +452,10 @@ void SMFRenderStateGLSL::Enable(const CSMFGroundDrawer* smfGroundDrawer, const D
 	glActiveTexture(GL_TEXTURE12); glBindTexture(GL_TEXTURE_2D, smfMap->GetLightEmissionTexture());
 	glActiveTexture(GL_TEXTURE13); glBindTexture(GL_TEXTURE_2D, smfMap->GetParallaxHeightTexture());
 	glActiveTexture(GL_TEXTURE14); glBindTexture(GL_TEXTURE_2D, infoTextureHandler->GetCurrentInfoTexture());
+	glActiveTexture(GL_TEXTURE15); glBindTexture(GL_TEXTURE_2D, smfMap->GetSplatDetailNormalTexture1());
+	glActiveTexture(GL_TEXTURE16); glBindTexture(GL_TEXTURE_2D, smfMap->GetSplatDetailNormalTexture2());
+	glActiveTexture(GL_TEXTURE17); glBindTexture(GL_TEXTURE_2D, smfMap->GetSplatDetailNormalTexture3());
+	glActiveTexture(GL_TEXTURE18); glBindTexture(GL_TEXTURE_2D, smfMap->GetSplatDetailNormalTexture4());
 
 	glActiveTexture(GL_TEXTURE0);
 }

--- a/rts/Map/SMF/SMFRenderState.cpp
+++ b/rts/Map/SMF/SMFRenderState.cpp
@@ -452,11 +452,12 @@ void SMFRenderStateGLSL::Enable(const CSMFGroundDrawer* smfGroundDrawer, const D
 	glActiveTexture(GL_TEXTURE12); glBindTexture(GL_TEXTURE_2D, smfMap->GetLightEmissionTexture());
 	glActiveTexture(GL_TEXTURE13); glBindTexture(GL_TEXTURE_2D, smfMap->GetParallaxHeightTexture());
 	glActiveTexture(GL_TEXTURE14); glBindTexture(GL_TEXTURE_2D, infoTextureHandler->GetCurrentInfoTexture());
-	glActiveTexture(GL_TEXTURE15); glBindTexture(GL_TEXTURE_2D, smfMap->GetSplatDetailNormalTexture1());
-	glActiveTexture(GL_TEXTURE16); glBindTexture(GL_TEXTURE_2D, smfMap->GetSplatDetailNormalTexture2());
-	glActiveTexture(GL_TEXTURE17); glBindTexture(GL_TEXTURE_2D, smfMap->GetSplatDetailNormalTexture3());
-	glActiveTexture(GL_TEXTURE18); glBindTexture(GL_TEXTURE_2D, smfMap->GetSplatDetailNormalTexture4());
-
+	if (smfMap->HaveSplatNormalTexture()){
+		const int detailNormalTextureBindings [4] = {GL_TEXTURE15,GL_TEXTURE16,GL_TEXTURE17,GL_TEXTURE18};
+		for (int i = 0; i < 4; i++){
+			glActiveTexture(detailNormalTextureBindings[i]); glBindTexture(GL_TEXTURE_2D, smfMap->GetSplatDetailNormalTexture(i));
+		}
+	}
 	glActiveTexture(GL_TEXTURE0);
 }
 


### PR DESCRIPTION
Works similarly to the previous SSMF splatting, but instead of sampling a combined texture of 4 different single-channel diffuse detail textures, it samples four separate normal textures.
The textures must contain the normal maps in the RGB channel (standard normal maps), with a diffuse luminance in the alpha channel.
The system uses the same splatDistrTex as regular SSMF.

Usage:
Specify splatDetailNormalTex1 .. splatDetailNormalTex4 in the MAP resources section.
splatDetailTex will be unused if the above are present.
specify splatDetailNormalDiffuseAlpha=1 to enable diffuse textures stored in alpha channels

~10% performance cost of sampling 4 textures once each vs the previous 1 texture 4 times.

Screenshot: http://beherith.eat-peet.net/stuff/detail_normals.png
Example map: http://beherith.eat-peet.net/stuff/DeltaSiegeDry_Reloaded_vBETA3.sd7

Issues discussed with jK in previous pull request have been addressed. (https://github.com/spring/spring/pull/131)