### PR TITLE
 Drawings callouts: allow to specify playerID

### DIFF
--- a/doc/changelog.txt
+++ b/doc/changelog.txt
@@ -71,6 +71,9 @@ Lua:
    and continuously in radar since (same rule as `GetUnitLosState(x).typed` and typed engine icons)
  - the GiveOrder* family of callouts can now accept a number for command params,
    equivalent to providing an array with one member (use it to save on arrays)
+ - MarkerAdd{Point,Line} now have an extra optional argument (after localOnly: 6th for point, 8th for line):
+   the playerID of the player who should appear as the author of the drawing (if missing, defaults to the local player).
+   Only has an effect when localOnly is true.
 
 
 AI:

--- a/rts/Lua/LuaUnsyncedCtrl.cpp
+++ b/rts/Lua/LuaUnsyncedCtrl.cpp
@@ -2636,7 +2636,7 @@ int LuaUnsyncedCtrl::MarkerAddPoint(lua_State* L)
 	const bool onlyLocal = (lua_isnumber(L, 5)) ? bool(luaL_optnumber(L, 5, 1)) : luaL_optboolean(L, 5, true);
 
 	if (onlyLocal) {
-		inMapDrawerModel->AddPoint(pos, text, gu->myPlayerNum);
+		inMapDrawerModel->AddPoint(pos, text, luaL_optnumber(L, 6, gu->myPlayerNum));
 	} else {
 		inMapDrawer->SendPoint(pos, text, true);
 	}
@@ -2659,7 +2659,7 @@ int LuaUnsyncedCtrl::MarkerAddLine(lua_State* L)
 	const bool onlyLocal = (lua_isnumber(L, 7)) ? bool(luaL_optnumber(L, 7, 0)) : luaL_optboolean(L, 7, false);
 
 	if (onlyLocal) {
-		inMapDrawerModel->AddLine(pos1, pos2, gu->myPlayerNum);
+		inMapDrawerModel->AddLine(pos1, pos2, luaL_optnumber(L, 8, gu->myPlayerNum));
 	} else {
 		inMapDrawer->SendLine(pos1, pos2, true);
 	}


### PR DESCRIPTION
MarkerAdd{Point,Line} now have an extra optional argument (after localOnly: 6th for point, 8th for line) the playerID of the player who should appear as the author of the drawing (if missing, defaults to the local player). Only has an effect when localOnly is true.