### PR TITLE
Fix a constant - nlc

### DIFF
--- a/rts/Sim/Weapons/Weapon.cpp
+++ b/rts/Sim/Weapons/Weapon.cpp
@@ -343,7 +343,7 @@ void CWeapon::ReAimWeapon()
 
 	// check max FireAngle
 	reAim |= (wantedDir.dot(lastRequestedDir) <= weaponDef->maxFireAngle);
-	reAim |= (wantedDir.dot(lastRequestedDir) <= math::cos(20.f));
+	reAim |= (wantedDir.dot(lastRequestedDir) <= math::cos(20.f * math::DEG_TO_RAD));
 
 	//note: angleGood checks unit/maindir, not the weapon's current aim dir!!!
 	//reAim |= (!angleGood);


### PR DESCRIPTION
Was supposed to be 20 degrees but is 20 radians.
20 radians is 3*360 + 20 degrees (!) so logic doesn't change but this prevents failures if someone changes the value.

Relatedly, this whole check might be pointless because there's already the weaponDef->maxFireAngle check and that tag also defaults to 20 degrees.