### PR TITLE
Non-manualfire weapons: only 1 salvo with META

### DIFF
--- a/rts/Sim/Units/CommandAI/CommandAI.cpp
+++ b/rts/Sim/Units/CommandAI/CommandAI.cpp
@@ -1648,11 +1648,12 @@ void CCommandAI::WeaponFired(CWeapon* weapon, const bool searchForNewTarget)
 
 	if (searchForNewTarget) {
 		// manual fire or attack commands with meta will only fire a single salvo
-		// noAutoTarget weapons finish an attack commands after a
-		// salvo if they have more orders queued
-		if (weapon->weaponDef->manualfire && !(c.GetOpts() & META_KEY))
+		if (weapon->weaponDef->manualfire && !(c.GetOpts() & META_KEY)
+		|| !weapon->weaponDef->manualfire &&  (c.GetOpts() & META_KEY))
 			orderFinished = true;
 
+		// noAutoTarget weapons finish an attack commands after a
+		// salvo if they have more orders queued
 		if (weapon->noAutoTarget && !(c.GetOpts() & META_KEY) && haveGroundAttackCmd && HasMoreMoveCommands())
 			orderFinished = true;
 


### PR DESCRIPTION
META doesn't seem to do anything for regular weapons but comments seem to imply it should work as a "shoot just 1 salvo".