### PR TITLE
Better fix(?) to https://springrts.com/mantis/view.php?id=6100

### DIFF
--- a/rts/Game/Camera.cpp
+++ b/rts/Game/Camera.cpp
@@ -262,11 +262,16 @@ void CCamera::UpdateViewRange()
 	// view-angle dependent (i.e. FPS-view)
 	wantedViewRange = std::max(wantedViewRange, angleViewRange);
 
+#if 0
 	// NOTE: factor is always >= 1, not what we want when near ground
 	const float factor = wantedViewRange / CGlobalRendering::MAX_VIEW_RANGE;
 
 	frustum.scales.z = CGlobalRendering::NEAR_PLANE * factor;
 	frustum.scales.w = CGlobalRendering::MAX_VIEW_RANGE * factor;
+#else
+	frustum.scales.z = 0.001 * wantedViewRange;
+	frustum.scales.w = wantedViewRange;
+#endif
 }
 
 

--- a/rts/Rendering/Env/BumpWater.cpp
+++ b/rts/Rendering/Env/BumpWater.cpp
@@ -1111,7 +1111,16 @@ void CBumpWater::Draw()
 
 	glMultiTexCoord2f(GL_TEXTURE1, windVec.x, windVec.z);
 	glPolygonMode(GL_FRONT_AND_BACK, GL_LINE * wireFrameMode + GL_FILL * (1 - wireFrameMode));
+#if 1
+	glEnable(GL_POLYGON_OFFSET_FILL);
+	glPolygonOffset(0, 2);
+
 	glCallList(displayList);
+
+	glDisable(GL_POLYGON_OFFSET_FILL);
+#else
+	glCallList(displayList);
+#endif
 	glPolygonMode(GL_FRONT_AND_BACK, GL_FILL);
 
 	waterShader->Disable();


### PR DESCRIPTION
Hopefully fixed bump water flickering by making znear larger and introducing glPolygonOffset into the bump water rendering loop. znear increase doesn't seem to reproduce any ill effects during my tests.

maintenance version for review and tests.