### PR TITLE
`GetUnit{Armored,IsActive}`: allow enemies in los

### DIFF
--- a/doc/changelog.txt
+++ b/doc/changelog.txt
@@ -146,6 +146,8 @@ Lua:
  ! Spring.GetTeamInfo: switched the last two return values around (incomeMultiplier is now 7th, customKeys is now 8th)
  - Added a second boolean parameter to Spring.Get{Player,Team}Info, if it is false the function will not return
    the (now) last return value, the customKeys table (allocation optimisation)
+ ! Spring.GetUnit{Armored,IsActive} now works on enemies in LoS
+ ! Spring.GetUnitMass no longer works on enemies outside of LoS
 
 AI:
  - reveal unit's captureProgress, buildProgress and paralyzeDamage params through

--- a/rts/Lua/LuaSyncedRead.cpp
+++ b/rts/Lua/LuaSyncedRead.cpp
@@ -2771,7 +2771,7 @@ int LuaSyncedRead::GetUnitStates(lua_State* L)
 
 int LuaSyncedRead::GetUnitArmored(lua_State* L)
 {
-	const CUnit* unit = ParseAllyUnit(L, __func__, 1);
+	const CUnit* unit = ParseInLosUnit(L, __func__, 1);
 	if (unit == nullptr)
 		return 0;
 
@@ -2783,7 +2783,7 @@ int LuaSyncedRead::GetUnitArmored(lua_State* L)
 
 int LuaSyncedRead::GetUnitIsActive(lua_State* L)
 {
-	const CUnit* unit = ParseAllyUnit(L, __func__, 1);
+	const CUnit* unit = ParseInLosUnit(L, __func__, 1);
 	if (unit == nullptr)
 		return 0;
 


### PR DESCRIPTION
Most existing games give visual feedback regarding both states so I think this is a preferable default behaviour.