### PR TITLE
[Fix] Error: reinterpret_cast from integer to pointer

### DIFF
--- a/rts/Rendering/GL/VertexArrayTypes.h
+++ b/rts/Rendering/GL/VertexArrayTypes.h
@@ -77,7 +77,7 @@ static_assert(sizeof(SColor) == sizeof(float), "");
 // #define VA_TYPE_OFFSET(T, n) (static_cast<uint8_t*>(nullptr) + sizeof(T) * (n))
 #define VA_TYPE_OFFSET(T, n) (reinterpret_cast<void*>(sizeof(T) * (n)))
 #else
-#define CONSTQUAL constexpr
+#define CONSTQUAL const
 #define VA_TYPE_OFFSET(T, n) ((const T*)(0) + (n))
 #endif
 


### PR DESCRIPTION
Manjaro Linux
gcc 8.1.0

Apparently, GCC is not able to resolve VA_TYPE_OFFSET expressions as constant ones while compiling rts/aGui/Button.cpp, returning the following errors:

```
rts/Rendering/GL/RenderDataBuffer.hpp:27:3: error: reinterpret_cast from integer to pointer
  }};
   ^
rts/Rendering/GL/RenderDataBuffer.hpp:41:3: error: reinterpret_cast from integer to pointer
  }};
   ^
rts/Rendering/GL/RenderDataBuffer.hpp:47:3: error: reinterpret_cast from integer to pointer
  }};
   ^
rts/Rendering/GL/RenderDataBuffer.hpp:56:3: error: reinterpret_cast from integer to pointer
  }};
   ^
rts/Rendering/GL/RenderDataBuffer.hpp:64:3: error: reinterpret_cast from integer to pointer
  }};
   ^
rts/Rendering/GL/RenderDataBuffer.hpp:73:3: error: reinterpret_cast from integer to pointer
  }};
   ^
rts/Rendering/GL/RenderDataBuffer.hpp:89:3: error: reinterpret_cast from integer to pointer
  }};
   ^
rts/Rendering/GL/RenderDataBuffer.hpp:101:3: error: reinterpret_cast from integer to pointer
  }};
   ^
rts/Rendering/GL/RenderDataBuffer.hpp:114:3: error: reinterpret_cast from integer to pointer
  }};
   ^
rts/Rendering/GL/RenderDataBuffer.hpp:130:3: error: reinterpret_cast from integer to pointer
  }};
   ^
```