### PR TITLE
Update streflop_cond file to remove unneeded limitations

### DIFF
--- a/rts/lib/streflop/streflop_cond.h
+++ b/rts/lib/streflop/streflop_cond.h
@@ -16,7 +16,6 @@ namespace math {
 }
 #else
 #include <cmath>
-
 #ifdef __APPLE__
 // macosx's cmath doesn't include c++11's std::hypot yet (tested 2013)
 namespace std {
@@ -51,27 +50,10 @@ namespace math {
 	using std::exp;
 	using std::frexp;
 	using std::ldexp;
-// the following are C99 functions -> not supported by VS C
-#if !defined(_MSC_VER) || _MSC_VER < 1500
 	using std::isnan;
 	using std::isinf;
 	using std::isfinite;
-
-#elif __cplusplus
-	template<typename T> inline bool isnan(T value) {
-		return value != value;
-	}
-	// requires include <limits>
-	template<typename T> inline bool isinf(T value) {
-		return std::numeric_limits<T>::has_infinity && value == std::numeric_limits<T>::infinity();
-	}
-	// requires include <limits>
-	template<typename T> inline bool isfinite(T value) {
-		return !isinf<T>(value);
-	}
-#endif
 }
-
 
 #ifdef __APPLE__
 // see above


### PR DESCRIPTION
Modify streflop/streflop_cond.h file as MSVC now has the std::isnan std::isinf and std::isfinite as part of the cmath header file.