### PR TITLE
Fix grass recieving shadows

### DIFF
--- a/cont/base/springcontent/shaders/GLSL/GrassFragProg.glsl
+++ b/cont/base/springcontent/shaders/GLSL/GrassFragProg.glsl
@@ -53,7 +53,7 @@ void main() {
 	gl_FragColor.a   = matColor.a * gl_Color.a;
 
 #ifdef HAVE_SHADOWS
-	float shadowCoeff = clamp(shadow2DProj(shadowMap, shadowTexCoords).a + groundShadowDensity, 0., 1.);
+	float shadowCoeff = clamp(shadow2DProj(shadowMap, shadowTexCoords).r, 1.0 - groundShadowDensity, 1.0);
 	gl_FragColor.rgb *= mix(ambientLightColor, vec3(1.0), shadowCoeff);
 #endif
 


### PR DESCRIPTION
On my nvidia card, shadow2DProj().a always returned 1. Also, clamping the value + groundshadowdensity was incorrect imo, as the greater the density, the less of an effect it had because of the addition.
