### PR TITLE
remove reference to moved object

### DIFF
--- a/rts/Rendering/Models/IModelParser.cpp
+++ b/rts/Rendering/Models/IModelParser.cpp
@@ -261,14 +261,14 @@ S3DModel* CModelLoader::CreateModel(
 		CreateLists(&model);
 
 	// add (parsed or dummy) model to cache
-	model.id = models.size();
+	const size_t new_index = models.size();
 
-	cache[name] = model.id;
-	cache[path] = model.id;
+	model.id = new_index;
+	cache[name] = new_index;
+	cache[path] = new_index;
 
-	models.emplace_back();
-	models.back() = std::move(model);
-	return &models[model.id];
+	models.emplace_back(std::move(model));
+	return &models[new_index];
 }
 
 


### PR DESCRIPTION
Object _model_ is first moved out, but after that we reference to its member _id_ which **should** be in unspecified state. Fortunately move assignment did not apply move to all of its members. I left _explicit moves_ as they were before, as this is deserves separate discussion.