### PR TITLE
Add `Spring.Set{Unit,Feature}PieceVisible`

### DIFF
--- a/rts/Lua/LuaSyncedCtrl.cpp
+++ b/rts/Lua/LuaSyncedCtrl.cpp
@@ -202,6 +202,7 @@ bool LuaSyncedCtrl::PushEntries(lua_State* L)
 
 	REGISTER_LUA_CFUNC(SetUnitCollisionVolumeData);
 	REGISTER_LUA_CFUNC(SetUnitPieceCollisionVolumeData);
+	REGISTER_LUA_CFUNC(SetUnitPieceVisible);
 	REGISTER_LUA_CFUNC(SetUnitPieceParent);
 	REGISTER_LUA_CFUNC(SetUnitPieceMatrix);
 	REGISTER_LUA_CFUNC(SetUnitSensorRadius);
@@ -247,6 +248,7 @@ bool LuaSyncedCtrl::PushEntries(lua_State* L)
 	REGISTER_LUA_CFUNC(SetFeatureRadiusAndHeight);
 	REGISTER_LUA_CFUNC(SetFeatureCollisionVolumeData);
 	REGISTER_LUA_CFUNC(SetFeaturePieceCollisionVolumeData);
+	REGISTER_LUA_CFUNC(SetFeaturePieceVisible);
 
 
 	REGISTER_LUA_CFUNC(SetProjectileAlwaysVisible);
@@ -624,6 +626,19 @@ static int SetSolidObjectPieceCollisionVolumeData(lua_State* L, CSolidObject* ob
 	// piece volumes are not allowed to use discrete hit-testing
 	vol->InitShape(scales, offset, vType, CollisionVolume::COLVOL_HITTEST_CONT, pAxis);
 	vol->SetIgnoreHits(!luaL_checkboolean(L, 3));
+	return 0;
+}
+
+static int SetSolidObjectPieceVisible(lua_State* L, CSolidObject* obj)
+{
+	if (obj == nullptr)
+		return 0;
+
+	LocalModelPiece* const lmp = ParseObjectLocalModelPiece(L, obj, 2);
+	if (lmp == nullptr)
+		luaL_argerror(L, 2, "invalid piece");
+
+	lmp->scriptSetVisible = luaL_checkboolean(L, 3);
 	return 0;
 }
 
@@ -2466,6 +2481,10 @@ int LuaSyncedCtrl::SetUnitPieceCollisionVolumeData(lua_State* L)
 	return (SetSolidObjectPieceCollisionVolumeData(L, ParseUnit(L, __func__, 1)));
 }
 
+int LuaSyncedCtrl::SetUnitPieceVisible(lua_State* L)
+{
+	return (SetSolidObjectPieceVisible(L, ParseUnit(L, __func__, 1)));
+}
 
 
 int LuaSyncedCtrl::SetUnitSensorRadius(lua_State* L)
@@ -3196,6 +3215,10 @@ int LuaSyncedCtrl::SetFeaturePieceCollisionVolumeData(lua_State* L)
 	return (SetSolidObjectPieceCollisionVolumeData(L, ParseFeature(L, __func__, 1)));
 }
 
+int LuaSyncedCtrl::SetFeaturePieceVisible(lua_State* L)
+{
+	return (SetSolidObjectPieceVisible(L, ParseFeature(L, __func__, 1)));
+}
 
 /******************************************************************************/
 /******************************************************************************/

--- a/rts/Lua/LuaSyncedCtrl.cpp
+++ b/rts/Lua/LuaSyncedCtrl.cpp
@@ -634,7 +634,7 @@ static int SetSolidObjectPieceVisible(lua_State* L, CSolidObject* obj)
 	if (obj == nullptr)
 		return 0;
 
-	LocalModelPiece* const lmp = ParseObjectLocalModelPiece(L, obj, 2);
+	const LocalModelPiece* lmp = ParseObjectLocalModelPiece(L, obj, 2);
 	if (lmp == nullptr)
 		luaL_argerror(L, 2, "invalid piece");
 

--- a/rts/Lua/LuaSyncedCtrl.h
+++ b/rts/Lua/LuaSyncedCtrl.h
@@ -94,6 +94,7 @@ class LuaSyncedCtrl
 		static int SetUnitRadiusAndHeight(lua_State* L);
 		static int SetUnitCollisionVolumeData(lua_State* L);
 		static int SetUnitPieceCollisionVolumeData(lua_State* L);
+		static int SetUnitPieceVisible(lua_State* L);
 		static int SetUnitPieceParent(lua_State* L);
 		static int SetUnitPieceMatrix(lua_State* L);
 		static int SetUnitSensorRadius(lua_State* L);
@@ -140,6 +141,7 @@ class LuaSyncedCtrl
 		static int SetFeatureRadiusAndHeight(lua_State* L);
 		static int SetFeatureCollisionVolumeData(lua_State* L);
 		static int SetFeaturePieceCollisionVolumeData(lua_State* L);
+		static int SetFeaturePieceVisible(lua_State* L);
 
 		static int SetProjectileAlwaysVisible(lua_State* L);
 		static int SetProjectileUseAirLos(lua_State* L);


### PR DESCRIPTION
Features don't have a unit script so need a standalone callout. Units are mostly there for consistency since they already have `SetPieceVisibility` in LUS but being able to hide a unit's piece outside LUS (either because COB or for convenience) is also nice.