### PR TITLE
Allow SetUnitVelocity in UnitDestroyed

### DIFF
--- a/rts/Sim/Units/Unit.cpp
+++ b/rts/Sim/Units/Unit.cpp
@@ -623,11 +623,12 @@ void CUnit::KillUnit(CUnit* attacker, bool selfDestruct, bool reclaimed, bool sh
 	}
 	transportedUnits.clear();
 
-	deathSpeed = speed;
 
 	// TODO: add UnitPreDestroyed, call these later
 	eventHandler.UnitDestroyed(this, attacker);
 	eoh->UnitDestroyed(*this, attacker);
+
+	deathSpeed = speed;
 
 	// Will be called in the destructor again, but this can not hurt
 	SetGroup(nullptr);


### PR DESCRIPTION
The patch makes wrecks save the parent unit's speed from after UnitDestroyed (currently is before). This allows to set wrecks' initial speed reliably.