### PR TITLE
Added StructurePlacementNotify Lua unsynced callin

### DIFF
--- a/cont/LuaUI/callins.lua
+++ b/cont/LuaUI/callins.lua
@@ -17,6 +17,8 @@ CallInsList = {
   "LayoutButtons",
   "ConfigureLayout",
   "CommandNotify",
+  
+  "StructurePlacementNotify",
 
   "KeyPress",
   "KeyRelease",

--- a/cont/LuaUI/main.lua
+++ b/cont/LuaUI/main.lua
@@ -100,6 +100,10 @@ function CommandNotify(id, params, options)
   return widgetHandler:CommandNotify(id, params, options)
 end
 
+function StructurePlacementNotify(unitDefID, x, y, z, buildHeight, x1, z1, x2, z2, allyteam)
+  return widgetHandler:StructurePlacementNotify(unitDefID, x, y, z, buildHeight, x1, z1, x2, z2, allyteam)
+end
+
 function DrawScreen(vsx, vsy)
   widgetHandler:SetViewSize(vsx, vsy)
   return widgetHandler:DrawScreen()

--- a/cont/LuaUI/widgets.lua
+++ b/cont/LuaUI/widgets.lua
@@ -155,6 +155,7 @@ local flexCallIns = {
   'DrawScreenEffects',
   'DrawInMiniMap',
   'RecvSkirmishAIMessage',
+  'StructurePlacementNotify',
 }
 local flexCallInMap = {}
 for _,ci in ipairs(flexCallIns) do
@@ -1655,6 +1656,16 @@ function widgetHandler:RecvSkirmishAIMessage(aiTeam, dataStr)
       return dataRet
     end
   end
+end
+
+function widgetHandler:StructurePlacementNotify(unitDefID, x, y, z, buildHeight, x1, z1, x2, z2, allyteam)
+  for _,w in ipairs(self.StructurePlacementNotifyList) do
+    local result, blockedSquares = w:StructurePlacementNotify(unitDefID, x, y, z, buildHeight, x1, z1, x2, z2, allyteam)
+    if not result then
+      return false, blockedSquares
+    end
+  end
+  return true, nil
 end
 
 function widgetHandler:WorldTooltip(ttType, ...)

--- a/doc/changelog.txt
+++ b/doc/changelog.txt
@@ -24,6 +24,7 @@ Lua:
  - Add Spring.GetFrameTimer(bool synced) to get a timer for the start of the frame
    this should give better results for camera interpolations.
  - Add an optional weaponNum argument to SetUnitTarget.
+ - Add Lua unsynced callin named StructurePlacementNotify. This callin is called to find out whether it's allowed to build certain stucture in certain place.
 
 Save/Load:
  ! remove UseCREGSaveLoad and add /LuaSave which generates .slsf files

--- a/rts/Game/GameHelper.h
+++ b/rts/Game/GameHelper.h
@@ -11,6 +11,7 @@
 
 #include <map>
 #include <vector>
+#include <unordered_set>
 
 class CUnit;
 class CWeapon;

--- a/rts/Lua/LuaHandle.h
+++ b/rts/Lua/LuaHandle.h
@@ -13,9 +13,11 @@
 #include <string>
 #include <vector>
 #include <set>
+#include <unordered_set>
 using std::string;
 using std::vector;
 using std::set;
+using std::unordered_set;
 
 
 #define LUA_HANDLE_ORDER_RULES            100
@@ -199,6 +201,8 @@ class CLuaHandle : public CEventClient
 		bool DefaultCommand(const CUnit* unit, const CFeature* feature, int& cmd) override;
 
 		bool CommandNotify(const Command& cmd) override;
+
+		bool StructurePlacementNotify(const UnitDef* def, const float3& pos, float buildHeight, int x1, int z1, int x2, int z2, int allyteam, unordered_set<float3>& modnobuildpos) override;
 
 		bool AddConsoleLine(const string& msg, const string& section, int level) override;
 

--- a/rts/System/EventClient.cpp
+++ b/rts/System/EventClient.cpp
@@ -155,6 +155,8 @@ std::string CEventClient::GetTooltip(int x, int y) { return ""; }
 
 bool CEventClient::CommandNotify(const Command& cmd) { return false; }
 
+bool CEventClient::StructurePlacementNotify(const UnitDef* def, const float3& pos, float buildHeight, int x1, int z1, int x2, int z2, int allyteam, unordered_set<float3>& modnobuildpos) { return true; }
+
 bool CEventClient::AddConsoleLine(const std::string& msg, const std::string& section, int level) { return false; }
 
 void CEventClient::LastMessagePosition(const float3& pos) {}

--- a/rts/System/EventClient.h
+++ b/rts/System/EventClient.h
@@ -6,6 +6,7 @@
 #include <string>
 #include <vector>
 #include <map>
+#include <unordered_set>
 #include <typeinfo>
 
 #include "System/float3.h"
@@ -20,6 +21,7 @@
 using std::string;
 using std::vector;
 using std::map;
+using std::unordered_set;
 
 class CUnit;
 class CWeapon;
@@ -276,6 +278,8 @@ class CEventClient
 		virtual bool DefaultCommand(const CUnit* unit, const CFeature* feature, int& cmd);
 
 		virtual bool CommandNotify(const Command& cmd);
+
+		virtual bool StructurePlacementNotify(const UnitDef* def, const float3& pos, float buildHeight, int x1, int z1, int x2, int z2, int allyteam, unordered_set<float3>& modnobuildpos);
 
 		virtual bool AddConsoleLine(const std::string& msg, const std::string& section, int level);
 

--- a/rts/System/EventHandler.cpp
+++ b/rts/System/EventHandler.cpp
@@ -12,6 +12,7 @@
 using std::string;
 using std::vector;
 using std::map;
+using std::unordered_set;
 
 
 CEventHandler eventHandler;
@@ -596,6 +597,13 @@ DRAW_ENTITY_CALLIN(Projectile, (const CProjectile* projectile), (projectile))
 			return true; \
 	}
 
