### PR TITLE
Add `GetCurrentCamera`, tableless `GetCameraState`

### DIFF
--- a/doc/changelog.txt
+++ b/doc/changelog.txt
@@ -144,6 +144,13 @@ Lua:
  ! Spring.GetTeamInfo: switched the last two return values around (incomeMultiplier is now 7th, customKeys is now 8th)
  - Added a second boolean parameter to Spring.Get{Player,Team}Info, if it is false the function will not return
    the (now) last return value, the customKeys table (allocation optimisation)
+ - Added Spring.GetCurrentCamera, returns the name of the current camera
+ - Added a boolean parameter to Spring.GetCameraState, if set to false it will return the following camera-specific values on the stack:
+     fps, rot -> oldHeight
+     ta -> height, angle, flipped
+     spring -> rx, ry, rz, dist
+     free -> rx, ry, rz, vx, vy, vz, avx, avy, avz
+     ov -> (nil)
 
 AI:
  - reveal unit's captureProgress, buildProgress and paralyzeDamage params through

--- a/doc/changelog.txt
+++ b/doc/changelog.txt
@@ -145,7 +145,8 @@ Lua:
  - Added a second boolean parameter to Spring.Get{Player,Team}Info, if it is false the function will not return
    the (now) last return value, the customKeys table (allocation optimisation)
  - Added Spring.GetCurrentCamera, returns the name of the current camera
- - Added a boolean parameter to Spring.GetCameraState, if set to false it will return the following camera-specific values on the stack:
+ - Added a boolean parameter to Spring.GetCameraState, if set to false it will return the current camera name
+   and then thefollowing camera-specific values on the stack:
      fps, rot -> oldHeight
      ta -> height, angle, flipped
      spring -> rx, ry, rz, dist

--- a/doc/changelog.txt
+++ b/doc/changelog.txt
@@ -148,9 +148,8 @@ Lua:
    the (now) last return value, the customKeys table (allocation optimisation)
  ! Spring.GetUnit{Armored,IsActive} now works on enemies in LoS
  ! Spring.GetUnitMass no longer works on enemies outside of LoS
- - Added Spring.GetCurrentCamera, returns the name of the current camera
  - Added a boolean parameter to Spring.GetCameraState, if set to false it will return the current camera name
-   and then thefollowing camera-specific values on the stack:
+   and then the following camera-specific values on the stack:
      fps, rot -> oldHeight
      ta -> height, angle, flipped
      spring -> rx, ry, rz, dist

--- a/rts/Lua/LuaUnsyncedRead.cpp
+++ b/rts/Lua/LuaUnsyncedRead.cpp
@@ -1440,27 +1440,29 @@ int LuaUnsyncedRead::GetCameraState(lua_State* L)
 	camHandler->GetState(camState);
 
 	if (!luaL_optboolean(L, 1, true)) {
-		// table-less version; pushes just the cam-specific values
-		// use GetCurrentCamera first to know how to interpret them
+		// table-less version; pushes just the name and the cam-specific values
+		// you can use GetCurrentCamera beforehand to know how to interpret the values
 		// use GetCamera{Position,Direction,FOV} for the common fields from the base class
+		lua_pushsstring(L, camHandler->GetCurrentController().GetName());
+
 		switch (camHandler->GetCurrentControllerNum()) {
 		case CCameraHandler::CAMERA_MODE_FIRSTPERSON:
 		case CCameraHandler::CAMERA_MODE_ROTOVERHEAD: // happens to have the same set of values as FPS
 			lua_pushnumber(L, camState["oldHeight"]);
-			return 1;
+			return 1 + 1;
 
 		case CCameraHandler::CAMERA_MODE_OVERHEAD:
 			lua_pushnumber(L, camState["height"]);
 			lua_pushnumber(L, camState["angle"]);
 			lua_pushnumber(L, camState["flipped"]);
-			return 3;
+			return 1 + 3;
 
 		case CCameraHandler::CAMERA_MODE_SPRING:
 			lua_pushnumber(L, camState["rx"]);
 			lua_pushnumber(L, camState["ry"]);
 			lua_pushnumber(L, camState["rz"]);
 			lua_pushnumber(L, camState["dist"]);
-			return 4;
+			return 1 + 4;
 
 		case CCameraHandler::CAMERA_MODE_FREE:
 			lua_pushnumber(L, camState["rx"]);
@@ -1472,12 +1474,12 @@ int LuaUnsyncedRead::GetCameraState(lua_State* L)
 			lua_pushnumber(L, camState["avx"]);
 			lua_pushnumber(L, camState["avy"]);
 			lua_pushnumber(L, camState["avz"]);
-			return 9;
+			return 1 + 9;
 
 		case CCameraHandler::CAMERA_MODE_OVERVIEW:
 		default:
 			// overview has no extra values
-			return 0;
+			return 1 + 0;
 		}
 	}
 

