### PR TITLE
fix #5537

### DIFF
--- a/rts/System/FileSystem/ArchiveScanner.h
+++ b/rts/System/FileSystem/ArchiveScanner.h
@@ -164,8 +164,10 @@ private:
 		std::string origName;     // non-lowercased name
 		std::string replaced;     // if not empty, use this archive instead
 		ArchiveData archiveData;
+		std::string archiveDataPath;
 
 		uint32_t modified = 0;
+		uint32_t modifiedArchiveData = 0;
 		uint8_t checksum[sha512::SHA_LEN];
 
 		bool updated = false;
@@ -208,7 +210,7 @@ private:
 	 */
 	bool GetArchiveChecksum(const std::string& filename, ArchiveInfo& archiveInfo);
 
-	bool CheckCachedData(const std::string& fullName, unsigned* modified, bool doChecksum);
+	bool CheckCachedData(const std::string& fullName, unsigned& modified, bool doChecksum);
 
 	/**
 	 * Returns a value > 0 if the file is rated as a meta-file.


### PR DESCRIPTION
ArchiveScanner will now properly detect when modinfo.lua/mapinfo.lua
 changes, and reparse the archive.
This fixes issues like changing the depends subtable and not seeing any
 change until the cache dir is deleted.

Implementation details:
- We now cache an additional path to the modinfo.lua/mapinfo.lua and
 the related modified timestamp. This applies to datadirs (.sdd)
 archives only
- This means that reading the cache will have two additional stat calls
 for datadirs. I have over 40 .sdd archives (on both HDD and SSD) and
 there is no noticeable performance hit. Players are likely to have very
 few of such archives, probably 0. So unlikely to hurt performance in
 general.
- Likewise, this information is only saved for datadirs as well, so
there shouldn't be any performance hit on writing the cache either.
- The way I obtain the full path of the archive is stolen from
`CVFSHandler::GetFileAbsolutePath`, and maybe could be rewritten with
DRY. Also probably should be tested on windows, the "/" seems suspicious

Minor:
- INTERNAL_VAR is incremented
- CheckCachedData signature is modified to pass modifiedTime by
reference as it cannot be nullptr
- internalver is loaded as lowercase (consistent to how its saved)