### PR TITLE
Remove movedef refcounts

### DIFF
--- a/cont/base/springcontent/gamedata/defs.lua
+++ b/cont/base/springcontent/gamedata/defs.lua
@@ -41,6 +41,8 @@ Spring.TimeCheck('[defs.lua] loading all *Defs tables:', function()
   DEFS.weaponDefs  = LoadDefs('weaponDefs')
   DEFS.armorDefs   = LoadDefs('armorDefs')
   DEFS.moveDefs    = LoadDefs('moveDefs')
+
+  LoadDefs('defs_post') -- misc cross-def postprocessing
 end)
 
 

--- a/cont/base/springcontent/gamedata/defs_post.lua
+++ b/cont/base/springcontent/gamedata/defs_post.lua
@@ -1,0 +1,22 @@
+-- filter out unused movedefs
+
+local usedMovedefs = {}
+for name, def in pairs (DEFS.unitDefs) do
+	local movedef = def.movementclass
+	if movedef then
+		usedMovedefs[movedef] = true
+	end
+end
+
+local i = 1
+while i <= #DEFS.moveDefs do
+	if not usedMovedefs[DEFS.moveDefs[i].name] then
+		DEFS.moveDefs[i] = DEFS.moveDefs[#DEFS.moveDefs]
+		DEFS.moveDefs[#DEFS.moveDefs] = nil
+	else
+		i = i + 1
+	end
+end
+
+return {}
+

--- a/cont/base/springcontent/gamedata/defs_post.lua
+++ b/cont/base/springcontent/gamedata/defs_post.lua
@@ -10,7 +10,7 @@ end
 
 local i = 1
 while i <= #DEFS.moveDefs do
-	if not usedMovedefs[DEFS.moveDefs[i].name] then
+	if not usedMovedefs[DEFS.moveDefs[i].name] and not DEFS.moveDefs[i].dont_remove then
 		DEFS.moveDefs[i] = DEFS.moveDefs[#DEFS.moveDefs]
 		DEFS.moveDefs[#DEFS.moveDefs] = nil
 	else

--- a/doc/changelog.txt
+++ b/doc/changelog.txt
@@ -70,6 +70,11 @@ Misc:
    0 disables, 1 scales pitch by the square root of game speed, 2
    scales linearly with game speed
  - `/nocost` now accepts 0/1 parameter (still toggles if none given)
+ - default `defs.lua` now reads a new file, `defs_post.lua`, which
+   currently filters out movedefs unused by any unitdef (previously
+   this was done by the engine). You can prevent this filter by adding
+   the `dont_remove` field to such movedefs. This is useful to make
+   them available in `Spring.MoveCtrl.SetMoveDef` but beware the perf cost.
 
 Fixes:
  - fix infinite backtracking loop in PFS

--- a/rts/Lua/LuaSyncedMoveCtrl.cpp
+++ b/rts/Lua/LuaSyncedMoveCtrl.cpp
@@ -621,14 +621,6 @@ int LuaSyncedMoveCtrl::SetMoveDef(lua_State* L)
 		return 1;
 	}
 
-	if (moveDef->udRefCount == 0) {
-		// pathfinders contain optimizations that
-		// make unreferenced movedef's non-usable
-		LOG_L(L_ERROR, "SetMoveDef: Tried to use an unreferenced (:=disabled) MoveDef!");
-		lua_pushboolean(L, false);
-		return 1;
-	}
-
 	// PFS might have cached data by path-type which must be cleared
 	if (unit->UsingScriptMoveType()) {
 		unit->prevMoveType->StopMoving();

--- a/rts/Sim/MoveTypes/MoveDefHandler.cpp
+++ b/rts/Sim/MoveTypes/MoveDefHandler.cpp
@@ -33,7 +33,6 @@ CR_REG_METADATA(MoveDef, (
 	CR_MEMBER(speedModMults),
 
 	CR_MEMBER(pathType),
-	CR_MEMBER(udRefCount),
 
 	CR_MEMBER(followGround),
 	CR_MEMBER(subMarine),
@@ -167,7 +166,6 @@ MoveDef::MoveDef()
 	, crushStrength(0.0f)
 
 	, pathType(0)
-	, udRefCount(0)
 
 	, heatMod(0.05f)
 	, flowMod(1.0f)

--- a/rts/Sim/MoveTypes/MoveDefHandler.h
+++ b/rts/Sim/MoveTypes/MoveDefHandler.h
@@ -108,8 +108,6 @@ struct MoveDef {
 	float speedModMults[SPEEDMOD_MOBILE_NUM_MULTS + 1];
 
 	unsigned int pathType;
-	/// number of UnitDef types that refer to this MoveDef class
-	unsigned int udRefCount;
 
 	/// heatmap path-cost modifier
 	float heatMod;

--- a/rts/Sim/Path/Default/PathConstants.h
+++ b/rts/Sim/Path/Default/PathConstants.h
@@ -26,7 +26,7 @@ static const float MEDRES_SEARCH_DISTANCE_EXT = (MEDRES_SEARCH_DISTANCE * 0.4f) 
 // how many recursive refinement attempts NextWayPoint should make
 static constexpr unsigned int MAX_PATH_REFINEMENT_DEPTH = 4;
 
-static constexpr unsigned int PATHESTIMATOR_VERSION = 88;
+static constexpr unsigned int PATHESTIMATOR_VERSION = 89;
 
 static constexpr unsigned int MEDRES_PE_BLOCKSIZE = 16;
 static constexpr unsigned int LOWRES_PE_BLOCKSIZE = 32;

--- a/rts/Sim/Path/Default/PathEstimator.cpp
+++ b/rts/Sim/Path/Default/PathEstimator.cpp
@@ -98,9 +98,6 @@ CPathEstimator::CPathEstimator(IPathFinder* pf, unsigned int BLOCK_SIZE, const s
 		for_mt(0, moveDefHandler->GetNumMoveDefs(), [&](unsigned int i) {
 			const MoveDef* md = moveDefHandler->GetMoveDefByPathType(i);
 
-			if (md->udRefCount == 0)
-				return;
-
 			for (int y = 0; y < mapDims.mapy; y++) {
 				for (int x = 0; x < mapDims.mapx; x++) {
 					childPE->maxSpeedMods[i] = std::max(childPE->maxSpeedMods[i], CMoveMath::GetPosSpeedMod(*md, x, y));
@@ -256,9 +253,6 @@ void CPathEstimator::CalculateBlockOffsets(unsigned int blockIdx, unsigned int t
 	for (unsigned int i = 0; i < moveDefHandler->GetNumMoveDefs(); i++) {
 		const MoveDef* md = moveDefHandler->GetMoveDefByPathType(i);
 
-		if (md->udRefCount == 0)
-			continue;
-
 		blockStates.peNodeOffsets[md->pathType][blockIdx] = FindBlockPosOffset(*md, blockPos.x, blockPos.y);
 	}
 }
@@ -280,9 +274,6 @@ void CPathEstimator::EstimatePathCosts(unsigned int blockIdx, unsigned int threa
 
 	for (unsigned int i = 0; i < moveDefHandler->GetNumMoveDefs(); i++) {
 		const MoveDef* md = moveDefHandler->GetMoveDefByPathType(i);
-
-		if (md->udRefCount == 0)
-			continue;
 
 		CalcVertexPathCosts(*md, blockPos, threadNum);
 	}
@@ -521,9 +512,6 @@ void CPathEstimator::Update()
 		// issue repathing for all active movedefs
 		for (unsigned int i = 0; i < numMoveDefs; i++) {
 			const MoveDef* md = moveDefHandler->GetMoveDefByPathType(i);
-
-			if (md->udRefCount == 0)
-				continue;
 
 			consumedBlocks.emplace_back(pos, md);
 		}

--- a/rts/Sim/Path/QTPFS/PathManager.cpp
+++ b/rts/Sim/Path/QTPFS/PathManager.cpp
@@ -212,9 +212,6 @@ void QTPFS::PathManager::Load() {
 		pfsCheckSum = mapCheckSum ^ modCheckSum;
 
 		for (unsigned int layerNum = 0; layerNum < nodeLayers.size(); layerNum++) {
-			if (moveDefHandler->GetMoveDefByPathType(layerNum)->udRefCount == 0)
-				continue;
-
 			#ifndef QTPFS_CONSERVATIVE_NEIGHBOR_CACHE_UPDATES
 			if (haveCacheDir) {
 				// if cache-dir exists, must set node relations after de-serializing its trees
@@ -362,9 +359,6 @@ void QTPFS::PathManager::InitNodeLayersThread(
 void QTPFS::PathManager::InitNodeLayer(unsigned int layerNum, const SRectangle& r) {
 	nodeTrees[layerNum] = new QTPFS::QTNode(NULL,  0,  r.x1, r.z1,  r.x2, r.z2);
 
-	if (moveDefHandler->GetMoveDefByPathType(layerNum)->udRefCount == 0)
-		return;
-
 	nodeLayers[layerNum].Init(layerNum);
 	nodeLayers[layerNum].RegisterNode(nodeTrees[layerNum]);
 }
@@ -414,8 +408,6 @@ void QTPFS::PathManager::UpdateNodeLayer(unsigned int layerNum, const SRectangle
 
 	if (!IsFinalized())
 		return;
-	if (md->udRefCount == 0)
-		return;
 
 	// NOTE:
 	//     this is needed for IsBlocked* --> SquareIsBlocked --> IsNonBlocking
@@ -458,9 +450,6 @@ void QTPFS::PathManager::UpdateNodeLayer(unsigned int layerNum, const SRectangle
 void QTPFS::PathManager::QueueNodeLayerUpdates(const SRectangle& r) {
 	for (unsigned int layerNum = 0; layerNum < nodeLayers.size(); layerNum++) {
 		const MoveDef* md = moveDefHandler->GetMoveDefByPathType(layerNum);
-
-		if (md->udRefCount == 0)
-			continue;
 
 		SRectangle mr;
 		// SRectangle ur;
@@ -553,9 +542,6 @@ void QTPFS::PathManager::Serialize(const std::string& cacheFileDir) {
 	// TODO: compress the tree cache-files?
 	for (unsigned int i = 0; i < nodeTrees.size(); i++) {
 		const MoveDef* md = moveDefHandler->GetMoveDefByPathType(i);
-
-		if (md->udRefCount == 0)
-			continue;
 
 		fileNames[i] = cacheFileDir + "tree" + IntToString(i, "%02x") + "-" + md->name;
 		fileStreams[i] = new std::fstream();

--- a/rts/Sim/Units/UnitDef.cpp
+++ b/rts/Sim/Units/UnitDef.cpp
@@ -518,7 +518,6 @@ UnitDef::UnitDef(const LuaTable& udTable, const std::string& unitName, int id)
 			if ((moveDef = moveDefHandler->GetMoveDefByName(moveClass)) == nullptr)
 				throw content_error(errMsg);
 
-			moveDef->udRefCount += 1;
 			this->pathType = moveDef->pathType;
 		}
 


### PR DESCRIPTION
Currently movedefs keep refcounts based on unitdefs that use them. Any movedef that has 0 refs is then skipped when processing. This is bad:
 * you can't use `Spring.MoveCtrl.SetMoveDef` for those movedefs.
 * there's no point keeping such inaccessible movedefs in memory, wasteful.

Ergo:
 * games should be able to explicitly specify which movedefs they are going to use.
 * useless movedefs shouldn't even reach the engine.

This patch removes the refcounts; all movedefs provided by the game will be processed. It is now game's responsibility to say which movedefs it wants. For backward compatibility, the builtin defs parser now filters out unused movedefs.