### PR TITLE
Seems like a fix to https://springrts.com/mantis/view.php?id=6307

### DIFF
--- a/rts/Game/Camera.cpp
+++ b/rts/Game/Camera.cpp
@@ -278,7 +278,7 @@ void CCamera::UpdateViewRange()
 	// camera-height dependence (i.e. TAB-view)
 	wantedViewRange = std::max(wantedViewRange, (pos.y - std::max(0.0f, mapMinHeight)) * 2.0f);
 	// view-angle dependence (i.e. FPS-view)
-	wantedViewRange = std::max(wantedViewRange, (1.0f - std::max(0.0f, forward.dot(UpVector))) * maxEdgeDist);
+	wantedViewRange = std::max(wantedViewRange, (1.0f - forward.dot(UpVector)) * maxEdgeDist);
 
 	#if 0
 	wantedViewRange = std::max(wantedViewRange, CGround::LinePlaneCol(pos, tlPixelDir, SQ_MAX_VIEW_RANGE, mapMinHeight));

--- a/rts/Rendering/GlobalRendering.cpp
+++ b/rts/Rendering/GlobalRendering.cpp
@@ -189,7 +189,7 @@ CGlobalRendering::CGlobalRendering()
 
 	// sane defaults
 	, minViewRange(MIN_ZNEAR_DIST * 8.0f)
-	, maxViewRange(MAX_VIEW_RANGE * 0.25f)
+	, maxViewRange(MAX_VIEW_RANGE * 0.6f)
 	, aspectRatio(1.0f)
 
 	, forceDisableShaders(configHandler->GetInt("ForceDisableShaders"))


### PR DESCRIPTION
White cutoff wall as per https://springrts.com/mantis/view.php?id=6307 seems to have been caused by:
*  `std::max(0.0f, ...)` of `std::max(0.0f, forward.dot(UpVector)))` when camera view angle becomes almost parallel to the ground
*  and insufficient default maxViewRange in the rest of the cases