### PR TITLE
Configurable drag selection and area command leeway (develop this time)

### DIFF
--- a/rts/Game/UI/GuiHandler.cpp
+++ b/rts/Game/UI/GuiHandler.cpp
@@ -58,6 +58,9 @@
 
 CONFIG(bool, MiniMapMarker).defaultValue(true).headlessValue(false);
 CONFIG(bool, InvertQueueKey).defaultValue(false);
+CONFIG(int, MouseDragCircleCommandThreshold).defaultValue(4).description("Distance in pixels which the mouse must be dragged to trigger a circular area command.");
+CONFIG(int, MouseDragBoxCommandThreshold).defaultValue(16).description("Distance in pixels which the mouse must be dragged to trigger a rectangular area command.");
+CONFIG(int, MouseDragFrontCommandThreshold).defaultValue(30).description("Distance in pixels which the mouse must be dragged to trigger a formation front command.");
 
 //////////////////////////////////////////////////////////////////////
 // Construction/Destruction
@@ -92,6 +95,10 @@ CGuiHandler::CGuiHandler():
 
 	miniMapMarker = configHandler->GetBool("MiniMapMarker");
 	invertQueueKey = configHandler->GetBool("InvertQueueKey");
+
+	dragCircleCommandThreshold = configHandler->GetInt("MouseDragCircleCommandThreshold");
+	dragBoxCommandThreshold = configHandler->GetInt("MouseDragBoxCommandThreshold");
+	dragFrontCommandThreshold = configHandler->GetInt("MouseDragFrontCommandThreshold");
 
 	autoShowMetal = mapInfo->gui.autoShowMetal;
 
