### PR TITLE
Circling construction plane fixes

### DIFF
--- a/rts/Sim/MoveTypes/HoverAirMoveType.cpp
+++ b/rts/Sim/MoveTypes/HoverAirMoveType.cpp
@@ -490,10 +490,15 @@ void CHoverAirMoveType::UpdateFlying()
 						if (relPos.x < 0.0001f && relPos.x > -0.0001f)
 							relPos.x = 0.0001f;
 
-						static const CMatrix44f rot(0.0f, math::QUARTERPI, 0.0f);
+						static const CMatrix44f rotCCW(0.0f, math::QUARTERPI, 0.0f);
+						static const CMatrix44f rotCW(0.0f, -math::QUARTERPI, 0.0f);
 
 						// make sure the point is on the circle, go there in a straight line
-						goalPos = circlingPos + (rot.Mul(relPos.Normalize2D()) * goalDistance);
+						if (gsRNG.NextFloat() > 0.5f) {
+							goalPos = circlingPos + (rotCCW.Mul(relPos.Normalize2D()) * goalDistance);
+						} else {
+							goalPos = circlingPos + (rotCW.Mul(relPos.Normalize2D()) * goalDistance);
+						}
 					}
 					waitCounter = 0;
 				}

--- a/rts/Sim/Units/CommandAI/BuilderCAI.cpp
+++ b/rts/Sim/Units/CommandAI/BuilderCAI.cpp
@@ -311,7 +311,7 @@ bool CBuilderCAI::MoveInBuildRange(const float3& objPos, float objRadius, const 
 	}
 
 	if (owner->unitDef->IsAirUnit()) {
-		StopMoveAndKeepPointing(objPos, objRadius, false);
+		StopMoveAndKeepPointing(objPos, GetBuildRange(objRadius) * 0.9f, false);
 	} else {
 		StopMoveAndKeepPointing(owner->moveType->goalPos, GetBuildRange(objRadius) * 0.9f, false);
 	}


### PR DESCRIPTION
Aircons in Phoenix Annihilation (see https://github.com/CommanderSpice/Phoenix-Annihilation) have collision disabled.
They don't do proper circling without the modification in BuilderCAI.cpp. Instead they just clump together above the unit beeing build.

The other Modification randomizes the circling direction, so they kind of distribute.
The distribution looks like a circle when collision is disabled. With collision they use a spherical formation.