### PR TITLE
Applied decloakUnitShape attribute to unit (was defined only on UnitDef level)

### DIFF
--- a/doc/changelog.txt
+++ b/doc/changelog.txt
@@ -24,6 +24,7 @@ Lua:
  - Add Spring.GetFrameTimer(bool synced) to get a timer for the start of the frame
    this should give better results for camera interpolations.
  - Add an optional weaponNum argument to SetUnitTarget.
+ - Spring.SetUnitCloak got additional parameter that controls decloakSpherical attribute
 
 Save/Load:
  ! remove UseCREGSaveLoad and add /LuaSave which generates .slsf files

--- a/rts/Game/UI/GuiHandler.cpp
+++ b/rts/Game/UI/GuiHandler.cpp
@@ -3609,7 +3609,7 @@ void CGuiHandler::DrawMapStuff(bool onMinimap)
 			// draw decloak distance
 			if (unit->decloakDistance > 0.0f) {
 				glColor4fv(cmdColors.rangeDecloak);
-				if (unit->unitDef->decloakSpherical && globalRendering->drawdebug) {
+				if (unit->decloakSpherical && globalRendering->drawdebug) {
 					glPushMatrix();
 					glTranslatef(unit->midPos.x, unit->midPos.y, unit->midPos.z);
 					glRotatef(90.0f, 1.0f, 0.0f, 0.0f);

--- a/rts/Lua/LuaSyncedCtrl.cpp
+++ b/rts/Lua/LuaSyncedCtrl.cpp
@@ -1833,6 +1833,16 @@ int LuaSyncedCtrl::SetUnitCloak(lua_State* L)
 		}
 	}
 
+	if (lua_isnil(L, 4)) {
+		bool defDS = unit->unitDef->decloakSpherical;
+		if (unit->decloakSpherical != defDS) {
+			unit->decloakSpherical = defDS;
+		}
+	}
+	else if (lua_isboolean(L, 4)) {
+		unit->decloakSpherical = lua_toboolean(L, 4);
+	}
+
 	return 0;
 }
 

--- a/rts/Sim/Units/Unit.cpp
+++ b/rts/Sim/Units/Unit.cpp
@@ -176,6 +176,7 @@ CUnit::CUnit()
 , cloakTimeout(128)
 , curCloakTimeout(gs->frameNum)
 , decloakDistance(0.0f)
+, decloakSpherical(true)
 , lastTerrainType(-1)
 , curTerrainType(0)
 , selfDCountdown(0)
@@ -376,6 +377,7 @@ void CUnit::PreInit(const UnitLoadParams& params)
 	wantCloak |= unitDef->startCloaked;
 	decloakDistance = unitDef->decloakDistance;
 	cloakTimeout = unitDef->cloakTimeout;
+	decloakSpherical = unitDef->decloakSpherical;
 
 	flankingBonusMode        = unitDef->flankingBonusMode;
 	flankingBonusDir         = unitDef->flankingBonusDir;
@@ -2405,7 +2407,7 @@ bool CUnit::GetNewCloakState(bool stunCheck) {
 	}
 
 	if (wantCloak || (scriptCloak >= 1)) {
-		const CUnit* closestEnemy = CGameHelper::GetClosestEnemyUnitNoLosTest(NULL, midPos, decloakDistance, allyteam, unitDef->decloakSpherical, false);
+		const CUnit* closestEnemy = CGameHelper::GetClosestEnemyUnitNoLosTest(NULL, midPos, decloakDistance, allyteam, decloakSpherical, false);
 		const float cloakCost = (Square(speed.w) > 0.2f)? unitDef->cloakCostMoving: unitDef->cloakCost;
 
 		if (decloakDistance > 0.0f && closestEnemy != NULL) {

--- a/rts/Sim/Units/Unit.cpp
+++ b/rts/Sim/Units/Unit.cpp
@@ -2916,6 +2916,7 @@ CR_REG_METADATA(CUnit, (
 	CR_MEMBER(curCloakTimeout),
 	CR_MEMBER(isCloaked),
 	CR_MEMBER(decloakDistance),
+	CR_MEMBER(decloakSpherical),
 
 	CR_MEMBER(lastTerrainType),
 	CR_MEMBER(curTerrainType),

--- a/rts/Sim/Units/Unit.h
+++ b/rts/Sim/Units/Unit.h
@@ -490,6 +490,9 @@ public:
 	int curCloakTimeout;
 	float decloakDistance;
 
+	// to allow for individual per-unit control of 2D/3D minCloakDistance application
+	bool decloakSpherical;
+
 	int lastTerrainType;
 	/// Used for calling setSFXoccupy which TA scripts want
 	int curTerrainType;


### PR DESCRIPTION
Proposed for the purpose of being able to change decloakUnitShape attribute on the fly through Lua synced control. This can be useful if cloaked unit changes its realm. For instance decloak may be spherical for a unit on the ground, but change to cylindrical when the unit is in the water.