### PR TITLE
not needed by macos buildbot [Question]

### DIFF
--- a/buildbot/slave/osx/macos_sierra_x64.cmake
+++ b/buildbot/slave/osx/macos_sierra_x64.cmake
@@ -9,8 +9,6 @@ set(Boost_USE_STATIC_LIBS  TRUE CACHE BOOL "")
 
 set(PRD_JSONCPP_INTERNAL FALSE CACHE BOOL "")
 
-set(GLEW_INCLUDE_DIR "/usr/local/include/GL" CACHE STRING "")
-
 set(CMAKE_OSX_SYSROOT "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.12.sdk" CACHE STRING "")
 
 include_directories("/usr/local/include")

--- a/rts/Rendering/GL/myGL.h
+++ b/rts/Rendering/GL/myGL.h
@@ -13,11 +13,7 @@
 #if defined(HEADLESS)
 	#include "lib/headlessStubs/glewstub.h"
 #else
-	#if defined(__APPLE__)
-		#include <OpenGL/glew.h>
-	#else
 		#include <GL/glew.h>
-	#endif
 #endif // defined(HEADLESS)
 
 

--- a/rts/lib/headlessStubs/glewstub.h
+++ b/rts/lib/headlessStubs/glewstub.h
@@ -14,8 +14,8 @@
 #endif
 
 #if defined(__APPLE__)
-	#include <OpenGL/gl.h>
-	#include <OpenGL/glext.h>
+	#include <OpenGL/gl3.h>
+	#include <OpenGL/gl3ext.h>
 #else
 	#include <GL/gl.h>
 	#include <GL/glext.h>


### PR DESCRIPTION
why is include specified to be OPENGL if __APPLE__?

none of the distributions of glew (brew or macSDK) install it in that path

instead they use GL/glew.h

Thanks
