### PR TITLE
Lack of the use of TeamColor uniform causes warning spam like this:

### DIFF
--- a/rts/Lua/LuaMaterial.cpp
+++ b/rts/Lua/LuaMaterial.cpp
@@ -642,8 +642,8 @@ void LuaMatUniforms::Validate(LuaMatShader* s)
 	}
 
 	// print warning when teamcolor is not bound
-	if (!teamColor.IsValid())
-		LOG_L(L_WARNING, fmts[1], __func__);
+	//if (!teamColor.IsValid())
+		//LOG_L(L_WARNING, fmts[1], __func__);
 
 
 	const decltype(GetEngineNameUniformPairs())& uniforms = GetEngineNameUniformPairs();


### PR DESCRIPTION
"Warning: [LuaMatUniforms::Validate] missing "TeamColor" uniform"

I don't think TeamColor should be mandatory. In fact it's only expected to be present for opaque* materials.
alpha* or shadow materials will most likely won't use the TeamColor uniform.
Therefore, I suggest we remove that check & warning.