### PR TITLE
WIP: clang-tidy checks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,31 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.6)
 
+find_program(
+  CLANG_TIDY_EXE
+  NAMES "clang-tidy"
+  DOC "Path to clang-tidy executable"
+)
+if(NOT CLANG_TIDY_EXE)
+  message(STATUS "clang-tidy not found.")
+else()
+  message(STATUS "clang-tidy found: ${CLANG_TIDY_EXE}")
+  string(CONCAT CLANG_TIDY_CHECKS
+  	# disable all by default
+  	"-*"
+	# enable a few general categories
+	",bugprone-*,misc-*,modernize-*,performance-*,portability-*,readability-*,"
+	# disable checks that go against our style
+	",-readability-braces-around-statements"
+	# disable various other checks
+	",-readability-implicit-bool-conversion,-modernize-use-auto,-misc-unused-parameters"
+	",-readability-inconsistent-declaration-parameter-name,-readability-else-after-return,-modernize-use-using"
+	",-readability-named-parameter,-misc-macro-parentheses,-performance-unnecessary-value-param,-modernize-pass-by-value"
+	",-bugprone-integer-division,-readability-static-accessed-through-instance,-misc-string-integer-assignment"
+	",-readability-avoid-const-params-in-decls,-modernize-raw-string-literal")
+	# TODO: Consider adding other checks such as those below:
+	# clang-analyzer-*,cert-*,cppcoreguidelines-*,-cppcoreguidelines-pro-type-union-access
+  set(DO_CLANG_TIDY "${CLANG_TIDY_EXE}" "-checks=${CLANG_TIDY_CHECKS}")
+endif()
 
 set(CMAKE_MODULES_SPRING "${CMAKE_CURRENT_SOURCE_DIR}/rts/build/cmake")
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_MODULES_SPRING}")

--- a/rts/builds/CMakeLists.txt
+++ b/rts/builds/CMakeLists.txt
@@ -65,6 +65,10 @@ macro    (create_engine_build_and_install_target targetName)
 		add_dependencies(spring spring-${targetName}) # This also works for custom targets
 		add_dependencies(install-spring install-spring-${targetName}) # This also works for custom targets
 		set_target_properties(engine-${targetName} PROPERTIES OUTPUT_NAME "spring")
+		set_target_properties(engine-${targetName} PROPERTIES CXX_STANDARD 14 CXX_STANDARD_REQUIRED ON COMPILE_FLAGS "${WARNING_FLAGS}")
+		if(CLANG_TIDY_EXE)
+			set_target_properties(engine-${targetName} PROPERTIES CXX_CLANG_TIDY "${DO_CLANG_TIDY}")
+		endif()
 	else()
 		set_target_properties(engine-${targetName} PROPERTIES OUTPUT_NAME "spring-${targetName}")
 	endif ()


### PR DESCRIPTION
Lately I've been working to get clang-tidy running for Spring, and doing some cleanup in the process.

[Clang-tidy](http://clang.llvm.org/extra/clang-tidy/)  is a useful tool for modernizing code, performing micro optimizations and even finding bugs (provided you use it carefully and don't introduce them instead!)

Right now I've setup clang-tidy to run while Spring is being built, and I've made it do only the checks that I wanted to deal with initially - as we go long the list of checks should probably be increased, but I think the first priority would be to get the warning count to 0 (by fixing diagnostics or explicitly [suppressing them](http://clang.llvm.org/extra/clang-tidy/#suppressing-undesired-diagnostics)).Unless we change our coding style, some checks will probably be disabled forever, e.g. `-readability-braces-around-statements`.

Performing clang-tidy while compiling can be awfully slow (didn't measure but build times seemed to have tripled at least) which feels largely unnecessary for the first build. 

During development I would like to have a way to turn it on for builds, e.g. my workflow would likely go as  follows:
1. build without clang-tidy
2. do some changes
3. build with clang-tidy

I would also like to do some refactoring from time to time:
1. perform full builds with clang-tidy
2. do some refactoring/global cleanup

And it would be nice to have it run on buildbots:
1. perform full builds with clang-tidy

CMake is not my strong suite, so if anyone's willing to lend a hand I'd be grateful.