### PR TITLE
Lasercannon: allow direction change

### DIFF
--- a/rts/Sim/Projectiles/WeaponProjectiles/LaserProjectile.cpp
+++ b/rts/Sim/Projectiles/WeaponProjectiles/LaserProjectile.cpp
@@ -42,7 +42,6 @@ CLaserProjectile::CLaserProjectile(const ProjectileParams& params): CWeaponProje
 {
 	projectileType = WEAPON_LASER_PROJECTILE;
 
-	// FIXME: constant, assumes |speed| never changes after creation
 	speedf = speed.w;
 
 	if (weaponDef != NULL) {
@@ -131,7 +130,7 @@ void CLaserProjectile::UpdatePos(const float4& oldSpeed) {
 	UpdateGroundBounce();
 
 	if (oldSpeed != speed) {
-		SetVelocityAndSpeed(speed);
+		speedf = speed.w;
 	}
 }
 


### PR DESCRIPTION
The most important use case is allowing ground bounces (currently it keeps grinding against the ground even if set to bounce)