### PR TITLE
Fix to 'invalid parameter array size' GLSL error

### DIFF
--- a/rts/Rendering/GL/LightHandler.h
+++ b/rts/Rendering/GL/LightHandler.h
@@ -28,8 +28,8 @@ namespace GL {
 		static constexpr unsigned int MaxConfigLights()       { return MAX_LIGHTS; }
 		                 unsigned int NumConfigLights() const { return  maxLights; }
 
-		static constexpr unsigned int MaxUniformVecs()       { return (MaxConfigLights() * (sizeof(RawLight) / sizeof(float))); }
-		                 unsigned int NumUniformVecs() const { return (NumConfigLights() * (sizeof(RawLight) / sizeof(float))); }
+		static constexpr unsigned int MaxUniformVecs()       { return (MaxConfigLights() * (sizeof(RawLight) / sizeof(float4))); }
+		                 unsigned int NumUniformVecs() const { return (NumConfigLights() * (sizeof(RawLight) / sizeof(float4))); }
 
 	private:
 		static constexpr unsigned int MAX_LIGHTS = 32;


### PR DESCRIPTION
Apparently SMF render was crashing because the number of vec4 uniforms was not correctly computed