### PR TITLE
Solid objects interpolation based on prevPos instead of speed

### DIFF
--- a/rts/Lua/LuaSyncedCtrl.cpp
+++ b/rts/Lua/LuaSyncedCtrl.cpp
@@ -601,6 +601,8 @@ static int SetSolidObjectPhysicalState(lua_State* L, CSolidObject* o)
 	// do not need ForcedSpin, above three calls cover it
 	o->ForcedMove(pos);
 	o->SetVelocityAndSpeed(speed);
+	if (luaL_optboolean(L, 14, true))
+		o->DisjointInterpolation();
 	return 0;
 }
 
@@ -2636,6 +2638,8 @@ int LuaSyncedCtrl::SetUnitPosition(lua_State* L)
 	}
 
 	unit->ForcedMove(pos);
+	if (luaL_optboolean(L, 5, true))
+		unit->DisjointInterpolation();
 	return 0;
 }
 
@@ -3104,6 +3108,8 @@ int LuaSyncedCtrl::SetFeaturePosition(lua_State* L)
 	pos.z = luaL_checkfloat(L, 4);
 
 	feature->ForcedMove(pos);
+	if (luaL_optboolean(L, 5, true))
+		feature->DisjointInterpolation();
 	return 0;
 }
 

--- a/rts/Rendering/UnitDrawer.cpp
+++ b/rts/Rendering/UnitDrawer.cpp
@@ -1511,9 +1511,9 @@ inline void CUnitDrawer::UpdateUnitDrawPos(CUnit* u) {
 	const CUnit* t = u->GetTransporter();
 
 	if (t != nullptr) {
-		u->drawPos = u->GetDrawPos(t->speed, globalRendering->timeOffset);
+		u->drawPos = u->GetDrawPos(t->pos - t->prevPos, globalRendering->timeOffset);
 	} else {
-		u->drawPos = u->GetDrawPos(          globalRendering->timeOffset);
+		u->drawPos = u->GetDrawPos(                     globalRendering->timeOffset);
 	}
 
 	u->drawMidPos = u->GetMdlDrawMidPos();

--- a/rts/Sim/Features/Feature.cpp
+++ b/rts/Sim/Features/Feature.cpp
@@ -464,10 +464,10 @@ void CFeature::ForcedMove(const float3& newPos)
 	quadField.RemoveFeature(this);
 
 	const float3 oldPos = pos;
-	prevPos = pos;
 
 	UnBlock();
 	Move(newPos - pos, true);
+	DisjointInterpolation();
 	Block();
 
 	// ForcedMove calls might cause the pstate to go stale
@@ -550,6 +550,7 @@ bool CFeature::UpdateVelocity(
 bool CFeature::UpdatePosition()
 {
 	const float3 oldPos = pos;
+	prevPos = pos;
 	// const float4 oldSpd = speed;
 
 	if (moveCtrl.enabled) {

--- a/rts/Sim/Features/Feature.cpp
+++ b/rts/Sim/Features/Feature.cpp
@@ -188,6 +188,7 @@ void CFeature::Initialize(const FeatureLoadParams& params)
 
 	// set position before mid-position
 	Move((params.pos).cClampInMap(), false);
+	DisjointInterpolation();
 	// use base-class version, AddFeature() below
 	// will already insert us in the update-queue
 	CWorldObject::SetVelocity(params.speed);
@@ -463,6 +464,7 @@ void CFeature::ForcedMove(const float3& newPos)
 	quadField.RemoveFeature(this);
 
 	const float3 oldPos = pos;
+	prevPos = pos;
 
 	UnBlock();
 	Move(newPos - pos, true);

--- a/rts/Sim/Objects/SolidObject.cpp
+++ b/rts/Sim/Objects/SolidObject.cpp
@@ -69,6 +69,7 @@ CR_REG_METADATA(CSolidObject,
 
 	CR_MEMBER(drawPos),
 	CR_MEMBER(drawMidPos),
+	CR_MEMBER(prevPos),
 	CR_IGNORED(blockMap), // reloaded in CUnit's PostLoad
 	CR_MEMBER(yardOpen),
 

--- a/rts/Sim/Objects/SolidObject.h
+++ b/rts/Sim/Objects/SolidObject.h
@@ -123,6 +123,7 @@ public:
 		midPos += dv;
 		aimPos += dv;
 	}
+	void DisjointInterpolation() {prevPos = pos; }
 
 	// this should be called whenever the direction
 	// vectors are changed (ie. after a rotation) in
@@ -287,6 +288,10 @@ public:
 
 	virtual void SetMass(float newMass);
 
+	// extrapolated base-positions; used in unsynced code
+	float3 GetDrawPos(                float t) const { return (prevPos + (pos - prevPos) * t); }
+	float3 GetDrawPos(const float3 v, float t) const { return (prevPos +               v * t); }
+
 private:
 	void SetMidPos(const float3& mp, bool relative) {
 		if (relative) {
@@ -402,6 +407,8 @@ public:
 	float3 drawPos;
 	///< drawPos + relMidPos (unsynced)
 	float3 drawMidPos;
+	///< position at the start of the frame
+	float3 prevPos;
 
 	/**
 	 * @brief mod controlled parameters

--- a/rts/Sim/Units/Unit.cpp
+++ b/rts/Sim/Units/Unit.cpp
@@ -338,6 +338,7 @@ void CUnit::PreInit(const UnitLoadParams& params)
 
 	SetVelocity(params.speed);
 	Move((params.pos).cClampInMap(), false);
+	DisjointInterpolation();
 	UpdateDirVectors(!upright);
 	SetMidAndAimPos(model->relMidPos, model->relMidPos, true);
 	SetRadiusAndHeight(model);

--- a/rts/Sim/Units/UnitHandler.cpp
+++ b/rts/Sim/Units/UnitHandler.cpp
@@ -323,6 +323,11 @@ void CUnitHandler::UpdateUnitMoveTypes()
 
 	for (activeUpdateUnit = 0; activeUpdateUnit < activeUnits.size(); ++activeUpdateUnit) {
 		CUnit* unit = activeUnits[activeUpdateUnit];
+		unit->prevPos = unit->pos;
+	}
+
+	for (activeUpdateUnit = 0; activeUpdateUnit < activeUnits.size(); ++activeUpdateUnit) {
+		CUnit* unit = activeUnits[activeUpdateUnit];
 		AMoveType* moveType = unit->moveType;
 
 		SanityCheckUnit(unit);

--- a/rts/Sim/Units/UnitHandler.cpp
+++ b/rts/Sim/Units/UnitHandler.cpp
@@ -324,10 +324,6 @@ void CUnitHandler::UpdateUnitMoveTypes()
 	for (activeUpdateUnit = 0; activeUpdateUnit < activeUnits.size(); ++activeUpdateUnit) {
 		CUnit* unit = activeUnits[activeUpdateUnit];
 		unit->prevPos = unit->pos;
-	}
-
-	for (activeUpdateUnit = 0; activeUpdateUnit < activeUnits.size(); ++activeUpdateUnit) {
-		CUnit* unit = activeUnits[activeUpdateUnit];
 		AMoveType* moveType = unit->moveType;
 
 		SanityCheckUnit(unit);


### PR DESCRIPTION
This PR replaces the draw interpolation based on speed with interpolation based on the units position at the start of the frame. The motivation is to better handle cases where a units speed is a poor predictor of where it will be next frame (such as when colliding with other units or terrain). This change to interpolation reduces the amount of jittering seen in these cases.

Added arguments to Set{Unit,Feature}Position and Set{Unit,Feature}Physics that reset the interpolation position. This allows lua to implement mechanics that cause discontinuous jumps in unit position, such as teleportation, without breaking the interpolation.

This PR only affects solid objects since speed is a good predictor for the next position of cegs and projectiles.

See: https://youtu.be/nQLdJUsbsRY