### PR TITLE
updated gcc w64 buildbot

### DIFF
--- a/buildbot/master/master.cfg
+++ b/buildbot/master/master.cfg
@@ -727,7 +727,7 @@ windows_builder_x64 = {
 		'OUTPUTDIR' : 'win64',
 		'CMAKEPARAM' :
 				' -DMINGWLIBS:PATH=/home/jtoledano/mingwlibs64'
-				' -DCMAKE_FIND_ROOT_PATH:PATH=/home/jtoledano/mxe/usr/libexec/gcc/x86_64-w64-mingw32.static/4.9.3'
+				' -DCMAKE_FIND_ROOT_PATH:PATH=/home/jtoledano/mxe/usr/libexec/gcc/x86_64-w64-mingw32.static/5.5.0'
 				' -DCMAKE_SYSTEM_NAME:STRING=Windows'
 				' -DUSERDOCS_PLAIN:BOOL=ON'
 				' -DCMAKE_INSTALL_PREFIX:PATH='


### PR DESCRIPTION
updated gcc version on the w64 buildbot to 5.5.0 from 4.9