### PR TITLE
Add `Spring.UnitFinishCommand(unitID)`

### DIFF
--- a/doc/changelog.txt
+++ b/doc/changelog.txt
@@ -135,6 +135,8 @@ Lua:
  - Added VFS.GetFileAbsolutePath(string vfsFilePath) -> string filePathOnDisk
  - Added VFS.GetArchiveContainingFile(string vfsFilePath) -> string archiveName
  - add a 6th return value (feature->reclaimTime) to GetFeatureResources.
+ - Add `Spring.UnitFinishCommand(unitID)`, finishes current command. Unlike CMD.REMOVE it works with Repeat/UnitCmdDone
+   and unlike CommandFallback it works on builtin engine commands. 
  - Allow spawning of any CEG from any LUS:
    EmitSfx(p, "cegTag") param will emit the CEG with tag="cegTag"
    EmitSfx(p, SFX.GLOBAL | cegID) will emit the CEG with id=cegID

--- a/rts/Lua/LuaSyncedCtrl.cpp
+++ b/rts/Lua/LuaSyncedCtrl.cpp
@@ -276,6 +276,7 @@ bool LuaSyncedCtrl::PushEntries(lua_State* L)
 	//FIXME: REGISTER_LUA_CFUNC(GetUnitCOBValue);
 	//FIXME: REGISTER_LUA_CFUNC(SetUnitCOBValue);
 
+	REGISTER_LUA_CFUNC(UnitFinishCommand);
 	REGISTER_LUA_CFUNC(GiveOrderToUnit);
 	REGISTER_LUA_CFUNC(GiveOrderToUnitMap);
 	REGISTER_LUA_CFUNC(GiveOrderToUnitArray);
@@ -3519,6 +3520,21 @@ static void ParseUnitArray(lua_State* L, const char* caller,
 
 
 /******************************************************************************/
+
+int LuaSyncedCtrl::UnitFinishCommand(lua_State* L)
+{
+	CheckAllowGameChanges(L);
+
+	CUnit* const unit = ParseUnit(L, __func__, 1);
+	if (unit == nullptr)
+		luaL_error(L, "Invalid unitID given to UnitFinishCommand()");
+
+	CCommandAI* const cai = unit->commandAI;
+	if (!cai->commandQue.empty())
+		cai->FinishCommand();
+
+	return 0;
+}
 
 int LuaSyncedCtrl::GiveOrderToUnit(lua_State* L)
 {

--- a/rts/Lua/LuaSyncedCtrl.cpp
+++ b/rts/Lua/LuaSyncedCtrl.cpp
@@ -3525,11 +3525,11 @@ int LuaSyncedCtrl::UnitFinishCommand(lua_State* L)
 {
 	CheckAllowGameChanges(L);
 
-	CUnit* const unit = ParseUnit(L, __func__, 1);
+	CUnit* unit = ParseUnit(L, __func__, 1);
 	if (unit == nullptr)
-		luaL_error(L, "Invalid unitID given to UnitFinishCommand()");
+		luaL_error(L, "[%s] invalid unitID", __func__);
 
-	CCommandAI* const cai = unit->commandAI;
+	CCommandAI* cai = unit->commandAI;
 	if (!cai->commandQue.empty())
 		cai->FinishCommand();
 
@@ -3543,7 +3543,7 @@ int LuaSyncedCtrl::GiveOrderToUnit(lua_State* L)
 	CUnit* unit = ParseUnit(L, __func__, 1);
 
 	if (unit == nullptr)
-		luaL_error(L, "Invalid unitID given to GiveOrderToUnit()");
+		luaL_error(L, "[%s] invalid unitID", __func__);
 
 	Command cmd = LuaUtils::ParseCommand(L, __func__, 2);
 
@@ -3553,7 +3553,7 @@ int LuaSyncedCtrl::GiveOrderToUnit(lua_State* L)
 	}
 
 	if (inGiveOrder)
-		luaL_error(L, "GiveOrderToUnit() recursion is not permitted");
+		luaL_error(L, "[%s] recursion not permitted", __func__);
 
 	inGiveOrder = true;
 	unit->commandAI->GiveCommand(cmd);
@@ -3580,9 +3580,8 @@ int LuaSyncedCtrl::GiveOrderToUnitMap(lua_State* L)
 
 	Command cmd = LuaUtils::ParseCommand(L, __func__, 2);
 
-	if (inGiveOrder) {
-		luaL_error(L, "GiveOrderToUnitMap() recursion is not permitted");
-	}
+	if (inGiveOrder)
+		luaL_error(L, "[%s] recursion not permitted", __func__);
 
 	inGiveOrder = true;
 	int count = 0;
@@ -3616,9 +3615,9 @@ int LuaSyncedCtrl::GiveOrderToUnitArray(lua_State* L)
 
 	Command cmd = LuaUtils::ParseCommand(L, __func__, 2);
 
-	if (inGiveOrder) {
-		luaL_error(L, "GiveOrderToUnitArray() recursion is not permitted");
-	}
+	if (inGiveOrder)
+		luaL_error(L, "[%s] recursion not permitted", __func__);
+
 	inGiveOrder = true;
 
 	int count = 0;
@@ -3656,9 +3655,9 @@ int LuaSyncedCtrl::GiveOrderArrayToUnitMap(lua_State* L)
 		return 1;
 	}
 
-	if (inGiveOrder) {
-		luaL_error(L, "GiveOrderArrayToUnitMap() recursion is not permitted");
-	}
+	if (inGiveOrder)
+		luaL_error(L, "[%s] recursion not permitted", __func__);
+
 	inGiveOrder = true;
 
 	int count = 0;
@@ -3699,9 +3698,9 @@ int LuaSyncedCtrl::GiveOrderArrayToUnitArray(lua_State* L)
 		return 1;
 	}
 
-	if (inGiveOrder) {
-		luaL_error(L, "GiveOrderArrayToUnitArray() recursion is not permitted");
-	}
+	if (inGiveOrder)
+		luaL_error(L, "[%s] recursion not permitted", __func__);
+
 	inGiveOrder = true;
 
 	int count = 0;

--- a/rts/Lua/LuaSyncedCtrl.h
+++ b/rts/Lua/LuaSyncedCtrl.h
@@ -43,6 +43,7 @@ class LuaSyncedCtrl
 		static int SetUnitRulesParam(lua_State* L);
 		static int SetFeatureRulesParam(lua_State* L);
 
+		static int UnitFinishCommand(lua_State* L);
 		static int GiveOrderToUnit(lua_State* L);
 		static int GiveOrderToUnitMap(lua_State* L);
 		static int GiveOrderToUnitArray(lua_State* L);


### PR DESCRIPTION
Finishes current command.
 * similar to `CMD.REMOVE`, but puts the command back onto the queue with the Repeat state.
 * similar to returning `true, true` from `CommandFallback` but works on builtin engine commands.