### PR TITLE
Nanoframes:

### DIFF
--- a/rts/Net/NetCommands.cpp
+++ b/rts/Net/NetCommands.cpp
@@ -902,8 +902,6 @@ void CGame::ClientReadNet()
 
 						if (unit->isDead)
 							continue;
-						if (unit->beingBuilt)
-							continue;
 						if (unit->IsCrashing())
 							continue;
 

--- a/rts/Sim/Units/UnitTypes/Factory.cpp
+++ b/rts/Sim/Units/UnitTypes/Factory.cpp
@@ -473,8 +473,13 @@ void CFactory::AssignBuildeeOrders(CUnit* unit) {
 
 bool CFactory::ChangeTeam(int newTeam, ChangeType type)
 {
-	StopBuild();
-	return (CBuilding::ChangeTeam(newTeam, type));
+	if (!CBuilding::ChangeTeam(newTeam, type))
+		return false;
+
+	if (curBuild)
+		curBuild->ChangeTeam(newTeam, type);
+
+	return true;
 }
 
 


### PR DESCRIPTION
 * if a factory changes team, move its buildee to that team as well
   instead of removing it from queue
 * allow to manually share nanoframes