--- a/rts/Lua/LuaUnsyncedRead.cpp
+++ b/rts/Lua/LuaUnsyncedRead.cpp
@@ -167,7 +167,6 @@ bool LuaUnsyncedRead::PushEntries(lua_State* L)
 	REGISTER_LUA_CFUNC(GetLosViewColors);
 
 	REGISTER_LUA_CFUNC(GetCameraNames);
-	REGISTER_LUA_CFUNC(GetCurrentCamera);
 	REGISTER_LUA_CFUNC(GetCameraState);
 	REGISTER_LUA_CFUNC(GetCameraPosition);
 	REGISTER_LUA_CFUNC(GetCameraDirection);
@@ -1428,12 +1427,6 @@ int LuaUnsyncedRead::GetCameraNames(lua_State* L)
 	return 1;
 }
 
-int LuaUnsyncedRead::GetCurrentCamera(lua_State* L)
-{
-	lua_pushsstring(L, camHandler->GetCurrentController().GetName());
-	return 1;
-}
-
 int LuaUnsyncedRead::GetCameraState(lua_State* L)
 {
 	CCameraController::StateMap camState;
@@ -1441,7 +1434,6 @@ int LuaUnsyncedRead::GetCameraState(lua_State* L)
 
 	if (!luaL_optboolean(L, 1, true)) {
 		// table-less version; pushes just the name and the cam-specific values
-		// you can use GetCurrentCamera beforehand to know how to interpret the values
 		// use GetCamera{Position,Direction,FOV} for the common fields from the base class
 		lua_pushsstring(L, camHandler->GetCurrentController().GetName());
 

--- a/rts/Lua/LuaUnsyncedRead.h
+++ b/rts/Lua/LuaUnsyncedRead.h
@@ -91,6 +91,7 @@ class LuaUnsyncedRead {
 		static int GetLosViewColors(lua_State* L);
 
 		static int GetCameraNames(lua_State* L);
+		static int GetCurrentCamera(lua_State* L);
 		static int GetCameraState(lua_State* L);
 		static int GetCameraPosition(lua_State* L);
 		static int GetCameraDirection(lua_State* L);

--- a/rts/Lua/LuaUnsyncedRead.h
+++ b/rts/Lua/LuaUnsyncedRead.h
@@ -91,7 +91,6 @@ class LuaUnsyncedRead {
 		static int GetLosViewColors(lua_State* L);
 
 		static int GetCameraNames(lua_State* L);
-		static int GetCurrentCamera(lua_State* L);
 		static int GetCameraState(lua_State* L);
 		static int GetCameraPosition(lua_State* L);
 		static int GetCameraDirection(lua_State* L);


### PR DESCRIPTION
`Spring.GetCurrentCamera` returns the name of the current camera,
for example "ta" or "spring" (currently available under the `name`
key in the table returned by `Spring.GetCameraState`).

`Spring.GetCameraState` now accepts a boolean parameter; if it is
false then instead of allocating a table, it returns cam-specific
values onto the stack (use `GetCurrentCamera` first to know how to
interpret them; use `GetCamera{Position,Direction,FOV}` to get the
non-specific values from the base class). The returned values are:
  fps, rot -> oldHeight
  ta -> height, angle, flipped
  spring -> rx, ry, rz, dist
  free -> rx, ry, rz, vx, vy, vz, avx, avy, avz
  ov -> (nil)