### PR TITLE
Probably fixed https://github.com/ZeroK-RTS/CrashReports/issues/23539

### DIFF
--- a/cont/base/springcontent/shaders/GLSL/ShadowGenVertProg.glsl
+++ b/cont/base/springcontent/shaders/GLSL/ShadowGenVertProg.glsl
@@ -1,3 +1,10 @@
+#if (GL_FRAGMENT_PRECISION_HIGH == 1)
+// ancient GL3 ATI drivers confuse GLSL for GLSL-ES and require this
+precision highp float;
+#else
+precision mediump float;
+#endif
+
 uniform vec4 shadowParams;
 
 #ifdef SHADOWGEN_PROGRAM_TREE_NEAR


### PR DESCRIPTION
> error: type mismatch for varying parameter (named {shadowViewMat, shadowProjMat, vertexModelPos}) between shader stages