@@ -2278,7 +2285,7 @@ Command CGuiHandler::GetCommand(int mouseX, int mouseY, int buttonHint, bool pre
 
 			Command c(commands[tempInCommand].id, CreateOptions(button), innerPos);
 
-			if (mouse->buttons[button].movement > 30) {
+			if (mouse->buttons[button].movement > dragFrontCommandThreshold) {
 				// only create the front if the mouse has moved enough
 				if ((outerDist = CGround::LineGroundCol(cameraPos, cameraPos + mouseDir * traceDist, false)) < 0.0f)
 					outerDist = CGround::LinePlaneCol(cameraPos, mouseDir, traceDist, innerPos.y);
@@ -2307,7 +2314,7 @@ Command CGuiHandler::GetCommand(int mouseX, int mouseY, int buttonHint, bool pre
 
 			Command c(commands[tempInCommand].id, CreateOptions(button));
 
-			if (mouse->buttons[button].movement < 4) {
+			if (mouse->buttons[button].movement <= dragCircleCommandThreshold) {
 				const CUnit* unit = nullptr;
 				const CFeature* feature = nullptr;
 				const float dist2 = TraceRay::GuiTraceRay(cameraPos, mouseDir, globalRendering->viewRange * 1.4f, NULL, unit, feature, true);
@@ -2365,7 +2372,7 @@ Command CGuiHandler::GetCommand(int mouseX, int mouseY, int buttonHint, bool pre
 		case CMDTYPE_ICON_UNIT_OR_RECTANGLE: {
 			Command c(commands[tempInCommand].id, CreateOptions(button));
 
-			if (mouse->buttons[button].movement < 16) {
+			if (mouse->buttons[button].movement <= dragBoxCommandThreshold) {
 				const CUnit* unit = nullptr;
 				const CFeature* feature = nullptr;
 
@@ -3495,7 +3502,7 @@ void CGuiHandler::DrawMapStuff(bool onMiniMap)
 			const SCommandDescription& cmdDesc = commands[cmdIndex];
 			switch (cmdDesc.type) {
 				case CMDTYPE_ICON_FRONT: {
-					if (mouse->buttons[button].movement > 30) {
+					if (mouse->buttons[button].movement > dragFrontCommandThreshold) {
 						float maxSize = 1000000.0f;
 						float sizeDiv = 0.0f;
 
@@ -3517,7 +3524,7 @@ void CGuiHandler::DrawMapStuff(bool onMiniMap)
 					if (cmdDesc.params.size() == 1)
 						maxRadius = atof(cmdDesc.params[0].c_str());
 
-					if (mouse->buttons[button].movement > 4) {
+					if (mouse->buttons[button].movement > dragCircleCommandThreshold) {
 						const float3 camTracePos = mouse->buttons[button].camPos;
 						const float3 camTraceDir = mouse->buttons[button].dir;
 
@@ -3579,7 +3586,7 @@ void CGuiHandler::DrawMapStuff(bool onMiniMap)
 
 				case CMDTYPE_ICON_UNIT_OR_RECTANGLE: {
 					// draw rectangular area-command
-					if (mouse->buttons[button].movement >= 16) {
+					if (mouse->buttons[button].movement > dragBoxCommandThreshold) {
 						const float3 camTracePos = mouse->buttons[button].camPos;
 						const float3 camTraceDir = mouse->buttons[button].dir;
 

--- a/rts/Game/UI/GuiHandler.h
+++ b/rts/Game/UI/GuiHandler.h
@@ -219,6 +219,10 @@ private:
 	bool invColorSelect;
 	bool frontByEnds;
 
+	int dragCircleCommandThreshold;
+	int dragBoxCommandThreshold;
+	int dragFrontCommandThreshold;
+
 	bool useStencil;
 
 	int iconsPerPage;

--- a/rts/Game/UI/MiniMap.cpp
+++ b/rts/Game/UI/MiniMap.cpp
@@ -476,7 +476,7 @@ void CMiniMap::SelectUnits(int x, int y)
 
 	CMouseHandler::ButtonPressEvt& bp = mouse->buttons[SDL_BUTTON_LEFT];
 
-	if (fullProxy && (bp.movement > 4)) {
+	if (fullProxy && (bp.movement > mouse->dragSelectionThreshold)) {
 		// use a selection box
 		const float3 newPos = GetMapPosition(x, y);
 		const float3 oldPos = GetMapPosition(bp.x, bp.y);
@@ -1161,7 +1161,7 @@ void CMiniMap::DrawCameraFrustumAndMouseSelection()
 	// selection box
 	glColor4f(1.0f, 1.0f, 1.0f, 1.0f);
 	CMouseHandler::ButtonPressEvt& bp = mouse->buttons[SDL_BUTTON_LEFT];
-	if (selecting && fullProxy && (bp.movement > 4)) {
+	if (selecting && fullProxy && (bp.movement > mouse->dragSelectionThreshold)) {
 		const float3 oldPos = GetMapPosition(bp.x, bp.y);
 		const float3 newPos = GetMapPosition(mouse->lastx, mouse->lasty);
 		glColor4fv(cmdColors.mouseBox);

--- a/rts/Game/UI/MouseHandler.cpp
+++ b/rts/Game/UI/MouseHandler.cpp
@@ -49,6 +49,7 @@
 CONFIG(bool, HardwareCursor).defaultValue(false).description("Sets hardware mouse cursor rendering. If you have a low framerate, your mouse cursor will seem \"laggy\". Setting hardware cursor will render the mouse cursor separately from spring and the mouse will behave normally. Note, not all GPU drivers support it in fullscreen mode!");
 CONFIG(bool, InvertMouse).defaultValue(false);
 CONFIG(float, DoubleClickTime).defaultValue(200.0f).description("Double click time in milliseconds.");
+CONFIG(int, MouseDragSelectionThreshold).defaultValue(4).description("Distance in pixels which the mouse must be dragged to trigger a selection box.");
 
 CONFIG(float, ScrollWheelSpeed)
 	.defaultValue(25.0f)
@@ -91,6 +92,7 @@ CMouseHandler::CMouseHandler()
 
 	, doubleClickTime(0.0f)
 	, scrollWheelSpeed(0.0f)
+	, dragSelectionThreshold(0)
 
 	, crossSize(0.0f)
 	, crossAlpha(0.0f)
@@ -116,6 +118,7 @@ CMouseHandler::CMouseHandler()
 	doubleClickTime = configHandler->GetFloat("DoubleClickTime") / 1000.0f;
 
 	scrollWheelSpeed = configHandler->GetFloat("ScrollWheelSpeed");
+	dragSelectionThreshold = configHandler->GetInt("MouseDragSelectionThreshold");
 
 	crossSize      = configHandler->GetFloat("CrossSize");
 	crossAlpha     = configHandler->GetFloat("CrossAlpha");
@@ -430,7 +433,7 @@ void CMouseHandler::MouseRelease(int x, int y, int button)
 		if (!KeyInput::GetKeyModState(KMOD_SHIFT) && !KeyInput::GetKeyModState(KMOD_CTRL))
 			selectedUnitsHandler.ClearSelected();
 
-		if (bp.movement > 4) {
+		if (bp.movement > dragSelectionThreshold) {
 			// select box
 			float2 topright, btmleft;
 			GetSelectionBoxCoeff(bp.camPos, bp.dir, camera->GetPos(), dir, topright, btmleft);
@@ -499,7 +502,7 @@ void CMouseHandler::DrawSelectionBox()
 		return;
 	if (bp.chorded)
 		return;
-	if (bp.movement <= 4)
+	if (bp.movement <= dragSelectionThreshold)
 		return;
 
 	if (inMapDrawer != nullptr && inMapDrawer->IsDrawMode())

--- a/rts/Game/UI/MouseHandler.h
+++ b/rts/Game/UI/MouseHandler.h
@@ -107,6 +107,7 @@ private:
 public:
 	float doubleClickTime;
 	float scrollWheelSpeed;
+	int dragSelectionThreshold;
 
 	/// locked mouse indicator size
 	float crossSize;


### PR DESCRIPTION
This PR adds the following springsettings:
- MouseDragSelectionThreshold
- MouseDragCircleCommandThreshold
- MouseDragBoxCommandThreshold
- MouseDragFrontCommandThreshold

Godde keeps commenting that he often right clicks on a unit with the intention to target it, but while doing so accidentally moves the mouse very slightly (because he is microing so hard). This movement leads the interface to interpret his input as an area command, which is likely to not include the desired unit. I have tried hacking some solutions for special cases, but it is a bit of a waste of time when the thresholds are so easily changed within the engine.

See http://zero-k.info/Forum/Post/197424#197424 and https://github.com/ZeroK-RTS/Zero-K/issues/3025

I also fixed an area command visualisation bug caused by mismatched inequalities.

I don't know what is wrong with the merge. Here is an erroneous PR to maintenance: https://github.com/spring/spring/pull/430