### PR TITLE
Fix circling at the start of paths

### DIFF
--- a/rts/Sim/MoveTypes/GroundMoveType.cpp
+++ b/rts/Sim/MoveTypes/GroundMoveType.cpp
@@ -1589,11 +1589,10 @@ bool CGroundMoveType::CanSetNextWayPoint() {
 			// note: can somehow cause units to move in circles near obstacles
 			// (mantis3718) if rectangle is too generous in size
 			const bool rangeTest = owner->moveDef->TestMoveSquareRange(owner, float3::min(cwp, pos), float3::max(cwp, pos), owner->speed, true, true, true);
-			const bool facePoint = ((cwp - pos).dot(flatFrontDir) >= 0.0f);
 			const bool allowSkip = ((cwp - pos).SqLength() <= Square(SQUARE_SIZE));
 
-			// CanSetNextWayPoint may return true if (allowSkip || (rangeTest && facePoint))
-			if (!allowSkip && (!rangeTest || !facePoint))
+			// CanSetNextWayPoint may return true if (allowSkip || rangeTest)
+			if (!allowSkip && !rangeTest)
 				return false;
 		}
 


### PR DESCRIPTION
My previous PR (https://github.com/spring/spring/pull/455) made it too difficult to skip waypoints, which caused units to circle on the spot when given new move commands. This PR removes the facePoint check for waypoint skipping. I have not found any issues with removing the facePoint test. It will require live testing and feedback.

Before my previous PR a waypoint could be skipped if (allowSkip || rangeTest || facePoint). The behaviour proposed here is (allowSkip || rangeTest). I tested and there is no regression for the waypoint skipping PR. The skipping check in this PR is harder to satisfy than prior to either PR, so it is unlikely that there is a regression in other behaviour. I did some testing of units that initially can skip waypoints but which become blocked due to their turning circle (see the end of the video).

If there are further issues I may try using a facePoint-like test to increase the apparent width of the unit by its turn radius for the purpose of TestMoveSquareRange. TestMoveSquareRange could also be improved to test movement along a line instead of in a rectangle.

See: https://youtu.be/boEM-gKh-1w