### PR TITLE
Configurable drag selection and area command leeway v3

### DIFF
--- a/rts/Game/UI/GuiHandler.cpp
+++ b/rts/Game/UI/GuiHandler.cpp
@@ -85,7 +85,10 @@ CGuiHandler::CGuiHandler()
 	configHandler->NotifyOnChange(this, {"MouseDragCircleCommandThreshold", "MouseDragBoxCommandThreshold", "MouseDragFrontCommandThreshold"});
 }
 
-
+CGuiHandler::~CGuiHandler()
+{
+	configHandler->RemoveObserver(this);
+}
 
 bool CGuiHandler::GetQueueKeystate() const
 {

--- a/rts/Game/UI/GuiHandler.cpp
+++ b/rts/Game/UI/GuiHandler.cpp
@@ -54,6 +54,9 @@
 
 CONFIG(bool, MiniMapMarker).defaultValue(true).headlessValue(false);
 CONFIG(bool, InvertQueueKey).defaultValue(false);
+CONFIG(int, MouseDragCircleCommandThreshold).defaultValue(4).description("Distance in pixels which the mouse must be dragged to trigger a circular area command.");
+CONFIG(int, MouseDragBoxCommandThreshold).defaultValue(16).description("Distance in pixels which the mouse must be dragged to trigger a rectangular area command.");
+CONFIG(int, MouseDragFrontCommandThreshold).defaultValue(30).description("Distance in pixels which the mouse must be dragged to trigger a formation front command.");
 
 //////////////////////////////////////////////////////////////////////
 // Construction/Destruction
@@ -72,6 +75,10 @@ CGuiHandler::CGuiHandler()
 
 	miniMapMarker = configHandler->GetBool("MiniMapMarker");
 	invertQueueKey = configHandler->GetBool("InvertQueueKey");
+
+	dragCircleCommandThreshold = configHandler->GetInt("MouseDragCircleCommandThreshold");
+	dragBoxCommandThreshold = configHandler->GetInt("MouseDragBoxCommandThreshold");
+	dragFrontCommandThreshold = configHandler->GetInt("MouseDragFrontCommandThreshold");
 
 	failedSound = sound->GetDefSoundId("FailedCommand");
 }
