### PR TITLE
Avoid deprecated socket_base::non_blocking_io

### DIFF
--- a/rts/System/Net/UDPListener.cpp
+++ b/rts/System/Net/UDPListener.cpp
@@ -32,8 +32,7 @@ UDPListener::UDPListener(int port, const std::string& ip): acceptNewConnections(
 	const std::string err = TryBindSocket(port, &socket, ip);
 
 	if (err.empty()) {
-		asio::socket_base::non_blocking_io socketCommand(true);
-		socket->io_control(socketCommand);
+		socket->non_blocking(true);
 
 		mySocket = socket;
 		SetAcceptingConnections(true);


### PR DESCRIPTION
http://www.boost.org/doc/libs/1_47_0/doc/html/boost_asio/reference/socket_base/non_blocking_io.html says it was deprecated since boost 1.47 (released 11.7.2011) and we are having trouble building this for @openSUSE Tumbleweed.