### PR TITLE
Fix fmod compile error

### DIFF
--- a/rts/Rendering/LineDrawer.cpp
+++ b/rts/Rendering/LineDrawer.cpp
@@ -4,6 +4,7 @@
 
 
 #include "LineDrawer.h"
+#include <cmath>
 
 #include "Rendering/GlobalRendering.h"
 #include "Game/UI/CommandColors.h"


### PR DESCRIPTION
Fix :
error : ‘fmod’ is not a member of ‘std’
  stippleTimer = std::fmod(stippleTimer, (16.0f / 20.0f));