### PR TITLE
GetPlayerInfo: restore backward compatibility

### DIFF
--- a/doc/changelog.txt
+++ b/doc/changelog.txt
@@ -15,8 +15,8 @@ Lua:
  - call gadgetHandler:Explosion for unsynced gadgets (but discard the return value)
  - allow specifying source by position but target by ID for Spring.GetUnitWeaponHaveFreeLineOfFire
  - allow setting terrain-type hardness and name via Spring.SetTerrainTypeData
- ! add extra boolean return-value to Spring.GetPlayerInfo between 'rank' (#9) and 'customPlayerKeys' (#11)
-   select(10, Spring.GetPlayerInfo(player)) is now equal to select(4, Spring.GetTeamInfo(player.team))
+ - add extra boolean return-value to Spring.GetPlayerInfo (#11, after 'customPlayerKeys') 
+   select(11, Spring.GetPlayerInfo(player)) is now equal to select(4, Spring.GetTeamInfo(player.team))
  ! return the terrain-type index from Spring.GetGroundInfo and Spring.GetTerrainTypeData
    these functions now push [number index, string name, ...] rather than [string name, ...]
    onto the stack

--- a/rts/Lua/LuaSyncedRead.cpp
+++ b/rts/Lua/LuaSyncedRead.cpp
@@ -1473,8 +1473,6 @@ int LuaSyncedRead::GetPlayerInfo(lua_State* L)
 	lua_pushnumber(L, player->cpuUsage);
 	lua_pushsstring(L, player->countryCode);
 	lua_pushnumber(L, player->rank);
-	// same as select(4, GetTeamInfo(teamID=player->team))
-	lua_pushboolean(L, skirmishAIHandler.HasSkirmishAIsInTeam(player->team));
 
 	const PlayerBase::customOpts& playerOpts = player->GetAllValues();
 
@@ -1485,6 +1483,9 @@ int LuaSyncedRead::GetPlayerInfo(lua_State* L)
 		lua_pushsstring(L, pair.second);
 		lua_rawset(L, -3);
 	}
+
+	// same as select(4, GetTeamInfo(teamID=player->team))
+	lua_pushboolean(L, skirmishAIHandler.HasSkirmishAIsInTeam(player->team));
 
 	return 11;
 }


### PR DESCRIPTION
All code that uses player options was broken. This patch puts them back to 10th spot, putting the new qol thingie as the 11th.