### PR TITLE
Rifle weapontype: remove hardcoded particles

### DIFF
--- a/rts/Sim/Weapons/Rifle.cpp
+++ b/rts/Sim/Weapons/Rifle.cpp
@@ -5,13 +5,9 @@
 #include "Game/TraceRay.h"
 #include "Game/GameHelper.h"
 #include "Map/Ground.h"
-#include "Rendering/Env/Particles/Classes/HeatCloudProjectile.h"
-#include "Rendering/Env/Particles/Classes/SmokeProjectile.h"
-#include "Rendering/Env/Particles/Classes/TracerProjectile.h"
 #include "Sim/Misc/GlobalSynced.h"
 #include "Sim/Units/Unit.h"
 #include "Sim/Features/Feature.h"
-#include "Sim/Projectiles/ProjectileMemPool.h"
 #include "System/SpringMath.h"
 
 CR_BIND_DERIVED(CRifle, CWeapon, )
@@ -35,14 +31,8 @@ void CRifle::FireImpl(const bool scriptCall)
 	const float length = TraceRay::TraceRay(weaponMuzzlePos, dir, range, 0, owner, hitUnit, hitFeature);
 	const float impulse = CGameHelper::CalcImpulseScale(*damages, 1.0f);
 
-	if (hitUnit != nullptr) {
+	if (hitUnit != nullptr)
 		hitUnit->DoDamage(*damages, dir * impulse, owner, weaponDef->id, -1);
-		projMemPool.alloc<CHeatCloudProjectile>(owner, weaponMuzzlePos + dir * length, hitUnit->speed * 0.9f, 30, 1);
-	} else if (hitFeature != nullptr) {
+	else if (hitFeature != nullptr)
 		hitFeature->DoDamage(*damages, dir * impulse, owner, weaponDef->id, -1);
-		projMemPool.alloc<CHeatCloudProjectile>(owner, weaponMuzzlePos + dir * length, hitFeature->speed * 0.9f, 30, 1);
-	}
-
-	projMemPool.alloc<CTracerProjectile>(owner, weaponMuzzlePos, dir * projectileSpeed, length);
-	projMemPool.alloc<CSmokeProjectile>(owner, weaponMuzzlePos, ZeroVector, 70, 0.1f, 0.02f, 0.6f);
 }


### PR DESCRIPTION
I don't think anybody is using Rifles (harcoded low-quality particles being one of the reasons!) so this should do no harm and is fairly easy to replicate with Lua. On the other hand, Rifle could become more useful as a very simple hitscan weapon (simpler than BeamLaser which still involves a projectile).