### PR TITLE
glPushAttrib/glPopAttrib removal assistant

### DIFF
--- a/rts/Rendering/GL/glStateDebug.h
+++ b/rts/Rendering/GL/glStateDebug.h
@@ -56,6 +56,8 @@
 	#define glDepthMask(flag) _wrap_glDepthMask(flag, FILEPOS)
 	#define glDepthFunc(func) _wrap_glDepthFunc(func, FILEPOS)
 	#define glColorMask(r, g, b, a) _wrap_glColorMask(r, g, b, a, FILEPOS)
+	#define glPushAttrib(i) _wrap_glPushAttrib(i, FILEPOS)
+	#define glPopAttrib() _wrap_glPopAttrib(FILEPOS)
 #endif
 
 
@@ -78,6 +80,18 @@ extern void _wrap_glDepthMask(GLboolean flag, std::string location);
 extern void _wrap_glDepthFunc(GLenum func, std::string location);
 
 extern void _wrap_glColorMask(GLboolean red, GLboolean green, GLboolean blue, GLboolean alpha, std::string location);
+
+extern void _wrap_glPushAttrib(GLenum cap, std::string location);
+
+extern void _wrap_glPopAttrib(std::string location);
+
+typedef struct {
+    GLenum x,y,z,w;
+} GLenum4;
+
+typedef struct {
+    GLboolean x,y,z,w;
+} GLboolean4;
 
 class CGLStateChecker
 {


### PR DESCRIPTION
This PR is not fixing ---nor even improving--- things. It's just an assistant to make easier the glPushAttrib and glPopAttrib calls removal (deprecated since GL 3.2).

Integrating that, and enabling all GL_DEBUG functionality (including DEBUG_GLSTATE at compile time), you can get reports like the following:

```
[f=-000001] Error: [/home/pepe/spring1944/spring/rts/Lua/LuaOpenGL.cpp:453]: glPushAttrib is a deprecated function!
[f=-000001] Debug: [/home/pepe/spring1944/spring/rts/Lua/LuaOpenGL.cpp:453]: glPushAttrib depth = 1
[f=-000001] Debug: [/home/pepe/spring1944/spring/rts/Lua/LuaOpenGL.cpp:368]: GL_DEPTH_TEST (2929) changed from 1 to 1
[f=-000001] Debug: [/home/pepe/spring1944/spring/rts/Lua/LuaOpenGL.cpp:369]: GL_DEPTH_FUNC changed from 0x0203 to 0x0203
[f=-000001] Debug: [/home/pepe/spring1944/spring/rts/Lua/LuaOpenGL.cpp:370]: GL_DEPTH_WRITEMASK changed from 1 to 0
[f=-000001] Debug: [/home/pepe/spring1944/spring/rts/Lua/LuaOpenGL.cpp:374]: GL_COLOR_WRITEMASK changed from (1, 1, 1, 1) to (1, 1, 1, 1)
[f=-000001] Debug: [/home/pepe/spring1944/spring/rts/Lua/LuaOpenGL.cpp:376]: GL_BLEND (3042) changed from 1 to 1
[f=-000001] Debug: [/home/pepe/spring1944/spring/rts/Lua/LuaOpenGL.cpp:380]: (GL_BLEND_SRC_RGB, GL_BLEND_SRC_ALPHA, GL_BLEND_DST_RGB, GL_BLEND_DST_ALPHA) changed from (0x0302, 0x0302, 0x0303, 0x0303) to (0x0302, 0x0302, 0x0303, 0x0303)
[f=-000001] Debug: [/home/pepe/spring1944/spring/rts/Lua/LuaOpenGL.cpp:382]: GL_ALPHA_TEST (3008) changed from 0 to 1
[f=-000001] Warning: [OPENGL_DEBUG] id=3 source=API type=ERROR severity=HIGH msg="GL_INVALID_ENUM in glDisable(GL_ALPHA_TEST)"
[f=-000001] Warning: [OPENGL_DEBUG] id=3 source=API type=ERROR severity=HIGH msg="GL_INVALID_OPERATION in unsupported function called (unsupported extension or deprecated function?)"
[f=-000001] Debug: [/home/pepe/spring1944/spring/rts/Lua/LuaOpenGL.cpp:390]: GL_CULL_FACE (2884) changed from 0 to 1
[f=-000001] Warning: [OPENGL_DEBUG] id=3 source=API type=ERROR severity=HIGH msg="GL_INVALID_OPERATION in unsupported function called (unsupported extension or deprecated function?)"
[f=-000001] Warning: [OPENGL_DEBUG] id=3 source=API type=ERROR severity=HIGH msg="GL_INVALID_OPERATION in unsupported function called (unsupported extension or deprecated function?)"
[f=-000001] Warning: [OPENGL_DEBUG] id=3 source=API type=ERROR severity=HIGH msg="GL_INVALID_ENUM in glIsEnabled(GL_TEXTURE_2D)"
[f=-000001] Debug: [/home/pepe/spring1944/spring/rts/Lua/LuaOpenGLUtils.cpp:745]: texType (3553) changed from 0 to 1
[f=-000001] Warning: [OPENGL_DEBUG] id=3 source=API type=ERROR severity=HIGH msg="GL_INVALID_ENUM in glEnable(GL_TEXTURE_2D)"
[f=-000001] Warning: [OPENGL_DEBUG] id=3 source=API type=ERROR severity=HIGH msg="GL_INVALID_OPERATION in unsupported function called (unsupported extension or deprecated function?)"
[f=-000001] Warning: [OPENGL_DEBUG] id=3 source=API type=ERROR severity=HIGH msg="GL_INVALID_OPERATION in unsupported function called (unsupported extension or deprecated function?)"
[f=-000001] Warning: [OPENGL_DEBUG] id=3 source=API type=ERROR severity=HIGH msg="GL_INVALID_OPERATION in unsupported function called (unsupported extension or deprecated function?)"
[f=-000001] Warning: [OPENGL_DEBUG] id=3 source=API type=ERROR severity=HIGH msg="GL_INVALID_OPERATION in unsupported function called (unsupported extension or deprecated function?)"
[f=-000001] Warning: [OPENGL_DEBUG] id=3 source=API type=ERROR severity=HIGH msg="GL_INVALID_OPERATION in unsupported function called (unsupported extension or deprecated function?)"
[f=-000001] Warning: [OPENGL_DEBUG] id=3 source=API type=ERROR severity=HIGH msg="GL_INVALID_OPERATION in unsupported function called (unsupported extension or deprecated function?)"
[f=-000001] Warning: [OPENGL_DEBUG] id=3 source=API type=ERROR severity=HIGH msg="GL_INVALID_OPERATION in unsupported function called (unsupported extension or deprecated function?)"
[f=-000001] Warning: [OPENGL_DEBUG] id=3 source=API type=ERROR severity=HIGH msg="GL_INVALID_OPERATION in unsupported function called (unsupported extension or deprecated function?)"
[f=-000001] Warning: [OPENGL_DEBUG] id=3 source=API type=ERROR severity=HIGH msg="GL_INVALID_OPERATION in unsupported function called (unsupported extension or deprecated function?)"
[f=-000001] Warning: [OPENGL_DEBUG] id=3 source=API type=ERROR severity=HIGH msg="GL_INVALID_OPERATION in unsupported function called (unsupported extension or deprecated function?)"
[f=-000001] Warning: [OPENGL_DEBUG] id=3 source=API type=ERROR severity=HIGH msg="GL_INVALID_ENUM in glIsEnabled(GL_TEXTURE_2D)"
[f=-000001] Debug: [/home/pepe/spring1944/spring/rts/Lua/LuaOpenGL.cpp:2574]: GL_TEXTURE_2D (3553) changed from 0 to 1
[f=-000001] Warning: [OPENGL_DEBUG] id=3 source=API type=ERROR severity=HIGH msg="GL_INVALID_ENUM in glDisable(GL_TEXTURE_2D)"
[f=-000001] Warning: [OPENGL_DEBUG] id=3 source=API type=ERROR severity=HIGH msg="GL_INVALID_OPERATION in unsupported function called (unsupported extension or deprecated function?)"
[f=-000001] Warning: [OPENGL_DEBUG] id=3 source=API type=ERROR severity=HIGH msg="GL_INVALID_OPERATION in unsupported function called (unsupported extension or deprecated function?)"
[f=-000001] Warning: [OPENGL_DEBUG] id=3 source=API type=ERROR severity=HIGH msg="GL_INVALID_OPERATION in unsupported function called (unsupported extension or deprecated function?)"
[f=-000001] Warning: [OPENGL_DEBUG] id=3 source=API type=ERROR severity=HIGH msg="GL_INVALID_OPERATION in unsupported function called (unsupported extension or deprecated function?)"
[f=-000001] Warning: [OPENGL_DEBUG] id=3 source=API type=ERROR severity=HIGH msg="GL_INVALID_OPERATION in unsupported function called (unsupported extension or deprecated function?)"
[f=-000001] Warning: [OPENGL_DEBUG] id=3 source=API type=ERROR severity=HIGH msg="GL_INVALID_OPERATION in unsupported function called (unsupported extension or deprecated function?)"
[f=-000001] Warning: [OPENGL_DEBUG] id=3 source=API type=ERROR severity=HIGH msg="GL_INVALID_OPERATION in unsupported function called (unsupported extension or deprecated function?)"
[f=-000001] Warning: [OPENGL_DEBUG] id=3 source=API type=ERROR severity=HIGH msg="GL_INVALID_OPERATION in unsupported function called (unsupported extension or deprecated function?)"
[f=-000001] Warning: [OPENGL_DEBUG] id=3 source=API type=ERROR severity=HIGH msg="GL_INVALID_OPERATION in unsupported function called (unsupported extension or deprecated function?)"
[f=-000001] Warning: [OPENGL_DEBUG] id=3 source=API type=ERROR severity=HIGH msg="GL_INVALID_OPERATION in unsupported function called (unsupported extension or deprecated function?)"
[f=-000001] Error: [/home/pepe/spring1944/spring/rts/Rendering/Fonts/glFont.cpp:580]: glPushAttrib is a deprecated function!
[f=-000001] Debug: [/home/pepe/spring1944/spring/rts/Rendering/Fonts/glFont.cpp:580]: glPushAttrib depth = 2
[f=-000001] Debug: [/home/pepe/spring1944/spring/rts/Rendering/Fonts/glFont.cpp:581]: GL_DEPTH_TEST (2929) changed from 0 to 1
[f=-000001] Debug: [/home/pepe/spring1944/spring/rts/Rendering/Fonts/glFont.cpp:582]: GL_BLEND (3042) changed from 1 to 1
[f=-000001] Debug: [/home/pepe/spring1944/spring/rts/Rendering/Fonts/glFont.cpp:583]: (GL_BLEND_SRC_RGB, GL_BLEND_SRC_ALPHA, GL_BLEND_DST_RGB, GL_BLEND_DST_ALPHA) changed from (0x0302, 0x0302, 0x0303, 0x0303) to (0x0302, 0x0302, 0x0303, 0x0303)
[f=-000001] Warning: [OPENGL_DEBUG] id=1 source=SHADER_COMPILER type=OTHER severity=UNKNOWN msg="Shader Stats: SGPRS: 24 VGPRS: 16 Code Size: 68 LDS: 0 Scratch: 0 Max Waves: 10 Spilled SGPRs: 0 Spilled VGPRs: 0 PrivMem VGPRs: 0"
[f=-000001] Warning: [OPENGL_DEBUG] id=3 source=API type=ERROR severity=HIGH msg="GL_INVALID_ENUM in glIsEnabled(GL_TEXTURE_2D)"
[f=-000001] Debug: [/home/pepe/spring1944/spring/rts/Rendering/Fonts/glFont.cpp:594]: GL_TEXTURE_2D (3553) changed from 0 to 1
[f=-000001] Warning: [OPENGL_DEBUG] id=3 source=API type=ERROR severity=HIGH msg="GL_INVALID_ENUM in glEnable(GL_TEXTURE_2D)"
[f=-000001] Error: [/home/pepe/spring1944/spring/rts/Rendering/Fonts/glFont.cpp:626]: glPopAttrib is a deprecated function!
[f=-000001] Warning: [OPENGL_DEBUG] id=3 source=API type=ERROR severity=HIGH msg="GL_INVALID_ENUM in glDisable(GL_ALPHA_TEST)"
[f=-000001] Warning: [OPENGL_DEBUG] id=3 source=API type=ERROR severity=HIGH msg="GL_INVALID_ENUM in glDisable(GL_TEXTURE_2D)"
[f=-000001] Debug: [/home/pepe/spring1944/spring/rts/Rendering/Fonts/glFont.cpp:626]: glPushAttrib depth = 1
[f=-000001] Error: [/home/pepe/spring1944/spring/rts/Rendering/Fonts/glFont.cpp:580]: glPushAttrib is a deprecated function!
[f=-000001] Debug: [/home/pepe/spring1944/spring/rts/Rendering/Fonts/glFont.cpp:580]: glPushAttrib depth = 2
[f=-000001] Debug: [/home/pepe/spring1944/spring/rts/Rendering/Fonts/glFont.cpp:581]: GL_DEPTH_TEST (2929) changed from 0 to 1
[f=-000001] Debug: [/home/pepe/spring1944/spring/rts/Rendering/Fonts/glFont.cpp:582]: GL_BLEND (3042) changed from 1 to 1
[f=-000001] Debug: [/home/pepe/spring1944/spring/rts/Rendering/Fonts/glFont.cpp:583]: (GL_BLEND_SRC_RGB, GL_BLEND_SRC_ALPHA, GL_BLEND_DST_RGB, GL_BLEND_DST_ALPHA) changed from (0x0302, 0x0302, 0x0303, 0x0303) to (0x0302, 0x0302, 0x0303, 0x0303)
[f=-000001] Warning: [OPENGL_DEBUG] id=3 source=API type=ERROR severity=HIGH msg="GL_INVALID_ENUM in glIsEnabled(GL_TEXTURE_2D)"
[f=-000001] Debug: [/home/pepe/spring1944/spring/rts/Rendering/Fonts/glFont.cpp:594]: GL_TEXTURE_2D (3553) changed from 0 to 1
[f=-000001] Warning: [OPENGL_DEBUG] id=3 source=API type=ERROR severity=HIGH msg="GL_INVALID_ENUM in glEnable(GL_TEXTURE_2D)"
[f=-000001] Error: [/home/pepe/spring1944/spring/rts/Rendering/Fonts/glFont.cpp:626]: glPopAttrib is a deprecated function!
[f=-000001] Warning: [OPENGL_DEBUG] id=3 source=API type=ERROR severity=HIGH msg="GL_INVALID_ENUM in glDisable(GL_ALPHA_TEST)"
[f=-000001] Warning: [OPENGL_DEBUG] id=3 source=API type=ERROR severity=HIGH msg="GL_INVALID_ENUM in glDisable(GL_TEXTURE_2D)"
[f=-000001] Debug: [/home/pepe/spring1944/spring/rts/Rendering/Fonts/glFont.cpp:626]: glPushAttrib depth = 1
[f=-000001] Error: [/home/pepe/spring1944/spring/rts/Rendering/Fonts/glFont.cpp:580]: glPushAttrib is a deprecated function!
[f=-000001] Debug: [/home/pepe/spring1944/spring/rts/Rendering/Fonts/glFont.cpp:580]: glPushAttrib depth = 2
[f=-000001] Debug: [/home/pepe/spring1944/spring/rts/Rendering/Fonts/glFont.cpp:581]: GL_DEPTH_TEST (2929) changed from 0 to 1
[f=-000001] Debug: [/home/pepe/spring1944/spring/rts/Rendering/Fonts/glFont.cpp:582]: GL_BLEND (3042) changed from 1 to 1
[f=-000001] Debug: [/home/pepe/spring1944/spring/rts/Rendering/Fonts/glFont.cpp:583]: (GL_BLEND_SRC_RGB, GL_BLEND_SRC_ALPHA, GL_BLEND_DST_RGB, GL_BLEND_DST_ALPHA) changed from (0x0302, 0x0302, 0x0303, 0x0303) to (0x0302, 0x0302, 0x0303, 0x0303)
[f=-000001] Warning: [OPENGL_DEBUG] id=3 source=API type=ERROR severity=HIGH msg="GL_INVALID_ENUM in glIsEnabled(GL_TEXTURE_2D)"
[f=-000001] Debug: [/home/pepe/spring1944/spring/rts/Rendering/Fonts/glFont.cpp:594]: GL_TEXTURE_2D (3553) changed from 0 to 1
[f=-000001] Warning: [OPENGL_DEBUG] id=3 source=API type=ERROR severity=HIGH msg="GL_INVALID_ENUM in glEnable(GL_TEXTURE_2D)"
[f=-000001] Error: [/home/pepe/spring1944/spring/rts/Rendering/Fonts/glFont.cpp:626]: glPopAttrib is a deprecated function!
[f=-000001] Warning: [OPENGL_DEBUG] id=3 source=API type=ERROR severity=HIGH msg="GL_INVALID_ENUM in glDisable(GL_ALPHA_TEST)"
[f=-000001] Warning: [OPENGL_DEBUG] id=3 source=API type=ERROR severity=HIGH msg="GL_INVALID_ENUM in glDisable(GL_TEXTURE_2D)"
[f=-000001] Debug: [/home/pepe/spring1944/spring/rts/Rendering/Fonts/glFont.cpp:626]: glPushAttrib depth = 1
[f=-000001] Warning: [OPENGL_DEBUG] id=3 source=API type=ERROR severity=HIGH msg="GL_INVALID_OPERATION in unsupported function called (unsupported extension or deprecated function?)"
[f=-000001] Error: [/home/pepe/spring1944/spring/rts/Lua/LuaOpenGL.cpp:464]: glPopAttrib is a deprecated function!
[f=-000001] Warning: [OPENGL_DEBUG] id=3 source=API type=ERROR severity=HIGH msg="GL_INVALID_ENUM in glDisable(GL_ALPHA_TEST)"
[f=-000001] Warning: [OPENGL_DEBUG] id=3 source=API type=ERROR severity=HIGH msg="GL_INVALID_ENUM in glDisable(GL_TEXTURE_2D)"
[f=-000001] Debug: [/home/pepe/spring1944/spring/rts/Lua/LuaOpenGL.cpp:464]: glPushAttrib depth = 0
```

That way, should be easier to know which Flags/States are actually changing, and the restoring value. 