### PR TITLE
Fix compile sqrt

### DIFF
--- a/rts/Rendering/IconHandler.cpp
+++ b/rts/Rendering/IconHandler.cpp
@@ -6,6 +6,7 @@
 #include <cctype>
 #include <vector>
 #include <string>
+#include <cmath>
 
 #include "Rendering/GL/myGL.h"
 #include "Rendering/GL/VertexArray.h"


### PR DESCRIPTION
Fix:
error : ‘sqrt’ is not a member of ‘std’
    const float r = std::sqrt((dx * dx) + (dy * dy)) / 64.0f;