### PR TITLE
add. c06a3057ad57d01a350b707aeb99b8c02cdaeae4

### DIFF
--- a/rts/Game/Game.cpp
+++ b/rts/Game/Game.cpp
@@ -471,6 +471,13 @@ void CGame::LoadDefs(LuaParser* defsParser)
 		defsParser->GetTable("Game");
 		defsParser->AddInt( "gameSpeed",  GAME_SPEED);
 		defsParser->AddInt("squareSize", SQUARE_SIZE);
+		defsParser->GetTable("speedModClasses");
+		defsParser->AddInt( "Tank", MoveDef::SpeedModClass::Tank );
+		defsParser->AddInt( "KBot", MoveDef::SpeedModClass::KBot );
+		defsParser->AddInt("Hover", MoveDef::SpeedModClass::Hover);
+		defsParser->AddInt( "Ship", MoveDef::SpeedModClass::Ship );
+		defsParser->AddInt( "Boat", MoveDef::SpeedModClass::Ship );
+		defsParser->EndTable();
 		defsParser->EndTable();
 		defsParser->GetTable("Spring");
 		defsParser->AddFunc("GetModOptions", LuaSyncedRead::GetModOptions);


### PR DESCRIPTION
Actually expose the moveclass constants to defs parsing
(super inelegant but there's a precedent in c2b9061b91be0eae0d73b67b1e0bfeca0345f2e9)