### PR TITLE
[AI] Add missing radarMiplevel and fix some docstrings

### DIFF
--- a/rts/ExternalAI/Interface/SSkirmishAICallback.h
+++ b/rts/ExternalAI/Interface/SSkirmishAICallback.h
@@ -1593,6 +1593,11 @@ struct SSkirmishAICallback {
 	int               (CALLING_CONV *Mod_getAirMipLevel)(int skirmishAIId);
 
 	/**
+	 * miplevel for radar
+	 */
+	int               (CALLING_CONV *Mod_getRadarMipLevel)(int skirmishAIId);
+
+	/**
 	 * when underwater, units are not in LOS unless also in sonar
 	 */
 	bool              (CALLING_CONV *Mod_getRequireSonarUnderWater)(int skirmishAIId);
@@ -1699,13 +1704,8 @@ struct SSkirmishAICallback {
 
 	/**
 	 * @brief the radar map
-	 * A square with value 0 means you do not have radar coverage on it.
-	 *
-	 * - do NOT modify or delete the height-map (native code relevant only)
-	 * - index 0 is top left
-	 * - each data position is 8*8 in size
-	 * - the value for the full resolution position (x, z) is at index ((z * width + x) / 8)
-	 * - the last value, bottom right, is at index (width/8 * height/8 - 1)
+	 * mapDims.mapx >> radarMipLevel
+	 * @see getLosMap()
 	 */
 	int               (CALLING_CONV *Map_getRadarMap)(int skirmishAIId, int* radarValues, int radarValues_sizeMax); //$ ARRAY:radarValues
 
@@ -1715,19 +1715,10 @@ struct SSkirmishAICallback {
 	/** @see getRadarMap() */
 	int               (CALLING_CONV *Map_getSeismicMap)(int skirmishAIId, int* seismicValues, int seismicValues_sizeMax); //$ ARRAY:seismicValues
 
-	/**
-	 * @brief the radar jammer map
-	 * A square with value 0 means you do not have radar jamming coverage.
-	 *
-	 * - do NOT modify or delete the height-map (native code relevant only)
-	 * - index 0 is top left
-	 * - each data position is 8*8 in size
-	 * - the value for the full resolution position (x, z) is at index ((z * width + x) / 8)
-	 * - the last value, bottom right, is at index (width/8 * height/8 - 1)
-	 */
+	/** @see getRadarMap() */
 	int               (CALLING_CONV *Map_getJammerMap)(int skirmishAIId, int* jammerValues, int jammerValues_sizeMax); //$ ARRAY:jammerValues
 
-	/** @see getJammerMap() */
+	/** @see getRadarMap() */
 	int               (CALLING_CONV *Map_getSonarJammerMap)(int skirmishAIId, int* sonarJammerValues, int sonarJammerValues_sizeMax); //$ ARRAY:sonarJammerValues
 
 	/**

--- a/rts/ExternalAI/Interface/SSkirmishAICallback.h
+++ b/rts/ExternalAI/Interface/SSkirmishAICallback.h
@@ -410,12 +410,12 @@ struct SSkirmishAICallback {
 	void              (CALLING_CONV *Game_getCategoryName)(int skirmishAIId, int categoryFlag, char* name, int name_sizeMax);
 
 	/**
-	 * @return float value of parameter if it's set, 0.0 otherwise.
+	 * @return float value of parameter if it's set, defaultValue otherwise.
 	 */
 	float             (CALLING_CONV *Game_getRulesParamFloat)(int skirmishAIId, const char* gameRulesParamName, float defaultValue);
 
 	/**
-	 * @return string value of parameter if it's set, empty string otherwise.
+	 * @return string value of parameter if it's set, defaultValue otherwise.
 	 */
 	const char*       (CALLING_CONV *Game_getRulesParamString)(int skirmishAIId, const char* gameRulesParamName, const char* defaultValue);
 
@@ -1206,12 +1206,12 @@ struct SSkirmishAICallback {
 	int               (CALLING_CONV *Unit_getDef)(int skirmishAIId, int unitId); //$ REF:RETURN->UnitDef
 
 	/**
-	 * @return float value of parameter if it's set, 0.0 otherwise.
+	 * @return float value of parameter if it's set, defaultValue otherwise.
 	 */
 	float             (CALLING_CONV *Unit_getRulesParamFloat)(int skirmishAIId, int unitId, const char* unitRulesParamName, float defaultValue);
 
 	/**
-	 * @return string value of parameter if it's set, empty string otherwise.
+	 * @return string value of parameter if it's set, defaultValue otherwise.
 	 */
 	const char*       (CALLING_CONV *Unit_getRulesParamString)(int skirmishAIId, int unitId, const char* unitRulesParamName, const char* defaultValue);
 
@@ -1352,12 +1352,12 @@ struct SSkirmishAICallback {
 	int               (CALLING_CONV *getAllyTeams)(int skirmishAIId, int* teamIds, int teamIds_sizeMax); //$ FETCHER:MULTI:IDs:Team:teamIds
 
 	/**
-	 * @return float value of parameter if it's set, 0.0 otherwise.
+	 * @return float value of parameter if it's set, defaultValue otherwise.
 	 */
 	float             (CALLING_CONV *Team_getRulesParamFloat)(int skirmishAIId, int teamId, const char* teamRulesParamName, float defaultValue);
 
 	/**
-	 * @return string value of parameter if it's set, empty string otherwise.
+	 * @return string value of parameter if it's set, defaultValue otherwise.
 	 */
 	const char*       (CALLING_CONV *Team_getRulesParamString)(int skirmishAIId, int teamId, const char* teamRulesParamName, const char* defaultValue);
 
@@ -1970,12 +1970,12 @@ struct SSkirmishAICallback {
 	void              (CALLING_CONV *Feature_getPosition)(int skirmishAIId, int featureId, float* return_posF3_out);
 
 	/**
-	 * @return float value of parameter if it's set, 0.0 otherwise.
+	 * @return float value of parameter if it's set, defaultValue otherwise.
 	 */
 	float             (CALLING_CONV *Feature_getRulesParamFloat)(int skirmishAIId, int unitId, const char* featureRulesParamName, float defaultValue);
 
 	/**
-	 * @return string value of parameter if it's set, empty string otherwise.
+	 * @return string value of parameter if it's set, defaultValue otherwise.
 	 */
 	const char*       (CALLING_CONV *Feature_getRulesParamString)(int skirmishAIId, int unitId, const char* featureRulesParamName, const char* defaultValue);
 

--- a/rts/ExternalAI/SSkirmishAICallbackImpl.cpp
+++ b/rts/ExternalAI/SSkirmishAICallbackImpl.cpp
@@ -1928,6 +1928,10 @@ EXPORT(int) skirmishAiCallback_Mod_getAirMipLevel(int skirmishAIId) {
 	return modInfo.airMipLevel;
 }
 
+EXPORT(int) skirmishAiCallback_Mod_getRadarMipLevel(int skirmishAIId) {
+	return modInfo.radarMipLevel;
+}
+
 EXPORT(bool) skirmishAiCallback_Mod_getRequireSonarUnderWater(int skirmishAIId) {
 	return modInfo.requireSonarUnderWater;
 }
@@ -5642,6 +5646,7 @@ static void skirmishAiCallback_init(SSkirmishAICallback* callback) {
 	callback->Mod_getFlankingBonusModeDefault = &skirmishAiCallback_Mod_getFlankingBonusModeDefault;
 	callback->Mod_getLosMipLevel = &skirmishAiCallback_Mod_getLosMipLevel;
 	callback->Mod_getAirMipLevel = &skirmishAiCallback_Mod_getAirMipLevel;
+	callback->Mod_getRadarMipLevel = &skirmishAiCallback_Mod_getRadarMipLevel;
 	callback->Mod_getRequireSonarUnderWater = &skirmishAiCallback_Mod_getRequireSonarUnderWater;
 	callback->Map_getChecksum = &skirmishAiCallback_Map_getChecksum;
 	callback->Map_getStartPos = &skirmishAiCallback_Map_getStartPos;

--- a/rts/ExternalAI/SSkirmishAICallbackImpl.h
+++ b/rts/ExternalAI/SSkirmishAICallbackImpl.h
@@ -893,6 +893,8 @@ EXPORT(int              ) skirmishAiCallback_Mod_getLosMipLevel(int skirmishAIId
 
 EXPORT(int              ) skirmishAiCallback_Mod_getAirMipLevel(int skirmishAIId);
 
+EXPORT(int              ) skirmishAiCallback_Mod_getRadarMipLevel(int skirmishAIId);
+
 EXPORT(bool             ) skirmishAiCallback_Mod_getRequireSonarUnderWater(int skirmishAIId);
 
 // END OBJECT Mod

--- a/rts/Sim/Misc/ModInfo.cpp
+++ b/rts/Sim/Misc/ModInfo.cpp
@@ -249,7 +249,7 @@ void CModInfo::Init(const char* modArchive)
 		}
 
 		if ((radarMipLevel < 0) || (radarMipLevel > 6)) {
-			throw content_error("Sensors\\Los\\LosMipLevel out of bounds. "
+			throw content_error("Sensors\\Los\\RadarMipLevel out of bounds. "
 						"The minimum value is 0. The maximum value is 6.");
 		}
 


### PR DESCRIPTION
According to [ModInfo.cpp](https://github.com/spring/spring/blob/6140fdde868985dbf05ba7d5126e17db5577664c/rts/Sim/Misc/ModInfo.cpp#L244) radarMipLevel is not constant (docstring says it's 8).