### PR TITLE
Fix floater tag assignment

### DIFF
--- a/rts/Sim/Units/UnitDef.cpp
+++ b/rts/Sim/Units/UnitDef.cpp
@@ -523,7 +523,6 @@ UnitDef::UnitDef(const LuaTable& udTable, const std::string& unitName, int id)
 
 		if (moveDef == nullptr) {
 			upright           |= !canfly;
-			floatOnWater      |= udTable.GetBool("floater", udTable.KeyExists("WaterLine"));
 
 			// we have no MoveDef, so pathType == -1 and IsAirUnit() MIGHT be true
 			cantBeTransported |= (!modInfo.transportAir && canfly);
@@ -537,6 +536,7 @@ UnitDef::UnitDef(const LuaTable& udTable, const std::string& unitName, int id)
 			cantBeTransported |= (!modInfo.transportShip   && moveDef->speedModClass == MoveDef::Ship );
 			cantBeTransported |= (!modInfo.transportHover  && moveDef->speedModClass == MoveDef::Hover);
 		}
+		floatOnWater          |= udTable.GetBool("floater", udTable.KeyExists("WaterLine"));
 
 		if (seismicSignature == -1.0f) {
 			const bool isTank = (moveDef != NULL && moveDef->speedModClass == MoveDef::Tank);


### PR DESCRIPTION
Despite having "floater=true" in [luaDef](https://github.com/ZeroK-RTS/Zero-K/blob/master/units/shipaa.lua#L35) AI API UnitDef::IsFloater() returns false, which means floatOnWater was not properly set.
[old behaviour](https://github.com/spring/spring/blob/af1edb128b06fd32c50a767f48a7ca6b58450ae2/rts/Sim/Units/UnitDef.cpp#L534)
[new broken behaviour](https://github.com/spring/spring/blob/develop/rts/Sim/Units/UnitDef.cpp#L533)
I didn't find a trace of MoveCtrl.SetMoveDef in ZK.

I don't know how to properly fix it, but this PR works for me.