### PR TITLE
Add a new modrule: experience.lastHitMult

### DIFF
--- a/rts/Sim/Misc/ModInfo.cpp
+++ b/rts/Sim/Misc/ModInfo.cpp
@@ -54,6 +54,7 @@ void CModInfo::ResetState()
 	captureEnergyCostFactor   = 0.0f;
 
 	unitExpMultiplier  = 0.0f;
+	unitExpLastHitMult = 0.0f;
 	unitExpPowerScale  = 0.0f;
 	unitExpHealthScale = 0.0f;
 	unitExpReloadScale = 0.0f;
@@ -208,6 +209,7 @@ void CModInfo::Init(const char* modArchive)
 		const LuaTable& experienceTbl = root.SubTable("experience");
 
 		unitExpMultiplier  = experienceTbl.GetFloat("experienceMult", 1.0f);
+		unitExpLastHitMult = experienceTbl.GetFloat(   "lastHitMult", 1.0f);
 		unitExpPowerScale  = experienceTbl.GetFloat(    "powerScale", 1.0f);
 		unitExpHealthScale = experienceTbl.GetFloat(   "healthScale", 0.7f);
 		unitExpReloadScale = experienceTbl.GetFloat(   "reloadScale", 0.4f);

--- a/rts/Sim/Misc/ModInfo.h
+++ b/rts/Sim/Misc/ModInfo.h
@@ -91,6 +91,7 @@ public:
 	float captureEnergyCostFactor;
 
 	float unitExpMultiplier;
+	float unitExpLastHitMult;
 	float unitExpPowerScale;
 	float unitExpHealthScale;
 	float unitExpReloadScale;

--- a/rts/Sim/Units/Unit.cpp
+++ b/rts/Sim/Units/Unit.cpp
@@ -71,6 +71,7 @@ bool  CUnit::spawnFeature = true;
 
 float CUnit::empDeclineRate = 0.0f;
 float CUnit::expMultiplier  = 0.0f;
+float CUnit::expLastHitMult = 0.0f;
 float CUnit::expPowerScale  = 0.0f;
 float CUnit::expHealthScale = 0.0f;
 float CUnit::expReloadScale = 0.0f;
@@ -259,6 +260,7 @@ void CUnit::InitStatic()
 	expGrade       = 0.0f;
 
 	SetExpMultiplier(modInfo.unitExpMultiplier);
+	SetExpLastHitMult(modInfo.unitExpLastHitMult);
 	SetExpPowerScale(modInfo.unitExpPowerScale);
 	SetExpHealthScale(modInfo.unitExpHealthScale);
 	SetExpReloadScale(modInfo.unitExpReloadScale);
@@ -1363,7 +1365,7 @@ void CUnit::DoDamage(
 		if (attacker == NULL) { return; }
 
 		if (!teamHandler->Ally(allyteam, attacker->allyteam)) {
-			attacker->AddExperience(expMultiplier * 0.1f * (power / attacker->power));
+			attacker->AddExperience(expMultiplier * 0.1f * (power / attacker->power) * expLastHitMult);
 			teamHandler->Team(attacker->team)->GetCurrentStats().unitsKilled++;
 		}
 	}

--- a/rts/Sim/Units/Unit.h
+++ b/rts/Sim/Units/Unit.h
@@ -233,12 +233,14 @@ public: // unsynced methods
 
 public:
 	static void  SetExpMultiplier(float value) { expMultiplier = value; }
+	static void  SetExpLastHitMult(float value) { expLastHitMult = value; }
 	static void  SetExpPowerScale(float value) { expPowerScale = value; }
 	static void  SetExpHealthScale(float value) { expHealthScale = value; }
 	static void  SetExpReloadScale(float value) { expReloadScale = value; }
 	static void  SetExpGrade(float value) { expGrade = value; }
 
 	static float GetExpMultiplier() { return expMultiplier; }
+	static float GetExpLastHitMult() { return expLastHitMult; }
 	static float GetExpPowerScale() { return expPowerScale; }
 	static float GetExpHealthScale() { return expHealthScale; }
 	static float GetExpReloadScale() { return expReloadScale; }
@@ -545,6 +547,7 @@ private:
 
 	static float empDeclineRate;
 	static float expMultiplier;
+	static float expLastHitMult;
 	static float expPowerScale;
 	static float expHealthScale;
 	static float expReloadScale;


### PR DESCRIPTION
A multiplier for the last hit XP bonus. Its default value is 1 which is the current behaviour, ie. the kill bonus is the same as bringing that unit from 100% to 0% health.