### PR TITLE
Prevent nullpo in LuaMenu Reload call

### DIFF
--- a/rts/System/SpringApp.cpp
+++ b/rts/System/SpringApp.cpp
@@ -648,7 +648,8 @@ void SpringApp::Reload(const std::string script)
 
 	// Lua shutdown functions need to access 'game' but spring::SafeDelete sets it to NULL.
 	// ~CGame also calls this, which does not matter because handlers are gone by then
-	game->KillLua(false);
+	if (game)
+		game->KillLua(false);
 
 	LOG("[SpringApp::%s][3]", __func__);
 

--- a/rts/System/SpringApp.cpp
+++ b/rts/System/SpringApp.cpp
@@ -647,8 +647,8 @@ void SpringApp::Reload(const std::string script)
 		clientNet->ResetDemoRecorder();
 
 	// Lua shutdown functions need to access 'game' but spring::SafeDelete sets it to NULL.
-	// ~CGame also calls this, which does not matter because handlers are gone by then
-	if (game)
+	// ~CGame also calls this, which does not matter because Lua handlers are gone by then
+	if (game != nullptr)
 		game->KillLua(false);
 
 	LOG("[SpringApp::%s][3]", __func__);


### PR DESCRIPTION
`game` can be a null pointer when LuaMenu calls `SpringApp::Reload`.

In practice this didn't cause many problems, as this gets optimised as
a fixed function call, with a null `this` parameter. This led it to be
left unnoticed.

However, when using tools that are stricter about bad behaviour
(-fsanitize=...), this would detect a null pointer dereference and
abort the program.

Encountered incidentally during mantis #6327.