### PR TITLE
GetGrass: false/true bool instead of 0/1 int

### DIFF
--- a/rts/Lua/LuaSyncedRead.cpp
+++ b/rts/Lua/LuaSyncedRead.cpp
@@ -5060,7 +5060,7 @@ int LuaSyncedRead::GetTerrainTypeData(lua_State* L)
 int LuaSyncedRead::GetGrass(lua_State* L)
 {
 	const float3 pos(luaL_checkfloat(L, 1), 0.0f, luaL_checkfloat(L, 2));
-	lua_pushnumber(L, grassDrawer->GetGrass(pos.cClampInBounds()));
+	lua_pushboolean(L, grassDrawer->GetGrass(pos.cClampInBounds()));
 	return 1;
 }
 


### PR DESCRIPTION
0 and 1 are both true in Lua which makes 0/1 annoying.