### PR TITLE
`CMD.REMOVE`: `META` option now means finish

### DIFF
--- a/doc/changelog.txt
+++ b/doc/changelog.txt
@@ -135,6 +135,7 @@ Lua:
  - Added VFS.GetFileAbsolutePath(string vfsFilePath) -> string filePathOnDisk
  - Added VFS.GetArchiveContainingFile(string vfsFilePath) -> string archiveName
  - add a 6th return value (feature->reclaimTime) to GetFeatureResources.
+ - the META option for the REMOVE command now means the removed command is subject to Repeat state
  - Allow spawning of any CEG from any LUS:
    EmitSfx(p, "cegTag") param will emit the CEG with tag="cegTag"
    EmitSfx(p, SFX.GLOBAL | cegID) will emit the CEG with id=cegID


### PR DESCRIPTION
Behaves as if the command finished normally (ie. gets put back at the end of the queue if Repeat state is enabled)

An alternate approach to #462.