@@ -2212,7 +2219,7 @@ Command CGuiHandler::GetCommand(int mouseX, int mouseY, int buttonHint, bool pre
 
 			Command c(commands[tempInCommand].id, CreateOptions(button), innerPos);
 
-			if (mouse->buttons[button].movement > 30) {
+			if (mouse->buttons[button].movement > dragFrontCommandThreshold) {
 				// only create the front if the mouse has moved enough
 				if ((outerDist = CGround::LineGroundCol(cameraPos, cameraPos + mouseDir * traceDist, false)) < 0.0f)
 					outerDist = CGround::LinePlaneCol(cameraPos, mouseDir, traceDist, innerPos.y);
@@ -2241,7 +2248,7 @@ Command CGuiHandler::GetCommand(int mouseX, int mouseY, int buttonHint, bool pre
 
 			Command c(commands[tempInCommand].id, CreateOptions(button));
 
-			if (mouse->buttons[button].movement < 4) {
+			if (mouse->buttons[button].movement <= dragCircleCommandThreshold) {
 				const CUnit* unit = nullptr;
 				const CFeature* feature = nullptr;
 				const float dist2 = TraceRay::GuiTraceRay(cameraPos, mouseDir, camera->GetFarPlaneDist() * 1.4f, nullptr, unit, feature, true);
@@ -2299,7 +2306,7 @@ Command CGuiHandler::GetCommand(int mouseX, int mouseY, int buttonHint, bool pre
 		case CMDTYPE_ICON_UNIT_OR_RECTANGLE: {
 			Command c(commands[tempInCommand].id, CreateOptions(button));
 
-			if (mouse->buttons[button].movement < 16) {
+			if (mouse->buttons[button].movement <= dragBoxCommandThreshold) {
 				const CUnit* unit = nullptr;
 				const CFeature* feature = nullptr;
 
@@ -3564,7 +3571,7 @@ void CGuiHandler::DrawMapStuff(bool onMiniMap)
 
 			switch (cmdDesc.type) {
 				case CMDTYPE_ICON_FRONT: {
-					if (mouse->buttons[button].movement > 30) {
+					if (mouse->buttons[button].movement > dragFrontCommandThreshold) {
 						float maxSize = 1000000.0f;
 						float sizeDiv = 0.0f;
 
@@ -3586,7 +3593,7 @@ void CGuiHandler::DrawMapStuff(bool onMiniMap)
 					if (cmdDesc.params.size() == 1)
 						maxRadius = atof(cmdDesc.params[0].c_str());
 
-					if (mouse->buttons[button].movement > 4) {
+					if (mouse->buttons[button].movement > dragCircleCommandThreshold) {
 						const float3 camTracePos = mouse->buttons[button].camPos;
 						const float3 camTraceDir = mouse->buttons[button].dir;
 
@@ -3648,7 +3655,7 @@ void CGuiHandler::DrawMapStuff(bool onMiniMap)
 
 				case CMDTYPE_ICON_UNIT_OR_RECTANGLE: {
 					// draw rectangular area-command
-					if (mouse->buttons[button].movement >= 16) {
+					if (mouse->buttons[button].movement > dragBoxCommandThreshold) {
 						const float3 camTracePos = mouse->buttons[button].camPos;
 						const float3 camTraceDir = mouse->buttons[button].dir;
 

--- a/rts/Game/UI/GuiHandler.cpp
+++ b/rts/Game/UI/GuiHandler.cpp
@@ -81,6 +81,8 @@ CGuiHandler::CGuiHandler()
 	dragFrontCommandThreshold = configHandler->GetInt("MouseDragFrontCommandThreshold");
 
 	failedSound = sound->GetDefSoundId("FailedCommand");
+	
+	configHandler->NotifyOnChange(this, {"MouseDragCircleCommandThreshold", "MouseDragBoxCommandThreshold", "MouseDragFrontCommandThreshold"});
 }
 
 
@@ -4407,5 +4409,15 @@ void CGuiHandler::DrawSelectBox(GL::RenderDataBufferC* rdb, Shader::IProgramObje
 
 		glAttribStatePtr->LineWidth(1.0f);
 	}
+}
+
+
+/******************************************************************************/
+
+void CGuiHandler::ConfigNotify(const std::string& key, const std::string& value)
+{
+	dragCircleCommandThreshold = configHandler->GetInt("MouseDragCircleCommandThreshold");
+	dragBoxCommandThreshold = configHandler->GetInt("MouseDragBoxCommandThreshold");
+	dragFrontCommandThreshold = configHandler->GetInt("MouseDragFrontCommandThreshold");
 }
 

--- a/rts/Game/UI/GuiHandler.h
+++ b/rts/Game/UI/GuiHandler.h
@@ -27,6 +27,7 @@ struct SCommandDescription;
 class CGuiHandler : public CInputReceiver {
 public:
 	CGuiHandler();
+	~CGuiHandler();
 
 	void Update();
 

--- a/rts/Game/UI/GuiHandler.h
+++ b/rts/Game/UI/GuiHandler.h
@@ -102,6 +102,9 @@ public:
 
 	void LayoutIcons(bool useSelectionPage);
 
+	/// @see ConfigHandler::ConfigNotifyCallback
+	void ConfigNotify(const std::string& key, const std::string& value);
+
 private:
 	void GiveCommand(const Command& cmd, bool fromUser = true);
 	void GiveCommandsNow();

--- a/rts/Game/UI/GuiHandler.h
+++ b/rts/Game/UI/GuiHandler.h
@@ -233,6 +233,9 @@ private:
 	bool invColorSelect = true;
 	bool frontByEnds = false;
 
+	int dragCircleCommandThreshold = 0;
+	int dragBoxCommandThreshold = 0;
+	int dragFrontCommandThreshold = 0;
 
 	struct Box {
 		float x1 = 0.0f;

--- a/rts/Game/UI/MiniMap.cpp
+++ b/rts/Game/UI/MiniMap.cpp
@@ -501,7 +501,7 @@ void CMiniMap::SelectUnits(int x, int y)
 
 	CMouseHandler::ButtonPressEvt& bp = mouse->buttons[SDL_BUTTON_LEFT];
 
-	if (fullProxy && (bp.movement > 4)) {
+	if (fullProxy && (bp.movement > mouse->dragSelectionThreshold)) {
 		// use a selection box
 		const float3 newMapPos = GetMapPosition(x, y);
 		const float3 oldMapPos = GetMapPosition(bp.x, bp.y);
@@ -1423,7 +1423,7 @@ void CMiniMap::RenderCameraFrustumLinesAndSelectionBox(GL::RenderDataBufferC* bu
 		// selection box
 		const CMouseHandler::ButtonPressEvt& bp = mouse->buttons[SDL_BUTTON_LEFT];
 
-		if (bp.movement <= 4)
+		if (bp.movement <= mouse->dragSelectionThreshold)
 			return;
 
 		const float3 oldMapPos = GetMapPosition(bp.x, bp.y);

--- a/rts/Game/UI/MouseHandler.cpp
+++ b/rts/Game/UI/MouseHandler.cpp
@@ -51,6 +51,7 @@ CONFIG(bool, HardwareCursor).defaultValue(false).description("Sets hardware mous
 CONFIG(bool, InvertMouse).defaultValue(false);
 CONFIG(bool, MouseRelativeModeWarp).defaultValue(true);
 CONFIG(float, DoubleClickTime).defaultValue(200.0f).description("Double click time in milliseconds.");
+CONFIG(int, MouseDragSelectionThreshold).defaultValue(4).description("Distance in pixels which the mouse must be dragged to trigger a selection box.");
 
 CONFIG(float, ScrollWheelSpeed)
 	.defaultValue(25.0f)
@@ -88,8 +89,8 @@ CMouseHandler::CMouseHandler()
 
 	invertMouse = configHandler->GetBool("InvertMouse");
 	doubleClickTime = configHandler->GetFloat("DoubleClickTime") / 1000.0f;
-
 	scrollWheelSpeed = configHandler->GetFloat("ScrollWheelSpeed");
+	dragSelectionThreshold = configHandler->GetInt("MouseDragSelectionThreshold");
 
 	crossSize      = configHandler->GetFloat("CrossSize");
 	crossAlpha     = configHandler->GetFloat("CrossAlpha");
@@ -423,7 +424,7 @@ void CMouseHandler::MouseRelease(int x, int y, int button)
 		if (!KeyInput::GetKeyModState(KMOD_SHIFT) && !KeyInput::GetKeyModState(KMOD_CTRL))
 			selectedUnitsHandler.ClearSelected();
 
-		if (bp.movement > 4) {
+		if (bp.movement > dragSelectionThreshold) {
 			// select box
 			float2 topright, btmleft;
 			GetSelectionBoxCoeff(bp.camPos, bp.dir, camera->GetPos(), dir, topright, btmleft);
@@ -489,7 +490,7 @@ void CMouseHandler::DrawSelectionBox()
 		return;
 	if (bp.chorded)
 		return;
-	if (bp.movement <= 4)
+	if (bp.movement <= dragSelectionThreshold)
 		return;
 
 	if (inMapDrawer != nullptr && inMapDrawer->IsDrawMode())

--- a/rts/Game/UI/MouseHandler.cpp
+++ b/rts/Game/UI/MouseHandler.cpp
@@ -98,7 +98,7 @@ CMouseHandler::CMouseHandler()
 
 	dragScrollThreshold = configHandler->GetFloat("MouseDragScrollThreshold");
 
-	configHandler->NotifyOnChange(this, {"MouseDragScrollThreshold", "ScrollWheelSpeed"});
+	configHandler->NotifyOnChange(this, {"MouseDragScrollThreshold", "ScrollWheelSpeed", "MouseDragSelectionThreshold"});
 }
 
 CMouseHandler::~CMouseHandler()
@@ -984,5 +984,6 @@ void CMouseHandler::ConfigNotify(const std::string& key, const std::string& valu
 {
 	dragScrollThreshold = configHandler->GetFloat("MouseDragScrollThreshold");
 	scrollWheelSpeed = configHandler->GetFloat("ScrollWheelSpeed");
+	dragSelectionThreshold = configHandler->GetInt("MouseDragSelectionThreshold");
 }
 

--- a/rts/Game/UI/MouseHandler.h
+++ b/rts/Game/UI/MouseHandler.h
@@ -125,6 +125,7 @@ private:
 public:
 	float doubleClickTime = 0.0f;
 	float scrollWheelSpeed = 0.0f;
+	int dragSelectionThreshold = 0;
 
 	/// locked mouse indicator size
 	float crossSize = 0.0f;


### PR DESCRIPTION
This PR adds the following springsettings:
- MouseDragSelectionThreshold
- MouseDragCircleCommandThreshold
- MouseDragBoxCommandThreshold
- MouseDragFrontCommandThreshold

Godde keeps commenting that he often right clicks on a unit with the intention to target it, but while doing so accidentally moves the mouse very slightly (because he is microing so hard). This movement leads the interface to interpret his input as an area command, which is likely to not include the desired unit. I have tried hacking some solutions for special cases, but it is a bit of a waste of time when the thresholds are so easily changed within the engine.

See http://zero-k.info/Forum/Post/197424#197424 and https://github.com/ZeroK-RTS/Zero-K/issues/3025

I also fixed an area command visualisation bug caused by mismatched inequalities.