### PR TITLE
Fix GetUnitHealth under recursive AddUnitDamage

### DIFF
--- a/rts/Sim/Units/Unit.cpp
+++ b/rts/Sim/Units/Unit.cpp
@@ -628,10 +628,7 @@ void CUnit::ForcedKillUnit(CUnit* attacker, bool selfDestruct, bool reclaimed, b
 		SetStunned(true);
 
 		paralyzeDamage = 100.0f * maxHealth;
-		health = std::max(health, 0.0f);
 	}
-	#else
-	health = std::max(health, 0.0f);
 	#endif
 }
 

--- a/rts/Sim/Units/Unit.cpp
+++ b/rts/Sim/Units/Unit.cpp
@@ -579,57 +579,40 @@ void CUnit::ForcedKillUnit(CUnit* attacker, bool selfDestruct, bool reclaimed, b
 	blockHeightChanges = false;
 	deathScriptFinished = (!showDeathSequence || reclaimed || beingBuilt);
 
-	if (!deathScriptFinished) {
-		const WeaponDef* wd;
-		const DynDamageArray* d;
-		if (selfDestruct) {
-			wd = unitDef->selfdExpWeaponDef;
-			d = selfdExpDamages;
-		} else {
-			wd = unitDef->deathExpWeaponDef;
-			d = deathExpDamages;
-		}
+	if (deathScriptFinished)
+		return;
 
-		if (wd != nullptr) {
-			assert(d != nullptr);
-			CExplosionParams params = {
-				pos,
-				ZeroVector,
-				*d,
-				wd,
-				this,                                    // owner
-				nullptr,                                 // hitUnit
-				nullptr,                                 // hitFeature
-				d->craterAreaOfEffect,
-				d->damageAreaOfEffect,
-				d->edgeEffectiveness,
-				d->explosionSpeed,
-				(d->GetDefault() > 500.0f)? 1.0f: 2.0f,  // gfxMod
-				false,                                   // impactOnly
-				false,                                   // ignoreOwner
-				true,                                    // damageGround
-				-1u                                      // projectileID
-			};
+	const WeaponDef* wd = selfDestruct? unitDef->selfdExpWeaponDef: unitDef->deathExpWeaponDef;
+	const DynDamageArray* da = selfDestruct? selfdExpDamages: deathExpDamages;
 
-			helper->Explosion(params);
-		}
+	if (wd != nullptr) {
+		assert(da != nullptr);
+		CExplosionParams params = {
+			pos,
+			ZeroVector,
+			*da,
+			wd,
+			this,                                    // owner
+			nullptr,                                 // hitUnit
+			nullptr,                                 // hitFeature
+			d->craterAreaOfEffect,
+			d->damageAreaOfEffect,
+			d->edgeEffectiveness,
+			d->explosionSpeed,
+			(d->GetDefault() > 500.0f)? 1.0f: 2.0f,  // gfxMod
+			false,                                   // impactOnly
+			false,                                   // ignoreOwner
+			true,                                    // damageGround
+			-1u                                      // projectileID
+		};
 
-		recentDamage += (maxHealth * 2.0f * selfDestruct);
-
-		// start running the unit's kill-script
-		script->Killed();
+		helper->Explosion(params);
 	}
 
-	#if 0
-	// put the unit in a pseudo-zombie state until Killed finishes
-	// disabled, better let Lua decide how it wants to handle this
-	if (!deathScriptFinished) {
-		SetVelocity(ZeroVector);
-		SetStunned(true);
+	recentDamage += (maxHealth * 2.0f * selfDestruct);
 
-		paralyzeDamage = 100.0f * maxHealth;
-	}
-	#endif
+	// start running the unit's kill-script
+	script->Killed();
 }
 
 

--- a/rts/Sim/Units/Unit.cpp
+++ b/rts/Sim/Units/Unit.cpp
@@ -595,11 +595,11 @@ void CUnit::ForcedKillUnit(CUnit* attacker, bool selfDestruct, bool reclaimed, b
 			this,                                    // owner
 			nullptr,                                 // hitUnit
 			nullptr,                                 // hitFeature
-			d->craterAreaOfEffect,
-			d->damageAreaOfEffect,
-			d->edgeEffectiveness,
-			d->explosionSpeed,
-			(d->GetDefault() > 500.0f)? 1.0f: 2.0f,  // gfxMod
+			da->craterAreaOfEffect,
+			da->damageAreaOfEffect,
+			da->edgeEffectiveness,
+			da->explosionSpeed,
+			(da->GetDefault() > 500.0f)? 1.0f: 2.0f, // gfxMod
 			false,                                   // impactOnly
 			false,                                   // ignoreOwner
 			true,                                    // damageGround


### PR DESCRIPTION
Reproduction: kill a unit using any form of damage with the following code on and observe how expected != actual.

```lua
local WEAPON_ID = -Game.envDamageTypes.Killed
local EXTRA_DMG = 100
function gadget:UnitDamaged(unitID, unitDefID, unitTeam, damage, paralyzer, weaponID)
	if weaponID == WEAPON_ID then
		return
	end

	local pre_HP = Spring.GetUnitHealth(unitID)
	if pre_HP >= 0 then
		return
	end
	Spring.Echo("health before: " .. pre_HP)

	Spring.Echo("adding " .. EXTRA_DMG .. " damage")
	Spring.AddUnitDamage(unitID, EXTRA_DMG, 0, -1, WEAPON_ID)

	local post_HP = Spring.GetUnitHealth(unitID)
	local expected_HP = pre_HP - EXTRA_DMG
	Spring.Echo("health after: " .. post_HP .. ", expected " .. expected_HP) -- differs!

	Spring.SetUnitHealth(unitID, expected_HP) -- negative HP is kosher
end
```

Negative HP is not a problem, tested on a unit with lengthy death animation (`Sleep()` in script `Killed()`).

The use case is knowing how severely a unit was overkilled, normally obtained by just checking current health but this won't work if `AddUnitDamage` was used beforehand - including by another gadget in a lower layer.