### PR TITLE
Feature defs: add a lockPosition tag to control XZ movement lock

### DIFF
--- a/doc/changelog.txt
+++ b/doc/changelog.txt
@@ -8,6 +8,10 @@ General:
  ! change default screenshot file type to jpg. to create png use /screenshot png
  - pr-downloader dependency is now mandatory (statically linked with spring)
 
+ FeatureDefs:
+ - new tag lockPosition, affects whether the feature is locked to XZ coordinate (like currently trees, rocks etc. are).
+   Integer value: -1 (default) = current behaviour: locked unless resurrectable; 0 = not locked, free to move; everything else = locked, cannot move
+ 
 Lua:
  ! GameID callin now gets the ID string encoded in hex.
  - new Spring.GetUICommands function to obtain a list of all UI commands (e.g. /luaui reload)

--- a/rts/Lua/LuaFeatureDefs.cpp
+++ b/rts/Lua/LuaFeatureDefs.cpp
@@ -497,6 +497,7 @@ static bool InitParamMap()
 	ADD_BOOL("geoThermal",   fd.geoThermal);
 	ADD_BOOL("noSelect",     fd.selectable);
 	ADD_INT("resurrectable", fd.resurrectable);
+	ADD_INT("lockPosition",  fd.lockPosition);
 
 	ADD_INT("smokeTime",    fd.smokeTime);
 

--- a/rts/Sim/Features/FeatureDef.cpp
+++ b/rts/Sim/Features/FeatureDef.cpp
@@ -17,6 +17,7 @@ CR_REG_METADATA(FeatureDef, (
 	CR_MEMBER(floating),
 	CR_MEMBER(geoThermal),
 	CR_MEMBER(deathFeatureDefID),
+	CR_MEMBER(lockPosition),
 	CR_MEMBER(smokeTime)
 ))
 
@@ -25,6 +26,7 @@ FeatureDef::FeatureDef()
 	, reclaimTime(0)
 	, drawType(DRAWTYPE_NONE)
 	, resurrectable(false)
+	, lockPosition(-1)
 	, smokeTime(0)
 	, destructable(false)
 	, autoreclaim(true)

--- a/rts/Sim/Features/FeatureDef.h
+++ b/rts/Sim/Features/FeatureDef.h
@@ -31,6 +31,9 @@ struct FeatureDef: public SolidObjectDef
 	/// -1 := only if it is the 1st wreckage of the unitdef (default), 0 := no it isn't, 1 := yes it is
 	int resurrectable;
 
+	/// whether the feature can move horizontally, 0 = yes, 1 = no, -1 (default) = only if not first-level wreckage
+	int lockPosition;
+
 	int smokeTime;
 
 	bool destructable;

--- a/rts/Sim/Features/FeatureHandler.cpp
+++ b/rts/Sim/Features/FeatureHandler.cpp
@@ -129,6 +129,7 @@ FeatureDef* CFeatureHandler::CreateFeatureDef(const LuaTable& fdTable, const std
 	fd->resurrectable =  fdTable.GetInt("resurrectable",    -1);
 	fd->geoThermal    =  fdTable.GetBool("geoThermal",      false);
 	fd->floating      =  fdTable.GetBool("floating",        false);
+	fd->lockPosition  =  fdTable.GetInt("lockPosition",     -1);
 
 	fd->metal       = fdTable.GetFloat("metal",  0.0f);
 	fd->energy      = fdTable.GetFloat("energy", 0.0f);
@@ -187,6 +188,7 @@ FeatureDef* CFeatureHandler::CreateDefaultTreeFeatureDef(const std::string& name
 	fd->health = 5.0f;
 	fd->xsize = 2;
 	fd->zsize = 2;
+	fd->lockPosition = 1;
 	fd->name = name;
 	fd->description = "Tree";
 	fd->mass = 20;
@@ -210,6 +212,7 @@ FeatureDef* CFeatureHandler::CreateDefaultGeoFeatureDef(const std::string& name)
 	fd->health = 0.0f;
 	fd->xsize = 0;
 	fd->zsize = 0;
+	fd->lockPosition = 1;
 	fd->name = name;
 	fd->mass = CSolidObject::DEFAULT_MASS;
 	// geothermal features have no physical map presence


### PR DESCRIPTION
Controls whether the feature is locked to an XZ position, like currently trees, rocks etc are.
Value is an int: -1 is current behaviour (locked iff not resurrectable), 0 is non-locked, 1 and everything else is locked

Also:
* non-locked features now obey the "floating" tag.
* fixes non-locked features having double vertical velocity (speed was already applied in Feature.cpp:519 but vertical was applied again in 540)
* fixes locked features keeping residual horizontal impulse (which caused flickering when it was high)