### PR TITLE
Remove license text from loadscreen, add to README.markdown and infolog

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -7,6 +7,10 @@ Spring (formerly TASpring) is an Open Source Real Time Strategy game engine.
 Visit our [project homepage](http://springrts.com/) for help, suggestions,
 bugs, community forum and everything spring related.
 
+## License
+
+This program is distributed under the GNU General Public License, see license.html for more info
+
 ### Compiling
 
 Detailed instructions for how to compile Spring can be found [here](http://springrts.com/wiki/Building_spring)

--- a/rts/Game/LoadScreen.cpp
+++ b/rts/Game/LoadScreen.cpp
@@ -42,6 +42,7 @@
 
 CONFIG(int, LoadingMT).defaultValue(-1).safemodeValue(0);
 CONFIG(bool, ShowLoadMessages).defaultValue(true);
+CONFIG(bool, LoadscreenLicenseLeftAlign).defaultValue(false);
 
 CLoadScreen* CLoadScreen::singleton = nullptr;
 
@@ -333,10 +334,18 @@ bool CLoadScreen::Draw()
 	font->Begin();
 		font->SetOutlineColor(0.0f,0.0f,0.0f,0.65f);
 		font->SetTextColor(1.0f,1.0f,1.0f,1.0f);
-		font->glFormat(0.5f,0.06f, globalRendering->viewSizeY / 35.0f, FONT_OUTLINE | FONT_CENTER | FONT_NORM,
-				"Spring %s", SpringVersion::GetFull().c_str());
-		font->glFormat(0.5f,0.02f, globalRendering->viewSizeY / 50.0f, FONT_OUTLINE | FONT_CENTER | FONT_NORM,
-			"This program is distributed under the GNU General Public License, see license.html for more info");
+		bool leftAlign = configHandler->GetBool("LoadscreenLicenseLeftAlign");
+		if (leftAlign) {
+			font->glFormat(0.02f,0.06f, globalRendering->viewSizeY / 35.0f, FONT_OUTLINE | FONT_NORM,
+					"Spring %s", SpringVersion::GetFull().c_str());
+			font->glFormat(0.02f,0.02f, globalRendering->viewSizeY / 50.0f, FONT_OUTLINE | FONT_NORM,
+				"This program is distributed under the GNU General Public License, see license.html for more info");
+		} else {
+			font->glFormat(0.5f,0.06f, globalRendering->viewSizeY / 35.0f, FONT_OUTLINE | FONT_CENTER | FONT_NORM,
+					"Spring %s", SpringVersion::GetFull().c_str());
+			font->glFormat(0.5f,0.02f, globalRendering->viewSizeY / 50.0f, FONT_OUTLINE | FONT_CENTER | FONT_NORM,
+				"This program is distributed under the GNU General Public License, see license.html for more info");
+		}
 	font->End();
 
 	if (!mtLoading)

--- a/rts/Game/LoadScreen.cpp
+++ b/rts/Game/LoadScreen.cpp
@@ -42,7 +42,6 @@
 
 CONFIG(int, LoadingMT).defaultValue(-1).safemodeValue(0);
 CONFIG(bool, ShowLoadMessages).defaultValue(true);
-CONFIG(bool, LoadscreenLicenseLeftAlign).defaultValue(false);
 
 CLoadScreen* CLoadScreen::singleton = nullptr;
 
@@ -329,24 +328,6 @@ bool CLoadScreen::Draw()
 			font->End();
 		}
 	}
-
-	// Always render Spring's license notice
-	font->Begin();
-		font->SetOutlineColor(0.0f,0.0f,0.0f,0.65f);
-		font->SetTextColor(1.0f,1.0f,1.0f,1.0f);
-		bool leftAlign = configHandler->GetBool("LoadscreenLicenseLeftAlign");
-		if (leftAlign) {
-			font->glFormat(0.02f,0.06f, globalRendering->viewSizeY / 35.0f, FONT_OUTLINE | FONT_NORM,
-					"Spring %s", SpringVersion::GetFull().c_str());
-			font->glFormat(0.02f,0.02f, globalRendering->viewSizeY / 50.0f, FONT_OUTLINE | FONT_NORM,
-				"This program is distributed under the GNU General Public License, see license.html for more info");
-		} else {
-			font->glFormat(0.5f,0.06f, globalRendering->viewSizeY / 35.0f, FONT_OUTLINE | FONT_CENTER | FONT_NORM,
-					"Spring %s", SpringVersion::GetFull().c_str());
-			font->glFormat(0.5f,0.02f, globalRendering->viewSizeY / 50.0f, FONT_OUTLINE | FONT_CENTER | FONT_NORM,
-				"This program is distributed under the GNU General Public License, see license.html for more info");
-		}
-	font->End();
 
 	if (!mtLoading)
 		SDL_GL_SwapWindow(globalRendering->window);

--- a/rts/System/SpringApp.cpp
+++ b/rts/System/SpringApp.cpp
@@ -185,7 +185,7 @@ bool SpringApp::Initialize()
 	assert(cmdline != NULL);
 	assert(configHandler != NULL);
 
-	LOG_L(L_ERROR, "Spring is distributed under the GNU General Public License, see license.html for more info");
+	LOG("Spring is distributed under the GNU General Public License, see license.html for more info");
 
 	// list user's config
 	LOG("============== <User Config> ==============");

--- a/rts/System/SpringApp.cpp
+++ b/rts/System/SpringApp.cpp
@@ -185,6 +185,8 @@ bool SpringApp::Initialize()
 	assert(cmdline != NULL);
 	assert(configHandler != NULL);
 
+	LOG_L(L_ERROR, "Spring is distributed under the GNU General Public License, see license.html for more info");
+
 	// list user's config
 	LOG("============== <User Config> ==============");
 	const std::map<std::string, std::string> settings = configHandler->GetDataWithoutDefaults();


### PR DESCRIPTION
Edit: the text now lives in README.markdown and is removed from loadscreen completely
Edit2: also lives in infolog
