### PR TITLE
Changed a few things to make develop compile on MSVC

### DIFF
--- a/rts/Lua/LuaIO.cpp
+++ b/rts/Lua/LuaIO.cpp
@@ -74,7 +74,7 @@ bool LuaIO::SafeWritePath(const std::string& path)
 	const std::array<std::string, 5> exeFiles = {"exe", "dll", "so", "bat", "com"};
 	const std::string ext = FileSystem::GetExtension(path);
 
-	if (std::find(std::begin(exeFiles), std::end(exeFiles), ext))
+	if (std::find(std::begin(exeFiles), std::end(exeFiles), ext) != exeFiles.end())
 		return false;
 
 	return dataDirsAccess.InWriteDir(path);

--- a/rts/Map/MapInfo.cpp
+++ b/rts/Map/MapInfo.cpp
@@ -19,6 +19,7 @@
 #include "System/Sound/OpenAL/EFXPresets.h"
 #endif
 
+#include <array>
 #include <cassert>
 
 

--- a/rts/Sim/Misc/DefinitionTag.h
+++ b/rts/Sim/Misc/DefinitionTag.h
@@ -8,6 +8,7 @@
 #include <cassert>
 #include "System/Misc/NonCopyable.h"
 
+#include <array>
 #include <vector>
 #include <sstream>
 #include <string>

--- a/rts/System/Platform/Win/WinVersion.cpp
+++ b/rts/System/Platform/Win/WinVersion.cpp
@@ -11,10 +11,12 @@
 #endif
 
 #include <windows.h>
-//#include <ntdef.h>
-
+#ifndef _MSC_VER
+#include <ntdef.h>
+#else
 typedef _Return_type_success_(return >= 0) LONG NTSTATUS;
 #define NT_SUCCESS(Status) (((NTSTATUS)(Status)) >= 0)
+#endif
 
 #include "WinVersion.h"
 

--- a/rts/System/Platform/Win/WinVersion.cpp
+++ b/rts/System/Platform/Win/WinVersion.cpp
@@ -11,7 +11,10 @@
 #endif
 
 #include <windows.h>
-#include <ntdef.h>
+//#include <ntdef.h>
+
+typedef _Return_type_success_(return >= 0) LONG NTSTATUS;
+#define NT_SUCCESS(Status) (((NTSTATUS)(Status)) >= 0)
 
 #include "WinVersion.h"
 

--- a/rts/aGui/HorizontalLayout.cpp
+++ b/rts/aGui/HorizontalLayout.cpp
@@ -1,5 +1,6 @@
 /* This file is part of the Spring engine (GPL v2 or later), see LICENSE.html */
 
+#include <algorithm>
 #include "HorizontalLayout.h"
 
 #include "Gui.h"


### PR DESCRIPTION
1) Added includes for array and algorithm
2) Simultaneous definition of #include <windows.h> and #include <ntdef.h> cause huge number of redefinition errors somehow. Removed ntdef.h for now.