### PR TITLE
SAT based collision detection (Don't merge yet)

### DIFF
--- a/rts/Sim/Misc/ModInfo.cpp
+++ b/rts/Sim/Misc/ModInfo.cpp
@@ -31,6 +31,7 @@ void CModInfo::ResetState()
 	allowUnitCollisionOverlap = true;
 	allowGroundUnitGravity    = true;
 	allowHoverUnitStrafing    = true;
+	useSATCollisionDetection  = false;
 
 	constructionDecay      = true;
 	constructionDecayTime  = 1000;
@@ -135,6 +136,7 @@ void CModInfo::Init(const char* modArchive)
 		allowUnitCollisionOverlap = movementTbl.GetBool("allowUnitCollisionOverlap", allowUnitCollisionOverlap);
 		allowGroundUnitGravity = movementTbl.GetBool("allowGroundUnitGravity", allowGroundUnitGravity);
 		allowHoverUnitStrafing = movementTbl.GetBool("allowHoverUnitStrafing", (pathFinderSystem == QTPFS_TYPE));
+		useSATCollisionDetection = movementTbl.GetBool("useSATCollisionDetection", useSATCollisionDetection);
 	}
 
 	{

--- a/rts/Sim/Misc/ModInfo.h
+++ b/rts/Sim/Misc/ModInfo.h
@@ -50,6 +50,7 @@ public:
 	bool allowUnitCollisionOverlap;  //< determines if unit footprints are allowed to semi-overlap during collisions
 	bool allowGroundUnitGravity;     //< determines if (ground-)units experience gravity during regular movement
 	bool allowHoverUnitStrafing;     //< determines if (hover-)units carry their momentum sideways when turning
+	bool useSATCollisionDetection;   //< determines if SAT-based collision detection should be considered
 
 	// Build behaviour
 	/// Should constructions without builders decay?

--- a/rts/Sim/MoveTypes/GroundMoveType.cpp
+++ b/rts/Sim/MoveTypes/GroundMoveType.cpp
@@ -1926,11 +1926,13 @@ void CGroundMoveType::HandleUnitCollisions(
 			continue;
 		// They are close enough to further analyse the collision. To do that
 		// we are using Separable Axes Theorem (SAT).
-		if ((getSATdist(collider->frontdir, separationVector, collidee) > collider->zsize * 0.5f * SQUARE_SIZE) ||
-			(getSATdist(collider->rightdir, separationVector, collidee) > collider->xsize * 0.5f * SQUARE_SIZE) ||
-			(getSATdist(collidee->frontdir, separationVector, collider) > collidee->zsize * 0.5f * SQUARE_SIZE) ||
-			(getSATdist(collidee->rightdir, separationVector, collider) > collidee->xsize * 0.5f * SQUARE_SIZE))
-			continue;
+		if (modInfo.useSATCollisionDetection) {
+			if ((getSATdist(collider->frontdir, separationVector, collidee) > collider->zsize * 0.5f * SQUARE_SIZE) ||
+				(getSATdist(collider->rightdir, separationVector, collidee) > collider->xsize * 0.5f * SQUARE_SIZE) ||
+				(getSATdist(collidee->frontdir, separationVector, collider) > collidee->zsize * 0.5f * SQUARE_SIZE) ||
+				(getSATdist(collidee->rightdir, separationVector, collider) > collidee->xsize * 0.5f * SQUARE_SIZE))
+				continue;
+		}
 
 		if (unloadingCollidee) {
 			collidee->unloadingTransportId = collider->id;

--- a/rts/Sim/MoveTypes/GroundMoveType.cpp
+++ b/rts/Sim/MoveTypes/GroundMoveType.cpp
@@ -1632,7 +1632,7 @@ void CGroundMoveType::HandleObjectCollisions()
 		//   square shape.
 		//   In case of non-square footprints we can later apply Separable Axes
 		//   theorem SAT
-		const float colliderRadius = std::max(collider->xsize, collider->zsize) * 0.5f * SQUARE_SIZE;
+		const float colliderRadius = collider->CalcMinimalBoundingFootPrintRadius();
 
 		HandleUnitCollisions(collider, colliderSpeed, colliderRadius, colliderUD, colliderMD);
 		HandleFeatureCollisions(collider, colliderSpeed, colliderRadius, colliderUD, colliderMD);
@@ -1917,7 +1917,7 @@ void CGroundMoveType::HandleUnitCollisions(
 		// use the collidee's MoveDef footprint as radius if it is mobile
 		// use the collidee's Unit (not UnitDef) footprint as radius otherwise
 		const float collideeSpeed = collidee->speed.w;
-		const float collideeRadius = std::max(collidee->xsize, collidee->zsize) * 0.5f * SQUARE_SIZE;
+		const float collideeRadius = collidee->CalcMinimalBoundingFootPrintRadius();
 
 		const float3 separationVector   = collider->pos - collidee->pos;
 		const float separationMinDistSq = (colliderRadius + collideeRadius) * (colliderRadius + collideeRadius);
@@ -2073,7 +2073,7 @@ void CGroundMoveType::HandleFeatureCollisions(
 		// const FeatureDef* collideeFD = collidee->def;
 
 		// use the collidee's Feature (not FeatureDef) footprint as radius
-		const float collideeRadius = std::max(collidee->xsize, collidee->zsize) * 0.5f * SQUARE_SIZE;
+		const float collideeRadius = collidee->CalcMinimalBoundingFootPrintRadius();
 		const float collisionRadiusSum = colliderRadius + collideeRadius;
 
 		const float3 separationVector   = collider->pos - collidee->pos;
@@ -2083,11 +2083,13 @@ void CGroundMoveType::HandleFeatureCollisions(
 			continue;
 		// They are close enough to further analyse the collision. To do that
 		// we are using Separable Axes Theorem (SAT).
-		if ((getSATdist(collider->frontdir, separationVector, collidee) > collider->zsize * 0.5f * SQUARE_SIZE) ||
-			(getSATdist(collider->rightdir, separationVector, collidee) > collider->xsize * 0.5f * SQUARE_SIZE) ||
-			(getSATdist(collidee->frontdir, separationVector, collider) > collidee->zsize * 0.5f * SQUARE_SIZE) ||
-			(getSATdist(collidee->rightdir, separationVector, collider) > collidee->xsize * 0.5f * SQUARE_SIZE))
-			continue;
+		if (modInfo.useSATCollisionDetection) {
+			if ((getSATdist(collider->frontdir, separationVector, collidee) > collider->zsize * 0.5f * SQUARE_SIZE) ||
+				(getSATdist(collider->rightdir, separationVector, collidee) > collider->xsize * 0.5f * SQUARE_SIZE) ||
+				(getSATdist(collidee->frontdir, separationVector, collider) > collidee->zsize * 0.5f * SQUARE_SIZE) ||
+				(getSATdist(collidee->rightdir, separationVector, collider) > collidee->xsize * 0.5f * SQUARE_SIZE))
+				continue;
+		}
 
 		if (CMoveMath::IsNonBlocking(*colliderMD, collidee, collider))
 			continue;

--- a/rts/Sim/MoveTypes/GroundMoveType.cpp
+++ b/rts/Sim/MoveTypes/GroundMoveType.cpp
@@ -2093,8 +2093,7 @@ void CGroundMoveType::HandleFeatureCollisions(
 		// we are applying Separable Axes Theorem (SAT), just in case the
 		// mod/game allows that, and at least one of the colliders requires it.
 		if (modInfo.useSATCollisionDetection &&
-			(colliderStretch > 0.1f) &&
-			(collidee->CalcFootPrintStretchingFactor() > 0.1f)) {
+			((colliderStretch > 0.1f) || (collidee->CalcFootPrintStretchingFactor() > 0.1f))) {
 			if ((getSATdist(collider->frontdir, separationVector, collidee) > collider->zsize * 0.5f * SQUARE_SIZE) ||
 				(getSATdist(collider->rightdir, separationVector, collidee) > collider->xsize * 0.5f * SQUARE_SIZE) ||
 				(getSATdist(collidee->frontdir, separationVector, collider) > collidee->zsize * 0.5f * SQUARE_SIZE) ||

--- a/rts/Sim/MoveTypes/GroundMoveType.cpp
+++ b/rts/Sim/MoveTypes/GroundMoveType.cpp
@@ -209,7 +209,7 @@ CGroundMoveType::CGroundMoveType(CUnit* owner):
 	// unit-gravity must always be negative
 	myGravity = mix(-math::fabs(ud->myGravity), mapInfo->map.gravity, ud->myGravity == 0.0f);
 
-	ownerRadius = ud->CalcFootPrintRadius(1.0f);
+	ownerRadius = owner->CalcFootPrintRadius(1.0f);
 }
 
 CGroundMoveType::~CGroundMoveType()
@@ -1092,7 +1092,7 @@ float3 CGroundMoveType::GetObstacleAvoidanceDir(const float3& desiredDir) {
 	nextObstacleAvoidanceFrame = gs->frameNum + 1;
 
 	CUnit* avoider = owner;
-	const UnitDef* avoiderUD = avoider->unitDef;
+	// const UnitDef* avoiderUD = avoider->unitDef;
 	const MoveDef* avoiderMD = avoider->moveDef;
 
 	// degenerate case: if facing anti-parallel to desired direction,
@@ -1111,7 +1111,7 @@ float3 CGroundMoveType::GetObstacleAvoidanceDir(const float3& desiredDir) {
 	// avoider always uses its never-rotated MoveDef footprint
 	// note: should increase radius for smaller turnAccel values
 	const float avoidanceRadius = std::max(currentSpeed, 1.0f) * (avoider->radius * 2.0f);
-	const float avoiderRadius = avoiderUD->CalcFootPrintRadius(1.0f);
+	const float avoiderRadius = avoider->CalcFootPrintRadius(1.0f);
 
 	QuadFieldQuery qfQuery;
 	quadField.GetSolidsExact(qfQuery, avoider->pos, avoidanceRadius, 0xFFFFFFFF, CSolidObject::CSTATE_BIT_SOLIDOBJECTS);
@@ -1631,7 +1631,7 @@ void CGroundMoveType::HandleObjectCollisions()
 		//   _minimally bounding_ the footprint (assuming square shape)
 		//
 		const float colliderSpeed = collider->speed.w;
-		const float colliderRadius = colliderUD->CalcFootPrintRadius(0.75f);
+		const float colliderRadius = collider->CalcFootPrintRadius(0.75f);
 
 		HandleUnitCollisions(collider, colliderSpeed, colliderRadius, colliderUD, colliderMD);
 		HandleFeatureCollisions(collider, colliderSpeed, colliderRadius, colliderUD, colliderMD);

--- a/rts/Sim/MoveTypes/GroundMoveType.cpp
+++ b/rts/Sim/MoveTypes/GroundMoveType.cpp
@@ -1625,13 +1625,14 @@ void CGroundMoveType::HandleObjectCollisions()
 		const UnitDef* colliderUD = collider->unitDef;
 		const MoveDef* colliderMD = collider->moveDef;
 
-		// NOTE:
-		//   0.75 * math::sqrt(2) ~= 1, so radius is always that of a circle
-		//   _maximally bounded_ by the footprint rather than a circle
-		//   _minimally bounding_ the footprint (assuming square shape)
-		//
 		const float colliderSpeed = collider->speed.w;
-		const float colliderRadius = collider->CalcFootPrintRadius(0.75f);
+		// NOTE:
+		//   We are considering a circle _maximally bounded_ by the footprint
+		//   rather than a circle _minimally bounding_ the footprint, assuming
+		//   square shape.
+		//   In case of non-square footprints we can later apply Separable Axes
+		//   theorem SAT
+		const float colliderRadius = std::max(collider->xsize, collider->zsize) * SQUARE_SIZE;
 
 		HandleUnitCollisions(collider, colliderSpeed, colliderRadius, colliderUD, colliderMD);
 		HandleFeatureCollisions(collider, colliderSpeed, colliderRadius, colliderUD, colliderMD);
@@ -1916,7 +1917,7 @@ void CGroundMoveType::HandleUnitCollisions(
 		// use the collidee's MoveDef footprint as radius if it is mobile
 		// use the collidee's Unit (not UnitDef) footprint as radius otherwise
 		const float collideeSpeed = collidee->speed.w;
-		const float collideeRadius = collidee->CalcFootPrintRadius(0.75f);
+		const float collideeRadius = std::max(collidee->xsize, collidee->zsize) * SQUARE_SIZE;
 
 		const float3 separationVector   = collider->pos - collidee->pos;
 		const float separationMinDistSq = (colliderRadius + collideeRadius) * (colliderRadius + collideeRadius);
@@ -2070,7 +2071,7 @@ void CGroundMoveType::HandleFeatureCollisions(
 		// const FeatureDef* collideeFD = collidee->def;
 
 		// use the collidee's Feature (not FeatureDef) footprint as radius
-		const float collideeRadius = collidee->CalcFootPrintRadius(0.75f);
+		const float collideeRadius = std::max(collidee->xsize, collidee->zsize) * SQUARE_SIZE;
 		const float collisionRadiusSum = colliderRadius + collideeRadius;
 
 		const float3 separationVector   = collider->pos - collidee->pos;

--- a/rts/Sim/MoveTypes/GroundMoveType.cpp
+++ b/rts/Sim/MoveTypes/GroundMoveType.cpp
@@ -1632,7 +1632,7 @@ void CGroundMoveType::HandleObjectCollisions()
 		//   square shape.
 		//   In case of non-square footprints we can later apply Separable Axes
 		//   theorem SAT
-		const float colliderRadius = std::max(collider->xsize, collider->zsize) * SQUARE_SIZE;
+		const float colliderRadius = std::max(collider->xsize, collider->zsize) * 0.5f * SQUARE_SIZE;
 
 		HandleUnitCollisions(collider, colliderSpeed, colliderRadius, colliderUD, colliderMD);
 		HandleFeatureCollisions(collider, colliderSpeed, colliderRadius, colliderUD, colliderMD);
@@ -1917,7 +1917,7 @@ void CGroundMoveType::HandleUnitCollisions(
 		// use the collidee's MoveDef footprint as radius if it is mobile
 		// use the collidee's Unit (not UnitDef) footprint as radius otherwise
 		const float collideeSpeed = collidee->speed.w;
-		const float collideeRadius = std::max(collidee->xsize, collidee->zsize) * SQUARE_SIZE;
+		const float collideeRadius = std::max(collidee->xsize, collidee->zsize) * 0.5f * SQUARE_SIZE;
 
 		const float3 separationVector   = collider->pos - collidee->pos;
 		const float separationMinDistSq = (colliderRadius + collideeRadius) * (colliderRadius + collideeRadius);
@@ -2073,7 +2073,7 @@ void CGroundMoveType::HandleFeatureCollisions(
 		// const FeatureDef* collideeFD = collidee->def;
 
 		// use the collidee's Feature (not FeatureDef) footprint as radius
-		const float collideeRadius = std::max(collidee->xsize, collidee->zsize) * SQUARE_SIZE;
+		const float collideeRadius = std::max(collidee->xsize, collidee->zsize) * 0.5f * SQUARE_SIZE;
 		const float collisionRadiusSum = colliderRadius + collideeRadius;
 
 		const float3 separationVector   = collider->pos - collidee->pos;

--- a/rts/Sim/MoveTypes/GroundMoveType.h
+++ b/rts/Sim/MoveTypes/GroundMoveType.h
@@ -132,6 +132,7 @@ private:
 		CUnit* collider,
 		const float colliderSpeed,
 		const float colliderRadius,
+		const float colliderStretch,
 		const UnitDef* colliderUD,
 		const MoveDef* colliderMD
 	);
@@ -139,6 +140,7 @@ private:
 		CUnit* collider,
 		const float colliderSpeed,
 		const float colliderRadius,
+		const float colliderStretch,
 		const UnitDef* colliderUD,
 		const MoveDef* colliderMD
 	);

--- a/rts/Sim/MoveTypes/MoveDefHandler.cpp
+++ b/rts/Sim/MoveTypes/MoveDefHandler.cpp
@@ -368,6 +368,21 @@ bool MoveDef::TestMoveSquareRange(
 }
 
 
+float MoveDef::CalcFootPrintRadius(float scale) const
+{
+	return ((math::sqrt((xsize * xsize + zsize * zsize)) * 0.5f * SQUARE_SIZE) * scale);
+}
+
+float MoveDef::CalcMinimalBoundingFootPrintRadius() const
+{
+	return std::max(xsize, zsize) * 0.5f * SQUARE_SIZE;
+}
+
+float MoveDef::CalcFootPrintStretchingFactor() const
+{
+	return std::abs(xsize - zsize) / (float)(xsize + zsize);
+}
+
 float MoveDef::GetDepthMod(float height) const {
 	// [DEPTHMOD_{MIN, MAX}_HEIGHT] are always >= 0,
 	// so we return early for positive height values

--- a/rts/Sim/MoveTypes/MoveDefHandler.cpp
+++ b/rts/Sim/MoveTypes/MoveDefHandler.cpp
@@ -368,7 +368,6 @@ bool MoveDef::TestMoveSquareRange(
 }
 
 
-float MoveDef::CalcFootPrintRadius(float scale) const { return ((math::sqrt((xsize * xsize + zsize * zsize)) * 0.5f * SQUARE_SIZE) * scale); }
 float MoveDef::GetDepthMod(float height) const {
 	// [DEPTHMOD_{MIN, MAX}_HEIGHT] are always >= 0,
 	// so we return early for positive height values

--- a/rts/Sim/MoveTypes/MoveDefHandler.h
+++ b/rts/Sim/MoveTypes/MoveDefHandler.h
@@ -48,7 +48,6 @@ struct MoveDef {
 	// aircraft and buildings defer to UnitDef::floatOnWater
 	bool FloatOnWater() const { return (speedModClass == MoveDef::Hover || speedModClass == MoveDef::Ship); }
 
-	float CalcFootPrintRadius(float scale) const;
 	float GetDepthMod(float height) const;
 
 	unsigned int GetCheckSum() const;

--- a/rts/Sim/MoveTypes/MoveDefHandler.h
+++ b/rts/Sim/MoveTypes/MoveDefHandler.h
@@ -48,7 +48,10 @@ struct MoveDef {
 	// aircraft and buildings defer to UnitDef::floatOnWater
 	bool FloatOnWater() const { return (speedModClass == MoveDef::Hover || speedModClass == MoveDef::Ship); }
 
+	float CalcFootPrintRadius(float scale) const;
+	float CalcMinimalBoundingFootPrintRadius() const;
 	float GetDepthMod(float height) const;
+	float CalcFootPrintStretchingFactor() const;
 
 	unsigned int GetCheckSum() const;
 

--- a/rts/Sim/Objects/SolidObject.cpp
+++ b/rts/Sim/Objects/SolidObject.cpp
@@ -431,13 +431,18 @@ void CSolidObject::Kill(CUnit* killer, const float3& impulse, bool crushed)
 
 
 
+float CSolidObject::CalcFootPrintRadius(float scale) const
+{
+	return ((math::sqrt((xsize * xsize + zsize * zsize)) * 0.5f * SQUARE_SIZE) * scale);
+}
+
 float CSolidObject::CalcMinimalBoundingFootPrintRadius() const
 {
 	return std::max(xsize, zsize) * 0.5f * SQUARE_SIZE;
 }
 
-float CSolidObject::CalcFootPrintRadius(float scale) const
+float CSolidObject::CalcFootPrintStretchingFactor() const
 {
-	return ((math::sqrt((xsize * xsize + zsize * zsize)) * 0.5f * SQUARE_SIZE) * scale);
+	return std::abs(xsize - zsize) / (float)(xsize + zsize);
 }
 

--- a/rts/Sim/Objects/SolidObject.cpp
+++ b/rts/Sim/Objects/SolidObject.cpp
@@ -431,6 +431,11 @@ void CSolidObject::Kill(CUnit* killer, const float3& impulse, bool crushed)
 
 
 
+float CSolidObject::CalcMinimalBoundingFootPrintRadius() const
+{
+	return std::max(xsize, zsize) * 0.5f * SQUARE_SIZE;
+}
+
 float CSolidObject::CalcFootPrintRadius(float scale) const
 {
 	return ((math::sqrt((xsize * xsize + zsize * zsize)) * 0.5f * SQUARE_SIZE) * scale);

--- a/rts/Sim/Objects/SolidObject.h
+++ b/rts/Sim/Objects/SolidObject.h
@@ -228,6 +228,7 @@ public:
 
 	float GetDrawRadius() const override { return (localModel.GetDrawRadius()); }
 	float CalcFootPrintRadius(float scale) const;
+	float CalcMinimalBoundingFootPrintRadius() const;
 
 	YardMapStatus GetGroundBlockingMaskAtPos(float3 gpos) const;
 

--- a/rts/Sim/Objects/SolidObject.h
+++ b/rts/Sim/Objects/SolidObject.h
@@ -229,6 +229,7 @@ public:
 	float GetDrawRadius() const override { return (localModel.GetDrawRadius()); }
 	float CalcFootPrintRadius(float scale) const;
 	float CalcMinimalBoundingFootPrintRadius() const;
+	float CalcFootPrintStretchingFactor() const;
 
 	YardMapStatus GetGroundBlockingMaskAtPos(float3 gpos) const;
 

--- a/rts/Sim/Units/UnitDef.cpp
+++ b/rts/Sim/Units/UnitDef.cpp
@@ -491,18 +491,6 @@ UnitDef::UnitDef(const LuaTable& udTable, const std::string& unitName, int id)
 	needGeo = false;
 	extractRange = mapInfo->map.extractorRadius * int(extractsMetal > 0.0f);
 
-	// Right now, units/features collisions are computed on top of the
-	// footprint. However, the footprint data used are the moveDef ones, in the
-	// first place, and just in case the unit is not mobile, the unitDef ones.
-	// That's great to can assign a footprint by movement class. But it is even
-	// better if you can optionally select different values per unit.
-	//
-	// To this end, we are initializing right now the footprint as 1 FOOTPRINT
-	// (16 elmos), eventually replacing it by the value set in the movement
-	// class. Finally, we are looking for unitDef defined footprint values
-	xsize = SPRING_FOOTPRINT_SCALE;
-	zsize = SPRING_FOOTPRINT_SCALE;
-
 	{
 		MoveDef* moveDef = nullptr;
 
@@ -529,8 +517,6 @@ UnitDef::UnitDef(const LuaTable& udTable, const std::string& unitName, int id)
 		} else {
 			upright           |= (moveDef->speedModClass == MoveDef::Hover);
 			upright           |= (moveDef->speedModClass == MoveDef::Ship );
-			xsize              = moveDef->xsize;
-			zsize              = moveDef->zsize;
 
 			// we have a MoveDef, so pathType != -1 and IsGroundUnit() MUST be true
 			cantBeTransported |= (!modInfo.transportGround && moveDef->speedModClass == MoveDef::Tank );
@@ -586,14 +572,8 @@ UnitDef::UnitDef(const LuaTable& udTable, const std::string& unitName, int id)
 	activateWhenBuilt = udTable.GetBool("activateWhenBuilt", false);
 	onoffable = udTable.GetBool("onoffable", false);
 
-	// At this point, we already have valid footprint values, that can be
-	// optionally overrided.
-	if (udTable.KeyExists("footprintX")) {
-		xsize = std::max(1 * SPRING_FOOTPRINT_SCALE, (udTable.GetInt("footprintX", 1) * SPRING_FOOTPRINT_SCALE));
-	}
-	if (udTable.KeyExists("footprintZ")) {
-		zsize = std::max(1 * SPRING_FOOTPRINT_SCALE, (udTable.GetInt("footprintZ", 1) * SPRING_FOOTPRINT_SCALE));
-	}
+	xsize = std::max(1 * SPRING_FOOTPRINT_SCALE, (udTable.GetInt("footprintX", 1) * SPRING_FOOTPRINT_SCALE));
+	zsize = std::max(1 * SPRING_FOOTPRINT_SCALE, (udTable.GetInt("footprintZ", 1) * SPRING_FOOTPRINT_SCALE));
 
 	buildingMask = (std::uint16_t)udTable.GetInt("buildingMask", 1); //1st bit set to 1 constitutes for "normal building"
 	if (IsImmobileUnit())


### PR DESCRIPTION
_Restored PR. See https://github.com/spring/spring/pull/422_

A collision detector based on Separable Axes Theorem (SAT). It is a bit more expensive than the radial check, but make possible to model outstretched bodies:

https://youtu.be/L2W0SO9i62w

Comments:

- WARNING! Very little tested! Probably some sort of profiling test is worthing
- ~~Now it is possible to define default footprint values at the moveDefs, optionally overriding them later in the unitDefs. This should be backward compatible, provided that in documentation it's stated that both values shall match. **Should we enforce odd values?**~~
- The repulsion model (when a collision is detected) is not affected yet.
- **Right now is possible to get units stucked**. I'm working on that, but **hints are welcome**.
- The y-direction (bottom-up) interactions are not affected at all, i.e. in that case the radial check is still used to determine if 2 solids are colliding.
- A new game/mod option is available to determine whether SAT-based collision detector should be considered or not
- SAT-based collision detector is not applied if both colliders have square footprint shapes
