### PR TITLE
Expose tableless GetUnitLosState even if !FullRead

### DIFF
--- a/rts/Lua/LuaSyncedRead.cpp
+++ b/rts/Lua/LuaSyncedRead.cpp
@@ -5597,8 +5597,14 @@ int LuaSyncedRead::GetUnitLosState(lua_State* L)
 		losStatus = unit->losStatus[allyTeamID];
 	}
 
-	if (CLuaHandle::GetHandleFullRead(L) && luaL_optboolean(L, 3, false)) {
-		lua_pushnumber(L, losStatus); // return a numeric value
+	constexpr int prevMask = LOS_PREVLOS | LOS_CONTRADAR;
+	const bool isTyped = (losStatus & prevMask) == prevMask;
+
+	if (luaL_optboolean(L, 3, false)) {
+		if (!CLuaHandle::GetHandleFullRead(L))
+			losStatus &= (isTyped ? prevMask : 0) | LOS_INLOS | LOS_INRADAR;
+
+		lua_pushnumber(L, losStatus);
 		return 1;
 	}
 
@@ -5609,9 +5615,7 @@ int LuaSyncedRead::GetUnitLosState(lua_State* L)
 	if (losStatus & LOS_INRADAR) {
 		HSTR_PUSH_BOOL(L, "radar", true);
 	}
-	const int prevMask = (LOS_PREVLOS | LOS_CONTRADAR);
-	if ((losStatus & LOS_INLOS) ||
-	    ((losStatus & prevMask) == prevMask)) {
+	if ((losStatus & LOS_INLOS) || isTyped) {
 		HSTR_PUSH_BOOL(L, "typed", true);
 	}
 	return 1;

--- a/rts/Lua/LuaSyncedRead.cpp
+++ b/rts/Lua/LuaSyncedRead.cpp
@@ -5597,12 +5597,15 @@ int LuaSyncedRead::GetUnitLosState(lua_State* L)
 		losStatus = unit->losStatus[allyTeamID];
 	}
 
+	constexpr int currMask = LOS_INLOS   | LOS_INRADAR;
 	constexpr int prevMask = LOS_PREVLOS | LOS_CONTRADAR;
-	const bool isTyped = (losStatus & prevMask) == prevMask;
+
+	const bool isTyped = ((losStatus & prevMask) == prevMask);
 
 	if (luaL_optboolean(L, 3, false)) {
+		// return a numeric value
 		if (!CLuaHandle::GetHandleFullRead(L))
-			losStatus &= (isTyped ? prevMask : 0) | LOS_INLOS | LOS_INRADAR;
+			losStatus &= ((prevMask * isTyped) | currMask);
 
 		lua_pushnumber(L, losStatus);
 		return 1;


### PR DESCRIPTION
LuaUI used to be unable to use the table-less version of GetUnitLosState (presumably because the value was not masked).