### PR TITLE
add. be14d9c2ecbbd9fb9cacc56c02442164824e9071

### DIFF
--- a/rts/Sim/Units/Unit.cpp
+++ b/rts/Sim/Units/Unit.cpp
@@ -1018,7 +1018,7 @@ void CUnit::SlowUpdate()
 		// DoDamage) we potentially start decaying from a lower damage
 		// level and would otherwise be de-paralyzed more quickly than
 		// specified by <paralyzeTime>
-		paralyzeDamage -= ((modInfo.paralyzeOnMaxHealth? maxHealth: health) * 0.5f * CUnit::empDeclineRate);
+		paralyzeDamage -= ((modInfo.paralyzeOnMaxHealth? maxHealth: health) * (UNIT_SLOWUPDATE_RATE / float(GAME_SPEED)) * CUnit::empDeclineRate);
 		paralyzeDamage = std::max(paralyzeDamage, 0.0f);
 	}
 


### PR DESCRIPTION
Replace a magic number (previously it made some sense because https://github.com/spring/spring/commit/be14d9c2ecbbd9fb9cacc56c02442164824e9071#diff-ed40a10d6489adbd290ee8870e244f93L272 was defined in terms of slowupdate but that is no longer the case)