### PR TITLE
Disallow building dead units

### DIFF
--- a/rts/Sim/Units/Unit.cpp
+++ b/rts/Sim/Units/Unit.cpp
@@ -1919,6 +1919,9 @@ bool CUnit::SetGroup(CGroup* newGroup, bool fromFactory, bool autoSelect)
 
 bool CUnit::AddBuildPower(CUnit* builder, float amount)
 {
+	if (isDead || IsCrashing())
+		return false;
+
 	// stop decaying on building AND reclaim
 	lastNanoAdd = gs->frameNum;
 
@@ -1991,9 +1994,6 @@ bool CUnit::AddBuildPower(CUnit* builder, float amount)
 		}
 	} else {
 		// reclaim
-		if (isDead || IsCrashing())
-			return false;
-
 		if (!AllowedReclaim(builder)) {
 			builder->DependentDied(this);
 			return false;


### PR DESCRIPTION
To prevent the case where UnitFinished happens after UnitDestroyed.