### PR TITLE
Put some engine consts in `Engine`

### DIFF
--- a/doc/changelog.txt
+++ b/doc/changelog.txt
@@ -65,6 +65,7 @@ Lua:
    the engine decide, returning false will force the engine to disallow transportation (for this specific call).
  - new unit rules param access level, 'typed': between 'inlos' and 'inradar', applicable when the unit has once been in LoS
    and continuously in radar since (same rule as `GetUnitLosState(x).typed` and typed engine icons)
+ - the `Engine` table contains `gameSpeed` and `squareSize` (same as in `Game`)
 
 
 AI:

--- a/rts/Lua/LuaConstEngine.cpp
+++ b/rts/Lua/LuaConstEngine.cpp
@@ -4,6 +4,7 @@
 #include "LuaHandle.h"
 #include "LuaUtils.h"
 #include "Game/GameVersion.h"
+#include "Sim/Misc/GlobalConstants.h"
 #include "System/Platform/Misc.h"
 
 bool LuaConstEngine::PushEntries(lua_State* L)
@@ -19,6 +20,10 @@ bool LuaConstEngine::PushEntries(lua_State* L)
 	#else
 	LuaPushNamedNumber(L, "wordSize", (!CLuaHandle::GetHandleSynced(L))? Platform::NativeWordSize() * 8: 0);
 	#endif
+
+	LuaPushNamedNumber(L, "gameSpeed",  GAME_SPEED);
+	LuaPushNamedNumber(L, "squareSize", SQUARE_SIZE);
+
 	return true;
 }
 


### PR DESCRIPTION
Currently they live in `Game` but are engine constants out of the game's control.

The practical reason is that I wanted to use `Game.gameSpeed` during `defs.lua` parsing but `Game` is unavailable there, unlike `Engine`.