### PR TITLE
make sure there is no nanoframe left when a factory is destructed

### DIFF
--- a/rts/Sim/Units/UnitTypes/Factory.cpp
+++ b/rts/Sim/Units/UnitTypes/Factory.cpp
@@ -52,15 +52,6 @@ CFactory::CFactory():
 {
 }
 
-CFactory::~CFactory() {
-	// there is a race condition that allows StartBuild to create a nanoframe
-	// after KillUnit has cleared curBuild. that nanoframe is destroyed here.
-	if (curBuild != nullptr) {
-		curBuild->KillUnit(nullptr, false, true);
-		curBuild = nullptr;
-	}
-}
-
 void CFactory::KillUnit(CUnit* attacker, bool selfDestruct, bool reclaimed, bool showDeathSequence)
 {
 	if (curBuild != nullptr) {

--- a/rts/Sim/Units/UnitTypes/Factory.cpp
+++ b/rts/Sim/Units/UnitTypes/Factory.cpp
@@ -52,6 +52,15 @@ CFactory::CFactory():
 {
 }
 
+CFactory::~CFactory() {
+	// there is a race condition that allows StartBuild to create a nanoframe
+	// after KillUnit has cleared curBuild. that nanoframe is destroyed here.
+	if (curBuild != nullptr) {
+		curBuild->KillUnit(nullptr, false, true);
+		curBuild = nullptr;
+	}
+}
+
 void CFactory::KillUnit(CUnit* attacker, bool selfDestruct, bool reclaimed, bool showDeathSequence)
 {
 	if (curBuild != nullptr) {

--- a/rts/Sim/Units/UnitTypes/Factory.cpp
+++ b/rts/Sim/Units/UnitTypes/Factory.cpp
@@ -155,9 +155,8 @@ void CFactory::SlowUpdate(void)
 
 
 void CFactory::StartBuild(const UnitDef* buildeeDef) {
-	if (isDead) {
+	if (isDead)
 		return;
-	}
 
 	const float3& buildPos = CalcBuildPos();
 	const bool blocked = groundBlockingObjectMap->GroundBlocked(buildPos, this);

--- a/rts/Sim/Units/UnitTypes/Factory.cpp
+++ b/rts/Sim/Units/UnitTypes/Factory.cpp
@@ -155,6 +155,10 @@ void CFactory::SlowUpdate(void)
 
 
 void CFactory::StartBuild(const UnitDef* buildeeDef) {
+	if (isDead) {
+		return;
+	}
+
 	const float3& buildPos = CalcBuildPos();
 	const bool blocked = groundBlockingObjectMap->GroundBlocked(buildPos, this);
 

--- a/rts/Sim/Units/UnitTypes/Factory.h
+++ b/rts/Sim/Units/UnitTypes/Factory.h
@@ -18,6 +18,7 @@ public:
 	CR_DECLARE(CFactory)
 
 	CFactory();
+	~CFactory();
 
 	void StartBuild(const UnitDef* buildeeDef);
 	void UpdateBuild(CUnit* buildee);

--- a/rts/Sim/Units/UnitTypes/Factory.h
+++ b/rts/Sim/Units/UnitTypes/Factory.h
@@ -18,7 +18,6 @@ public:
 	CR_DECLARE(CFactory)
 
 	CFactory();
-	~CFactory();
 
 	void StartBuild(const UnitDef* buildeeDef);
 	void UpdateBuild(CUnit* buildee);


### PR DESCRIPTION
This fixes units being built without a factory.