### PR TITLE
Add `GetUnitCurrentCommand` lua callout

### DIFF
--- a/doc/changelog.txt
+++ b/doc/changelog.txt
@@ -121,7 +121,9 @@ Lua:
    EmitSfx(p, "cegTag") param will emit the CEG with tag="cegTag"
    EmitSfx(p, SFX.GLOBAL | cegID) will emit the CEG with id=cegID
    Added Spring.GetCEGID("cegTag") to get CEG id from tag
-
+ - Added Spring.GetUnitCurrentCommand(unitID) -> [cmdID, cmdOpts (coded), cmdTag[, cmdParam1[, cmdParam2 ... ]]]
+   Returns the first command in the unit's queue (or nil). Note: cmdOpts are represented by a single number
+   (usually a table otherwise), and params are returned on the stack as well. This function allocates no tables.
 
 AI:
  - reveal unit's captureProgress, buildProgress and paralyzeDamage params through

--- a/rts/Lua/LuaSyncedRead.cpp
+++ b/rts/Lua/LuaSyncedRead.cpp
@@ -4271,10 +4271,10 @@ int LuaSyncedRead::GetUnitCurrentCommand(lua_State* L)
 
 	const CFactoryCAI* factoryCAI = dynamic_cast<const CFactoryCAI*>(commandAI);
 	const CCommandQueue* queue = (factoryCAI == nullptr)? &commandAI->commandQue : &factoryCAI->newUnitCommands;
-	if (queue.empty())
+	if (queue->empty())
 		return 0;
 
-	const Command& cmd = queue.front();
+	const Command& cmd = queue->front();
 	lua_pushnumber(L, cmd.GetID());
 	lua_pushnumber(L, cmd.GetOpts());
 	lua_pushnumber(L, cmd.GetTag());

--- a/rts/Lua/LuaSyncedRead.h
+++ b/rts/Lua/LuaSyncedRead.h
@@ -154,6 +154,7 @@ class LuaSyncedRead {
 		static int GetUnitMoveTypeData(lua_State* L);
 
 		static int GetUnitCommands(lua_State* L);
+		static int GetUnitCurrentCommand(lua_State* L);
 		static int GetFactoryCounts(lua_State* L);
 		static int GetFactoryCommands(lua_State* L);
 


### PR DESCRIPTION
Spring.GetUnitCurrentCommand(unitID) -> [cmdID, cmdOpts (coded), cmdTag[, cmdParam1[, cmdParam2 ... ]]]

Options are coded as a single number and parameters are returned on the stack so that there are no table allocations. This is a form of optimisation because getting the current command is a common action but so far the only available option was GetUnitCommands(unitID, 1) which still allocated 3 tables.