### PR TITLE
Waypoint skipping fix for Mantis 6206.

### DIFF
--- a/rts/Sim/MoveTypes/GroundMoveType.cpp
+++ b/rts/Sim/MoveTypes/GroundMoveType.cpp
@@ -1589,8 +1589,8 @@ bool CGroundMoveType::CanSetNextWayPoint() {
 			// note: can somehow cause units to move in circles near obstacles
 			// (mantis3718) if rectangle is too generous in size
 			const bool rangeTest = owner->moveDef->TestMoveSquareRange(owner, float3::min(cwp, pos), float3::max(cwp, pos), owner->speed, true, true, true);
-			const bool facePoint = ((pos - cwp).dot(flatFrontDir) < 0.0f);
-			const bool allowSkip = ((pos - cwp).SqLength() <= Square(SQUARE_SIZE));
+			const bool facePoint = ((cwp - pos).dot(flatFrontDir) >= 0.0f);
+			const bool allowSkip = ((cwp - pos).SqLength() <= Square(SQUARE_SIZE));
 
 			// CanSetNextWayPoint may return true if (allowSkip || (rangeTest && facePoint))
 			if (!allowSkip && (!rangeTest || !facePoint))

--- a/rts/Sim/MoveTypes/GroundMoveType.cpp
+++ b/rts/Sim/MoveTypes/GroundMoveType.cpp
@@ -1589,9 +1589,11 @@ bool CGroundMoveType::CanSetNextWayPoint() {
 			// note: can somehow cause units to move in circles near obstacles
 			// (mantis3718) if rectangle is too generous in size
 			const bool rangeTest = owner->moveDef->TestMoveSquareRange(owner, float3::min(cwp, pos), float3::max(cwp, pos), owner->speed, true, true, true);
-			const bool allowSkip = ((pos - cwp).SqLength() <= Square(SQUARE_SIZE) || (pos - cwp).dot(flatFrontDir) < 0.0f);
+			const bool facePoint = ((pos - cwp).dot(flatFrontDir) < 0.0f);
+			const bool allowSkip = ((pos - cwp).SqLength() <= Square(SQUARE_SIZE));
 
-			if (!rangeTest && !allowSkip)
+			// CanSetNextWayPoint may return true if (allowSkip || (rangeTest && facePoint))
+			if (!allowSkip && (!rangeTest || !facePoint))
 				return false;
 		}
 


### PR DESCRIPTION
This PR changes the logic in CanSetNextWayPoint and splits allowSkip into allowSkip and facePoint.

Previously, CanSetNextWayPoint could return true if (allowSkip || rangeTest || facePoint). This caused waypoints to be skipped even if there was no free path to it's goal (!rangeTest) if it happened to be facing its goal (facePoint).

This change has CanSetNextWayPoint able to return true if (allowSkip || (rangeTest && facePoint)), which fixes the issue with the previous behaviour.