### PR TITLE
Fix whitespaces and newlines in tooltips text

### DIFF
--- a/AI/Skirmish/AAI/data/cfg/mod/TA.cfg
+++ b/AI/Skirmish/AAI/data/cfg/mod/TA.cfg
@@ -1,0 +1,38 @@
+SIDES 3
+START_UNITS ARMCOM CORCOM TLLCOM
+SIDE_NAMES Arm Core Tll
+MAX_SCOUTS 6
+MAX_BUILDERS 50
+MAX_BUILDERS_PER_TYPE 5
+MAX_FACTORIES_PER_TYPE 3
+MAX_GROUP_SIZE 20
+MAX_AIR_GROUP_SIZE 4
+MAX_XROW 8
+MAX_YROW 8
+X_SPACE 16
+Y_SPACE 16
+MAX_BASE_SIZE 18
+
+HIGH_RANGE_UNITS_RATE 4
+AIRCRAFT_RATE 4
+
+SCOUT_SPEED 120.0
+SEA_ARTY_RANGE 1300.0
+STATIONARY_ARTY_RANGE 3210.0
+MAX_STAT_ARTY 3
+
+MIN_ENERGY 18
+
+MAX_METAL_COST 8000
+MAX_DEFENCES 14
+METAL_ENERGY_RATIO 25
+MAX_METAL_MAKERS 15
+MAX_MEX_DISTANCE 8
+MAX_MEX_DEFENCE_DISTANCE 7
+
+NON_AMPHIB_MAX_WATERDEPTH 22
+
+SCOUTS 20 corfav armfav armpeep corfink armawac corawac armflea armfast armsh corsh corpt armpt armspy corspy tllbug tllgladius tllprob tllrsplane tllhoverlight tllotter
+DONT_BUILD 12 aafus cafus armmlv cormlv armfmine3 armmine1 armmine2 armmine3 corfmine3 cormine1 cormine2 cormine3
+TRANSPORTERS 8 corthovr armthovr corvalk armatlas armsl armdfly cortship armtship
+METAL_MAKERS 23 armgen tllgen corgen armmakr armfmkr ametalmakerlvl1 armamaker armckmakr armmmkr armuwmmm ametalmakerlvl2 cormakr corfmkr cmetalmakerlvl1 coramaker corhmakr cormmkr coruwmmm cmetalmakerlvl2 tllmm tllwmconv tllammaker tllwmmohoconv

--- a/rts/Sim/Units/CommandAI/BuilderCAI.cpp
+++ b/rts/Sim/Units/CommandAI/BuilderCAI.cpp
@@ -137,7 +137,7 @@ CBuilderCAI::CBuilderCAI(CUnit* owner):
 
 		c.action    = "reclaim";
 		c.name      = "Reclaim";
-		c.tooltip   = c.name + ": Sucks in the metal/energy content of a unit/feature and add it to your storage";
+		c.tooltip   = c.name + ": Sucks in the metal/energy content of a unit/feature\nand add it to your storage";
 		c.mouseicon = c.name;
 		possibleCommands.push_back(commandDescriptionCache->GetPtr(c));
 	}

--- a/rts/Sim/Units/CommandAI/CommandAI.cpp
+++ b/rts/Sim/Units/CommandAI/CommandAI.cpp
@@ -249,7 +249,7 @@ CCommandAI::CCommandAI(CUnit* owner):
 
 		c.action    = "firestate";
 		c.name      = "Fire state";
-		c.tooltip   = c.name + ": Sets under what conditions an\n unit will start to fire at enemy units\n without an explicit attack order";
+		c.tooltip   = c.name + ": Sets under what conditions an\nunit will start to fire at enemy units\nwithout an explicit attack order";
 		c.mouseicon = c.name;
 
 		c.params.push_back(IntToString(FIRESTATE_FIREATWILL));
@@ -270,7 +270,7 @@ CCommandAI::CCommandAI(CUnit* owner):
 
 		c.action    = "movestate";
 		c.name      = "Move state";
-		c.tooltip   = c.name + ": Sets how far out of its way\n an unit will move to attack enemies";
+		c.tooltip   = c.name + ": Sets how far out of its way\nan unit will move to attack enemies";
 		c.mouseicon = c.name;
 
 		c.params.push_back(IntToString(MOVESTATE_MANEUVER));
@@ -293,7 +293,7 @@ CCommandAI::CCommandAI(CUnit* owner):
 
 		c.action    = "repeat";
 		c.name      = "Repeat";
-		c.tooltip   = c.name + ": If on, the unit will continuously\n push finished orders to the end of its\n order queue";
+		c.tooltip   = c.name + ": If on, the unit will continuously\npush finished orders to the end of its\norder queue";
 		c.mouseicon = c.name;
 
 		c.params.push_back("0");
@@ -313,7 +313,7 @@ CCommandAI::CCommandAI(CUnit* owner):
 
 		c.action    = "trajectory";
 		c.name      = "Trajectory";
-		c.tooltip   = c.name + ": If set to high, weapons that\n support it will try to fire in a higher\n trajectory than usual (experimental)";
+		c.tooltip   = c.name + ": If set to high, weapons that\nsupport it will try to fire in a higher\ntrajectory than usual (experimental)";
 		c.mouseicon = c.name;
 
 		c.params.push_back("0");


### PR DESCRIPTION
Fix whitespace after newline in tooltips text for Fire state, Move state, Repeat and Trajectory.
Add newline to tooltips text for reclaim command.