### PR TITLE
Feature XZ position lock patch

### DIFF
--- a/rts/Lua/LuaSyncedCtrl.cpp
+++ b/rts/Lua/LuaSyncedCtrl.cpp
@@ -231,6 +231,7 @@ bool LuaSyncedCtrl::PushEntries(lua_State* L)
 	REGISTER_LUA_CFUNC(SetFeatureMidAndAimPos);
 	REGISTER_LUA_CFUNC(SetFeatureRadiusAndHeight);
 	REGISTER_LUA_CFUNC(SetFeatureCollisionVolumeData);
+	REGISTER_LUA_CFUNC(SetFeatureLockPosition);
 
 
 	REGISTER_LUA_CFUNC(SetProjectileAlwaysVisible);
@@ -2811,6 +2812,16 @@ int LuaSyncedCtrl::SetFeatureRadiusAndHeight(lua_State* L)
 int LuaSyncedCtrl::SetFeatureCollisionVolumeData(lua_State* L)
 {
 	return (SetSolidObjectCollisionVolumeData(L, ParseFeature(L, __FUNCTION__, 1)));
+}
+
+int LuaSyncedCtrl::SetFeatureLockPosition(lua_State* L)
+{
+	CFeature* feature = ParseFeature(L, __FUNCTION__, 1);
+	if (feature == NULL) {
+		return 0;
+	}
+	feature->lockPosition = !!luaL_checkboolean(L, 2);
+	return 0;
 }
 
 /******************************************************************************/

--- a/rts/Lua/LuaSyncedCtrl.h
+++ b/rts/Lua/LuaSyncedCtrl.h
@@ -125,6 +125,7 @@ class LuaSyncedCtrl
 		static int SetFeatureMidAndAimPos(lua_State* L);
 		static int SetFeatureRadiusAndHeight(lua_State* L);
 		static int SetFeatureCollisionVolumeData(lua_State* L);
+		static int SetFeatureLockPosition(lua_State* L);
 
 		static int SetProjectileAlwaysVisible(lua_State* L);
 		static int SetProjectileMoveControl(lua_State* L);

--- a/rts/Lua/LuaSyncedRead.cpp
+++ b/rts/Lua/LuaSyncedRead.cpp
@@ -273,6 +273,7 @@ bool LuaSyncedRead::PushEntries(lua_State* L)
 	REGISTER_LUA_CFUNC(GetFeatureResurrect);
 	REGISTER_LUA_CFUNC(GetFeatureCollisionVolumeData);
 	REGISTER_LUA_CFUNC(GetFeatureSeparation);
+	REGISTER_LUA_CFUNC(GetFeatureLockPosition);
 
 	REGISTER_LUA_CFUNC(GetProjectilePosition);
 	REGISTER_LUA_CFUNC(GetProjectileDirection);
@@ -4566,6 +4567,16 @@ int LuaSyncedRead::GetFeatureCollisionVolumeData(lua_State* L)
 	return (PushCollisionVolumeData(L, feature->collisionVolume));
 }
 
+
+int LuaSyncedRead::GetFeatureLockPosition(lua_State* L)
+{
+	CFeature* feature = ParseFeature(L, __FUNCTION__, 1);
+	if (feature == NULL || !IsFeatureVisible(L, feature)) {
+		return 0;
+	}
+	lua_pushboolean(L, feature->lockPosition);
+	return 1;
+}
 
 /******************************************************************************/
 /******************************************************************************/

--- a/rts/Lua/LuaSyncedRead.h
+++ b/rts/Lua/LuaSyncedRead.h
@@ -185,6 +185,7 @@ class LuaSyncedRead {
 		static int GetFeatureNoSelect(lua_State* L);
 		static int GetFeatureResurrect(lua_State* L);
 		static int GetFeatureCollisionVolumeData(lua_State* L);
+		static int GetFeatureLockPosition(lua_State* L);
 
 		static int GetProjectilePosition(lua_State* L);
 		static int GetProjectileDirection(lua_State* L);

--- a/rts/Sim/Features/Feature.h
+++ b/rts/Sim/Features/Feature.h
@@ -82,6 +82,7 @@ public:
 	 */
 	bool isRepairingBeforeResurrect;
 	bool isAtFinalHeight;
+	bool lockPosition;
 	bool inUpdateQue;
 	bool deleteMe;
 


### PR DESCRIPTION
Features can currently have their XZ position locked (only able to move along the Y vector) but this is hardcoded and tied to resurrectability (locked iff not resurrectable). The patch adds a way to control that and fixes some related issues.

* add Spring.{Get,Set}FeatureLockPosition Lua functions to control the XZ position lock.
* non-locked features now obey the "floating" tag.
* fix locked features keeping horizontal impulse (which caused rendering flickering when it was high).
* fix non-locked features having double vertical velocity.
* fix features not inheriting velocity if created from other features.