### PR TITLE
Changed the MAG_FILTER of $heightmap to LINEAR. 

### DIFF
--- a/rts/Map/HeightMapTexture.cpp
+++ b/rts/Map/HeightMapTexture.cpp
@@ -43,7 +43,7 @@ void HeightMapTexture::Init()
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP);
 
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
-	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
 
 	const float* heightMap = readMap->GetCornerHeightMapUnsynced();
 


### PR DESCRIPTION
I don't think NEAREST has any particular reason to stay.