### PR TITLE
[AI] Only istream gets reset, not ostream. Safe aiSize for CregLoadSave

### DIFF
--- a/rts/System/LoadSave/CregLoadSaveHandler.cpp
+++ b/rts/System/LoadSave/CregLoadSaveHandler.cpp
@@ -148,13 +148,11 @@ void CCregLoadSaveHandler::SaveGame(const std::string& path)
 			// save AI state
 			const int aiStart = oss.tellp();
 
-			// reset by each Save() call
-			std::stringstream aiData;
-
 			for (const auto& ai: skirmishAIHandler.GetAllSkirmishAIs()) {
+				std::stringstream aiData;
 				eoh->Save(&aiData, ai.first);
 
-				oss << (std::streamsize) aiData.tellp();
+				oss << (std::streamsize) aiData.tellp() << '\n';
 				oss << aiData.rdbuf();
 			}
 			PrintSize("AIs", ((int)oss.tellp()) - aiStart);
@@ -251,6 +249,7 @@ void CCregLoadSaveHandler::LoadGame()
 	for (const auto& ai: skirmishAIHandler.GetAllSkirmishAIs()) {
 		std::streamsize aiSize;
 		*iss >> aiSize;
+		iss->seekg(iss->tellg() + std::streampos(sizeof('\n')));  // skip '\n' delimiter
 		std::vector<char> buffer(aiSize);
 		iss->read(&buffer[0], buffer.size());
 		std::stringstream aiData;

--- a/rts/System/LoadSave/CregLoadSaveHandler.cpp
+++ b/rts/System/LoadSave/CregLoadSaveHandler.cpp
@@ -251,9 +251,9 @@ void CCregLoadSaveHandler::LoadGame()
 		inputStream.SerializeInt(&aiSize, sizeof(aiSize));
 
 		std::vector<char> buffer(aiSize);
-		iss->read(&buffer[0], buffer.size());
 		std::stringstream aiData;
-		aiData.write(&buffer[0], buffer.size());
+		iss->read(buffer.data(), buffer.size());
+		aiData.write(buffer.data(), buffer.size());
 
 		eoh->Load(&aiData, ai.first);
 	}

--- a/rts/System/LoadSave/LuaLoadSaveHandler.cpp
+++ b/rts/System/LoadSave/LuaLoadSaveHandler.cpp
@@ -121,10 +121,8 @@ void CLuaLoadSaveHandler::SaveGameStartInfo()
 
 void CLuaLoadSaveHandler::SaveAIData()
 {
-	// reset by each Save() call
-	std::stringstream aiData;
-
 	for (const auto& ai: skirmishAIHandler.GetAllSkirmishAIs()) {
+		std::stringstream aiData;
 		eoh->Save(&aiData, ai.first);
 
 		const std::string aiSection = FILE_AIDATA + IntToString(ai.first, ".%i");


### PR DESCRIPTION
ostream is an output, it doesn't seem logical to reset output in streamCopy (SkirmishAIWrapper.cpp)

Actually resetting istream after each AI started to use own load-stream is actually pointless with current usage. But still streamCopy, if it's really "copy", shouldn't change input in theory.

Edit: I should have probably mention earlier that this is not an enhancement, but a bug fix.
Currently each subsequent AI saves all previous data plus its own. Save/Load is broken.