+#define CONTROL_REVERSE_ITERATE_DEF_FALSE(name, ...) \
+    for (int i = list##name.size() - 1; i >= 0; --i) { \
+        CEventClient* ec = list##name[i]; \
+        if (!ec->name(__VA_ARGS__)) \
+            return false; \
+    }
+
 #define CONTROL_REVERSE_ITERATE_STRING(name, ...) \
 	for (int i = list##name.size() - 1; i >= 0; --i) { \
 		CEventClient* ec = list##name[i]; \
@@ -608,6 +616,13 @@ bool CEventHandler::CommandNotify(const Command& cmd)
 {
 	CONTROL_REVERSE_ITERATE_DEF_TRUE(CommandNotify, cmd)
 	return false;
+}
+
+
+bool CEventHandler::StructurePlacementNotify(const UnitDef* def, const float3& pos, float buildHeight, int x1, int z1, int x2, int z2, int allyteam, unordered_set<float3>& modnobuildpos)
+{
+    CONTROL_REVERSE_ITERATE_DEF_FALSE(StructurePlacementNotify, def, pos, buildHeight, x1, z1, x2, z2, allyteam, modnobuildpos)
+    return true;
 }
 
 

--- a/rts/System/EventHandler.h
+++ b/rts/System/EventHandler.h
@@ -6,6 +6,7 @@
 #include <string>
 #include <vector>
 #include <map>
+#include <unordered_set>
 
 #include "System/EventClient.h"
 #include "Sim/Units/Unit.h"
@@ -217,6 +218,8 @@ class CEventHandler
 		bool DefaultCommand(const CUnit* unit, const CFeature* feature, int& cmd);
 
 		bool CommandNotify(const Command& cmd);
+
+		bool StructurePlacementNotify(const UnitDef* def, const float3& pos, float buildHeight, int x1, int z1, int x2, int z2, int allyteam, std::unordered_set<float3>& modnobuildpos);
 
 		bool AddConsoleLine(const std::string& msg, const std::string& section, int level);
 

--- a/rts/System/Events.def
+++ b/rts/System/Events.def
@@ -109,14 +109,15 @@
 	SETUP_EVENT(DownloadFailed,        MANAGED_BIT | UNSYNCED_BIT)
 	SETUP_EVENT(DownloadProgress,      MANAGED_BIT | UNSYNCED_BIT)
 
-	SETUP_EVENT(LastMessagePosition, MANAGED_BIT | UNSYNCED_BIT)
-	SETUP_EVENT(DefaultCommand,      MANAGED_BIT | UNSYNCED_BIT | CONTROL_BIT)
-	SETUP_EVENT(CommandNotify,       MANAGED_BIT | UNSYNCED_BIT | CONTROL_BIT)
-	SETUP_EVENT(AddConsoleLine,      MANAGED_BIT | UNSYNCED_BIT)
-	SETUP_EVENT(GroupChanged,        MANAGED_BIT | UNSYNCED_BIT)
-	SETUP_EVENT(GameSetup,           MANAGED_BIT | UNSYNCED_BIT | CONTROL_BIT)
-	SETUP_EVENT(WorldTooltip,        MANAGED_BIT | UNSYNCED_BIT)
-	SETUP_EVENT(MapDrawCmd,          MANAGED_BIT | UNSYNCED_BIT | CONTROL_BIT)
+        SETUP_EVENT(LastMessagePosition,            MANAGED_BIT | UNSYNCED_BIT)
+        SETUP_EVENT(DefaultCommand,                 MANAGED_BIT | UNSYNCED_BIT | CONTROL_BIT)
+        SETUP_EVENT(CommandNotify,                  MANAGED_BIT | UNSYNCED_BIT | CONTROL_BIT)
+        SETUP_EVENT(StructurePlacementNotify,       MANAGED_BIT | UNSYNCED_BIT | CONTROL_BIT)
+        SETUP_EVENT(AddConsoleLine,                 MANAGED_BIT | UNSYNCED_BIT)
+        SETUP_EVENT(GroupChanged,                   MANAGED_BIT | UNSYNCED_BIT)
+        SETUP_EVENT(GameSetup,                      MANAGED_BIT | UNSYNCED_BIT | CONTROL_BIT)
+        SETUP_EVENT(WorldTooltip,                   MANAGED_BIT | UNSYNCED_BIT)
+        SETUP_EVENT(MapDrawCmd,                     MANAGED_BIT | UNSYNCED_BIT | CONTROL_BIT)
 
 	SETUP_EVENT(SunChanged,     MANAGED_BIT | UNSYNCED_BIT) //FIXME make synced? (whole dynSun code needs to then)
 

--- a/rts/System/float3.h
+++ b/rts/System/float3.h
@@ -13,6 +13,9 @@
 #include "System/Platform/Win/win32.h"
 #endif
 
+#include <boost/functional/hash_fwd.hpp>
+#include <functional>
+
 
 /**
  * @brief float3 class
@@ -691,6 +694,19 @@ public:
 		struct { float s,t,p; };
 		struct { float xstart, ystart, xend; };
 		struct { float xyz[3]; };
+	};
+};
+
+namespace std {
+	template <> struct hash<float3> {
+		size_t operator()(float3 const& value) const
+		{
+			size_t seed = 0;
+			boost::hash_combine(seed, value.x);
+			boost::hash_combine(seed, value.y);
+			boost::hash_combine(seed, value.z);
+			return seed;
+		}
 	};
 };
 


### PR DESCRIPTION
This is to allow for native drawing of blocked squares, defined by mod. Say you, as a mod builder, would like to:

-  disallow building of any type except metal extractors on metal spots
-  or you want metal extractors to be only buildable on certain location
-  or you don't want non geo-enabled buildings to occupy geo spot.

Existing solutions can track such construction requests using CommandNotify in unsynced context. Few issues exist however:

1. Blocked squares cannot be drawn in a native way (i.e. as yellow/reg/green grid under the building blueprint). DrawWorld call-in is called before mentioned grid and building's model are drawn when you hover mouse with active command set. Therefore whatever you have drawn in DrawWorld becomes overwritten afterwards.

2. Complex construction modes like, line build, rectangular build are not easy to track from Lua: It should be done before the command is issued (while you're moving your mouse and setting up blueprint for future line/rect construction), and therefore should give appropriate visual feedback. This requires replicating of lots of stuff, done by engine anyway and taking into account quite a few events such as keys pressed (shift, alt, ctrl), mouse move, mouse button clicks, build spacing, selected mode (single building, line, rectangle, hollow rectangle).

The proposed solution augments **unsynced** part of CGameHelper::TestUnitBuildSquare with optional Lua callin, which asks Lua mod if particular building can be built in particular place. It also requests for mod-blocked squares, this information is then merged with engine-blocked squares (like another building is there, slope is too steep, water, etc) and displayed in the same way. Handling of such callin is optional on mod side, if it's not defined in the Lua, then nothing will change.

I didn't touch synced part on purpose as AllowCommand or AllowUnitCreation could be used to do same already for synced context (AllowUnitCreation parameters are fact is very similar to parameters, supplied to the proposed call-in). The reason I didn't touch sync was that I didn't want to multiply controlling entities. If requested, the code could be modified, such as that a synced part is handled as well. At least I think It's possible.