### PR TITLE
DefaultCommand call-in:

### DIFF
--- a/cont/base/springcontent/LuaGadgets/gadgets.lua
+++ b/cont/base/springcontent/LuaGadgets/gadgets.lua
@@ -1707,9 +1707,9 @@ function gadgetHandler:Update()
 end
 
 
-function gadgetHandler:DefaultCommand(type, id)
+function gadgetHandler:DefaultCommand(type, id, cmd)
   for _,g in r_ipairs(self.DefaultCommandList) do
-    local id = g:DefaultCommand(type, id)
+    local id = g:DefaultCommand(type, id, cmd)
     if (id) then
       return id
     end

--- a/doc/changelog.txt
+++ b/doc/changelog.txt
@@ -18,6 +18,14 @@ Lua:
  ! return the terrain-type index from Spring.GetGroundInfo and Spring.GetTerrainTypeData
    these functions now push [number index, string name, ...] rather than [string name, ...]
    onto the stack
+ ! change DefaultCommand call order
+    previously widgets were called first, and if they returned anything, gadgets weren't called at all
+    now gadgets are called first, then widgets are always called and can override
+ - add a 3rd param to DefaultCommand callin: the current default command
+    works with the above: gadgets receive the default engine cmd,
+    widgets then receive what gadgets returned (possibly engine default)
+ - add Spring.GetGlobalLos(allyTeamID) -> bool to LuaSyncedRead
+ - add Spring.IsNoCostEnabled() -> bool to LuaSyncedRead
  - add Spring.GetLuaMemUsage to LuaUnsyncedRead
    returns the number of (kilo-)bytes used and (kilo-)allocations performed
    by the calling Lua state individually, as well as by all states globally
@@ -51,6 +59,7 @@ Misc:
  - change PitchAdjust config-setting from a boolean to an integer
    0 disables, 1 scales pitch by the square root of game speed, 2
    scales linearly with game speed
+ - `/nocost` now accepts 0/1 parameter (still toggles if none given)
 
 Fixes:
  - fix #5803 (move goals cancelled when issued onto blocked terrain)

--- a/rts/Game/SelectedUnitsHandler.cpp
+++ b/rts/Game/SelectedUnitsHandler.cpp
@@ -765,11 +765,6 @@ static inline bool IsBetterLeader(const UnitDef* newDef, const UnitDef* oldDef)
 // LuaUnsyncedRead::GetDefaultCommand --> CGuiHandler::GetDefaultCommand --> GetDefaultCmd
 int CSelectedUnitsHandler::GetDefaultCmd(const CUnit* unit, const CFeature* feature)
 {
-	int luaCmd;
-	if (eventHandler.DefaultCommand(unit, feature, luaCmd)) {
-		return luaCmd;
-	}
-
 	// return the default if there are no units selected
 	if (selectedUnits.empty())
 		return CMD_STOP;
@@ -799,7 +794,9 @@ int CSelectedUnitsHandler::GetDefaultCmd(const CUnit* unit, const CFeature* feat
 		leaderUnit = testUnit;
 	}
 
-	return (leaderUnit->commandAI->GetDefaultCmd(unit, feature));
+	int cmd = leaderUnit->commandAI->GetDefaultCmd(unit, feature);
+	eventHandler.DefaultCommand(unit, feature, cmd);
+	return cmd;
 }
 
 

--- a/rts/Lua/LuaHandle.cpp
+++ b/rts/Lua/LuaHandle.cpp
@@ -1676,22 +1676,25 @@ bool CLuaHandle::DefaultCommand(const CUnit* unit,
                                 const CFeature* feature, int& cmd)
 {
 	LUA_CALL_IN_CHECK(L, false);
-	luaL_checkstack(L, 4, __func__);
+	luaL_checkstack(L, 5, __func__);
 	static const LuaHashString cmdStr(__func__);
 	if (!cmdStr.GetGlobalFunc(L))
 		return false;
 
-	int args = 0;
 	if (unit) {
 		HSTR_PUSH(L, "unit");
 		lua_pushnumber(L, unit->id);
-		args = 2;
 	}
 	else if (feature) {
 		HSTR_PUSH(L, "feature");
 		lua_pushnumber(L, feature->id);
-		args = 2;
 	}
+	else {
+		lua_pushnil(L);
+		lua_pushnil(L);
+	}
+	lua_pushnumber(L, cmd);
+
 /* FIXME
 	else if (groundPos) {
 		HSTR_PUSH(L, "ground");
@@ -1707,10 +1710,10 @@ bool CLuaHandle::DefaultCommand(const CUnit* unit,
 */
 
 	// call the routine
-	if (!RunCallIn(L, cmdStr, args, 1))
+	if (!RunCallIn(L, cmdStr, 3, 1))
 		return false;
 
-	if (!lua_isnumber(L, 1)) {
+	if (!lua_isnumber(L, -1)) {
 		lua_pop(L, 1);
 		return false;
 	}

--- a/rts/System/EventHandler.h
+++ b/rts/System/EventHandler.h
@@ -703,12 +703,10 @@ inline bool CEventHandler::DefaultCommand(const CUnit* unit,
 {
 	const size_t count = listDefaultCommand.size();
 
-	// reverse order, user has the override
 	for (size_t i = 0; i < count; i++) {
-		CEventClient* ec = listDefaultCommand[count - 1 - i];
+		CEventClient* ec = listDefaultCommand[i];
 
-		if (ec->DefaultCommand(unit, feature, cmd))
-			return true;
+		ec->DefaultCommand(unit, feature, cmd);
 	}
 
 	return false;


### PR DESCRIPTION
Previously:
 * widgets run the callin "blind" (they dont know what the engine command would be)
 * unsynced gadgets are run only if widgets dont return anything (they implicitly know widgets didnt override but dont know the engine command either)

Now:
 * unsynced gadgets are run first, they receive the engine default cmd as 3rd param
 * widgets are then run and receive current default (taking into account what gadgets said)