### PR TITLE
[AI] Reveal captureProgress, buildProgress and paralyzeDamage params.

### DIFF
--- a/doc/changelog.txt
+++ b/doc/changelog.txt
@@ -56,6 +56,10 @@ Lua:
    the `dont_remove` field to such movedefs. This is useful to make
    them available in `Spring.MoveCtrl.SetMoveDef` but beware the perf cost.
 
+AI:
+ - reveal unit's captureProgress, buildProgress and paralyzeDamage params through
+   skirmishAiCallback_Unit_get{CaptureProgress,BuildProgress,ParalyzeDamage} functions
+
 Misc:
  - remove joystick support
  - detect hangs during filesystem initialisation

--- a/rts/ExternalAI/Interface/SSkirmishAICallback.h
+++ b/rts/ExternalAI/Interface/SSkirmishAICallback.h
@@ -1302,6 +1302,12 @@ struct SSkirmishAICallback {
 	/** The unit's current health */
 	float             (CALLING_CONV *Unit_getHealth)(int skirmishAIId, int unitId);
 
+	float             (CALLING_CONV *Unit_getParalyzeDamage)(int skirmishAIId, int unitId);
+
+	float             (CALLING_CONV *Unit_getCaptureProgress)(int skirmishAIId, int unitId);
+
+	float             (CALLING_CONV *Unit_getBuildProgress)(int skirmishAIId, int unitId);
+
 	float             (CALLING_CONV *Unit_getSpeed)(int skirmishAIId, int unitId);
 
 	/**

--- a/rts/ExternalAI/SSkirmishAICallbackImpl.cpp
+++ b/rts/ExternalAI/SSkirmishAICallbackImpl.cpp
@@ -3886,6 +3886,73 @@ EXPORT(float) skirmishAiCallback_Unit_getHealth(int skirmishAIId, int unitId) {
 	return skirmishAIId_callback[skirmishAIId]->GetUnitHealth(unitId);
 }
 
+EXPORT(float) skirmishAiCallback_Unit_getParalyzeDamage(int skirmishAIId, int unitId) {
+	float result = -1.0f;
+
+	const CUnit* unit = getUnit(unitId);
+	if (unit == nullptr)
+		return result;
+
+	if (skirmishAiCallback_Cheats_isEnabled(skirmishAIId))
+		return unit->paralyzeDamage;
+
+	const int teamId = skirmishAIId_teamId[skirmishAIId];
+	const int allyId = teamHandler->AllyTeam(teamId);
+
+	if (teamHandler->Ally(unit->allyteam, allyId)) {
+		result = unit->paralyzeDamage;
+	} else if (unit->losStatus[allyId] & LOS_INLOS) {
+		const UnitDef* unitDef = unit->unitDef;
+		const UnitDef* decoyDef = unitDef->decoyDef;
+
+		if (decoyDef == nullptr) {
+			result = unit->paralyzeDamage;
+		} else {
+			result = unit->paralyzeDamage * (decoyDef->health / unitDef->health);
+		}
+	}
+
+	return result;
+}
+
+EXPORT(float) skirmishAiCallback_Unit_getCaptureProgress(int skirmishAIId, int unitId) {
+	const float fail = -1.0f;
+
+	const CUnit* unit = getUnit(unitId);
+	if (unit == nullptr)
+		return fail;
+
+	if (skirmishAiCallback_Cheats_isEnabled(skirmishAIId))
+		return unit->captureProgress;
+
+	const int teamId = skirmishAIId_teamId[skirmishAIId];
+	const int allyId = teamHandler->AllyTeam(teamId);
+
+	if (teamHandler->Ally(unit->allyteam, allyId) || unit->losStatus[allyId] & LOS_INLOS)
+		return unit->captureProgress;
+
+	return fail;
+}
+
+EXPORT(float) skirmishAiCallback_Unit_getBuildProgress(int skirmishAIId, int unitId) {
+	const float fail = -1.0f;
+
+	const CUnit* unit = getUnit(unitId);
+	if (unit == nullptr)
+		return fail;
+
+	if (skirmishAiCallback_Cheats_isEnabled(skirmishAIId))
+		return unit->buildProgress;
+
+	const int teamId = skirmishAIId_teamId[skirmishAIId];
+	const int allyId = teamHandler->AllyTeam(teamId);
+
+	if (teamHandler->Ally(unit->allyteam, allyId) || unit->losStatus[allyId] & LOS_INLOS)
+		return unit->buildProgress;
+
+	return fail;
+}
+
 EXPORT(float) skirmishAiCallback_Unit_getSpeed(int skirmishAIId, int unitId) {
 	return skirmishAIId_callback[skirmishAIId]->GetUnitSpeed(unitId);
 }
@@ -5582,6 +5649,9 @@ static void skirmishAiCallback_init(SSkirmishAICallback* callback) {
 	callback->Unit_SupportedCommand_isDisabled = &skirmishAiCallback_Unit_SupportedCommand_isDisabled;
 	callback->Unit_SupportedCommand_getParams = &skirmishAiCallback_Unit_SupportedCommand_getParams;
 	callback->Unit_getHealth = &skirmishAiCallback_Unit_getHealth;
+	callback->Unit_getParalyzeDamage = &skirmishAiCallback_Unit_getParalyzeDamage;
+	callback->Unit_getCaptureProgress = &skirmishAiCallback_Unit_getCaptureProgress;
+	callback->Unit_getBuildProgress = &skirmishAiCallback_Unit_getBuildProgress;
 	callback->Unit_getSpeed = &skirmishAiCallback_Unit_getSpeed;
 	callback->Unit_getPower = &skirmishAiCallback_Unit_getPower;
 	callback->Unit_getResourceUse = &skirmishAiCallback_Unit_getResourceUse;

--- a/rts/ExternalAI/SSkirmishAICallbackImpl.h
+++ b/rts/ExternalAI/SSkirmishAICallbackImpl.h
@@ -748,6 +748,12 @@ EXPORT(int              ) skirmishAiCallback_Unit_SupportedCommand_getParams(int
 
 EXPORT(float            ) skirmishAiCallback_Unit_getHealth(int skirmishAIId, int unitId);
 
+EXPORT(float            ) skirmishAiCallback_Unit_getParalyzeDamage(int skirmishAIId, int unitId);
+
+EXPORT(float            ) skirmishAiCallback_Unit_getCaptureProgress(int skirmishAIId, int unitId);
+
+EXPORT(float            ) skirmishAiCallback_Unit_getBuildProgress(int skirmishAIId, int unitId);
+
 EXPORT(float            ) skirmishAiCallback_Unit_getSpeed(int skirmishAIId, int unitId);
 
 EXPORT(float            ) skirmishAiCallback_Unit_getPower(int skirmishAIId, int unitId);


### PR DESCRIPTION
Ability to query captureProgress param should give AI more options to retreat/save its units.

Other params were added by Lua's GetUnitHealth analogy.
