### PR TITLE
Unit[Pre]Damaged: get attackerTeam from projectile

### DIFF
--- a/doc/changelog.txt
+++ b/doc/changelog.txt
@@ -90,6 +90,9 @@ Lua:
    writing the tesselation control shader.
    4) New vertex primitive type GL.PATCHES
  ! Renamed SetShaderParameter to SetGeometryShaderParameter to avoid confusion of what kind shader parameters belongs to.
+ ! Unit[Pre]Damaged's attackerTeam argument takes the team from projectile,
+   meaning it's still present if the attacker dies meanwhile,
+   and uses the value from the time of shooting if he gets captured.
 
 
 AI:

--- a/rts/Lua/LuaHandle.cpp
+++ b/rts/Lua/LuaHandle.cpp
@@ -24,6 +24,7 @@
 #include "Sim/Misc/GlobalSynced.h"
 #include "Sim/Misc/TeamHandler.h"
 #include "Sim/Projectiles/Projectile.h"
+#include "Sim/Projectiles/ProjectileHandler.h"
 #include "Sim/Projectiles/WeaponProjectiles/WeaponProjectile.h"
 #include "Sim/Features/FeatureDef.h"
 #include "Sim/Units/Unit.h"
@@ -990,11 +991,19 @@ void CLuaHandle::UnitDamaged(
 	lua_pushnumber(L, weaponDefID);
 	lua_pushnumber(L, projectileID);
 
-	if (attacker != nullptr && GetHandleFullRead(L)) {
-		lua_pushnumber(L, attacker->id);
-		lua_pushnumber(L, attacker->unitDef->id);
-		lua_pushnumber(L, attacker->team);
-		argCount += 3;
+	if (GetHandleFullRead(L)) {
+		const CProjectile *const proj = projectileHandler.GetProjectileBySyncedID(projectileID);
+		if (attacker != nullptr) {
+			lua_pushnumber(L, attacker->id);
+			lua_pushnumber(L, attacker->unitDef->id);
+			lua_pushnumber(L, proj != nullptr ? proj->GetTeamID() : attacker->team);
+			argCount += 3;
+		} else if (proj != nullptr) {
+			lua_pushnil(L);
+			lua_pushnil(L);
+			lua_pushnumber(L, proj->GetTeamID());
+			argCount += 3;
+		}
 	}
 
 	// call the routine

--- a/rts/Lua/LuaHandleSynced.cpp
+++ b/rts/Lua/LuaHandleSynced.cpp
@@ -36,6 +36,7 @@
 #include "Sim/Misc/TeamHandler.h"
 #include "Sim/Features/FeatureDef.h"
 #include "Sim/Features/FeatureDefHandler.h"
+#include "Sim/Projectiles/ProjectileHandler.h"
 #include "Sim/Units/BuildInfo.h"
 #include "Sim/Units/UnitDef.h"
 #include "Sim/Units/UnitDefHandler.h"
@@ -1009,10 +1010,16 @@ bool CSyncedLuaHandle::UnitPreDamaged(
 		lua_pushnumber(L, weaponDefID); inArgCount += 1;
 		lua_pushnumber(L, projectileID); inArgCount += 1;
 
+		const CProjectile *const proj = projectileHandler.GetProjectileBySyncedID(projectileID);
 		if (attacker != nullptr) {
 			lua_pushnumber(L, attacker->id);
 			lua_pushnumber(L, attacker->unitDef->id);
-			lua_pushnumber(L, attacker->team);
+			lua_pushnumber(L, proj != nullptr ? proj->GetTeamID() : attacker->team);
+			inArgCount += 3;
+		} else if (proj != nullptr) {
+			lua_pushnil(L);
+			lua_pushnil(L);
+			lua_pushnumber(L, proj->GetTeamID());
 			inArgCount += 3;
 		}
 	}


### PR DESCRIPTION
Fixes the case where the attacker is captured/killed during
projectile flight which leaves the teamID incorrect/missing.