### PR TITLE
Added AllowProximityDecloak synced callin

### DIFF
--- a/cont/base/springcontent/LuaGadgets/callins.lua
+++ b/cont/base/springcontent/LuaGadgets/callins.lua
@@ -104,6 +104,7 @@ CALLIN_LIST = {
 	"AllowResourceTransfer",
 	"AllowDirectUnitControl",
 	"AllowBuilderHoldFire",
+	"AllowProximityDecloak",
 	"AllowWeaponTargetCheck",
 	"AllowWeaponTarget",
 	"AllowWeaponInterceptTarget",

--- a/cont/base/springcontent/LuaGadgets/gadgets.lua
+++ b/cont/base/springcontent/LuaGadgets/gadgets.lua
@@ -1199,14 +1199,22 @@ end
 
 
 function gadgetHandler:AllowBuilderHoldFire(unitID, unitDefID, action)
-  for _,g in r_ipairs(self.AllowBuilderHoldFire) do
-    if (not AllowBuilderHoldFire(unitID, unitDefID, action)) then
+  for _,g in r_ipairs(self.AllowBuilderHoldFireList) do
+    if (not g:AllowBuilderHoldFire(unitID, unitDefID, action)) then
       return false
     end
   end
   return true
 end
 
+function gadgetHandler:AllowProximityDecloak(unitID, unitDefID, decloakerDefID, decloakerUnitID)
+  for _,g in r_ipairs(self.AllowProximityDecloakList) do
+    if (not g:AllowProximityDecloak(unitID, unitDefID, decloakerDefID, decloakerUnitID)) then
+      return false
+    end
+  end
+  return true
+end
 
 function gadgetHandler:MoveCtrlNotify(unitID, unitDefID, unitTeam, data)
   local state = false

--- a/doc/changelog.txt
+++ b/doc/changelog.txt
@@ -24,6 +24,7 @@ Lua:
  - Add Spring.GetFrameTimer(bool synced) to get a timer for the start of the frame
    this should give better results for camera interpolations.
  - Add an optional weaponNum argument to SetUnitTarget.
+ - Add AllowProximityDecloak synced callin. It allows to block proximity based decloak.
 
 Save/Load:
  ! remove UseCREGSaveLoad and add /LuaSave which generates .slsf files

--- a/rts/Lua/LuaHandleSynced.cpp
+++ b/rts/Lua/LuaHandleSynced.cpp
@@ -765,6 +765,30 @@ bool CSyncedLuaHandle::AllowStartPosition(int playerID, unsigned char readyState
 	return retval;
 }
 
+bool CSyncedLuaHandle::AllowProximityDecloak(const CUnit* unit, const CUnit* decloakerUnit)
+{
+	LUA_CALL_IN_CHECK(L, true);
+	luaL_checkstack(L, 2 + 4 + 1, __func__);
+	static const LuaHashString cmdStr(__func__);
+	if (!cmdStr.GetGlobalFunc(L))
+		return true; // the call is not defined
+
+	lua_pushnumber(L, unit->id);
+	lua_pushnumber(L, unit->unitDef->id);
+
+	lua_pushnumber(L, decloakerUnit->id);
+	lua_pushnumber(L, decloakerUnit->unitDef->id);
+
+	// call the function
+	if (!RunCallIn(L, cmdStr, 4, 1))
+		return true;
+
+	// get the results
+	const bool retval = luaL_optboolean(L, -1, true);
+	lua_pop(L, 1);
+	return retval;
+}
+
 
 bool CSyncedLuaHandle::MoveCtrlNotify(const CUnit* unit, int data)
 {

--- a/rts/Lua/LuaHandleSynced.h
+++ b/rts/Lua/LuaHandleSynced.h
@@ -65,6 +65,7 @@ class CSyncedLuaHandle : public CLuaHandle
 		bool AllowDirectUnitControl(int playerID, const CUnit* unit);
 		bool AllowBuilderHoldFire(const CUnit* unit, int action);
 		bool AllowStartPosition(int playerID, unsigned char readyState, const float3& clampedPos, const float3& rawPickPos);
+		bool AllowProximityDecloak(const CUnit* unit, const CUnit* decloakerUnit);
 
 		bool TerraformComplete(const CUnit* unit, const CUnit* build);
 		bool MoveCtrlNotify(const CUnit* unit, int data);

--- a/rts/Sim/Units/Unit.cpp
+++ b/rts/Sim/Units/Unit.cpp
@@ -2408,7 +2408,7 @@ bool CUnit::GetNewCloakState(bool stunCheck) {
 		const CUnit* closestEnemy = CGameHelper::GetClosestEnemyUnitNoLosTest(NULL, midPos, decloakDistance, allyteam, unitDef->decloakSpherical, false);
 		const float cloakCost = (Square(speed.w) > 0.2f)? unitDef->cloakCostMoving: unitDef->cloakCost;
 
-		if (decloakDistance > 0.0f && closestEnemy != NULL) {
+		if ( decloakDistance > 0.0f && closestEnemy != NULL && eventHandler.AllowProximityDecloak(this, closestEnemy) ) {
 			curCloakTimeout = gs->frameNum + cloakTimeout;
 			return false;
 		}

--- a/rts/System/EventClient.cpp
+++ b/rts/System/EventClient.cpp
@@ -62,6 +62,7 @@ bool CEventClient::AllowResourceTransfer(int oldTeam, int newTeam, const string&
 bool CEventClient::AllowDirectUnitControl(int playerID, const CUnit* unit) { return true; }
 bool CEventClient::AllowBuilderHoldFire(const CUnit* unit, int action) { return true; }
 bool CEventClient::AllowStartPosition(int playerID, unsigned char readyState, const float3& clampedPos, const float3& rawPickPos) { return true; }
+bool CEventClient::AllowProximityDecloak(const CUnit* unit, const CUnit* decloakerUnit) { return true; }
 
 bool CEventClient::TerraformComplete(const CUnit* unit, const CUnit* build) { return false; }
 bool CEventClient::MoveCtrlNotify(const CUnit* unit, int data) { return false; }

--- a/rts/System/EventClient.h
+++ b/rts/System/EventClient.h
@@ -202,6 +202,7 @@ class CEventClient
 		virtual bool AllowDirectUnitControl(int playerID, const CUnit* unit);
 		virtual bool AllowBuilderHoldFire(const CUnit* unit, int action);
 		virtual bool AllowStartPosition(int playerID, unsigned char readyState, const float3& clampedPos, const float3& rawPickPos);
+		virtual bool AllowProximityDecloak(const CUnit* unit, const CUnit* decloakerUnit);
 
 		virtual bool TerraformComplete(const CUnit* unit, const CUnit* build);
 		virtual bool MoveCtrlNotify(const CUnit* unit, int data);

--- a/rts/System/EventHandler.cpp
+++ b/rts/System/EventHandler.cpp
@@ -291,6 +291,10 @@ bool CEventHandler::AllowStartPosition(int playerID, unsigned char readyState, c
 	CONTROL_ITERATE_DEF_TRUE(AllowStartPosition, playerID, readyState, clampedPos, rawPickPos)
 }
 
+bool CEventHandler::AllowProximityDecloak(const CUnit* unit, const CUnit* decloakerUnit)
+{
+	CONTROL_ITERATE_DEF_TRUE(AllowProximityDecloak, unit, decloakerUnit)
+}
 
 
 bool CEventHandler::TerraformComplete(const CUnit* unit, const CUnit* build)

--- a/rts/System/EventHandler.h
+++ b/rts/System/EventHandler.h
@@ -148,6 +148,7 @@ class CEventHandler
 		bool AllowDirectUnitControl(int playerID, const CUnit* unit);
 		bool AllowBuilderHoldFire(const CUnit* unit, int action);
 		bool AllowStartPosition(int playerID, unsigned char readyState, const float3& clampedPos, const float3& rawPickPos);
+		bool AllowProximityDecloak(const CUnit* unit, const CUnit* decloakerUnit);
 
 		bool TerraformComplete(const CUnit* unit, const CUnit* build);
 		bool MoveCtrlNotify(const CUnit* unit, int data);

--- a/rts/System/Events.def
+++ b/rts/System/Events.def
@@ -164,6 +164,8 @@
 	SETUP_EVENT(AllowDirectUnitControl, MANAGED_BIT | CONTROL_BIT)
 	SETUP_EVENT(AllowBuilderHoldFire,   MANAGED_BIT | CONTROL_BIT)
 	SETUP_EVENT(AllowStartPosition,     MANAGED_BIT | CONTROL_BIT)
+	SETUP_EVENT(AllowProximityDecloak,  MANAGED_BIT | CONTROL_BIT)
+	
 	SETUP_EVENT(TerraformComplete,      MANAGED_BIT | CONTROL_BIT)
 	SETUP_EVENT(MoveCtrlNotify,         MANAGED_BIT | CONTROL_BIT)
 


### PR DESCRIPTION
Synced AllowProximityDecloak is here to possibly cancel engine inducted decloak of a cloaked unit, entered its decloak radius. The use case is to be able to better control when a unit is decloaked from the mod. One example is amphibian cloaked unit, which is supposed to have sphere decloak shape on land and cylinder shape in the water. Though cylinder height should be limited to some value a bit above water level (otherwise air will be able to decloak amphibian in the water). So in order to achieve desired behavior, the decloakShape will be set  to cylinder in UnitDef and then checked inside AllowProximityDecloak whether the decloaking unit is within sphere if cloaked unit is on land or whether the decloaking unit is within height-limited cylinder when cloaked unit is under water.

Proposed as a better alternative to https://github.com/spring/spring/pull/252
