### PR TITLE
Fix build failure with new glibc 2.30 and gcc-9 with security hardeni…

### DIFF
--- a/rts/System/Platform/Linux/ThreadSupport.h
+++ b/rts/System/Platform/Linux/ThreadSupport.h
@@ -21,6 +21,8 @@ namespace Threading {
 	);
 }
 
-int gettid ();
+extern "C" {
+__pid_t gettid() __THROW;
+}
 
 #endif // THREADSIGNALHANDLER_H


### PR DESCRIPTION
…ng flags enabled

cd /<<BUILDDIR>>/spring-104.0+dfsg/obj-x86_64-linux-gnu/test && /usr/bin/c++  -DASIO_STANDALONE -DBOOST_NO_FENV_H -DBOOST_TEST_DYN_LINK -DSPRING_DATADIR=\"/usr/share/games/spring:/usr/lib/spring\" -DSTREFLOP_SSE -DSYNCCHECK -DUNIT_TEST -DUSE_LIBSQUISH -D_GLIBCXX_USE_NANOSLEEP -D_RANDOM_TCC -I/<<BUILDDIR>>/spring-104.0+dfsg/obj-x86_64-linux-gnu/src-generated/engine -I/<<BUILDDIR>>/spring-104.0+dfsg/rts -I/<<BUILDDIR>>/spring-104.0+dfsg/rts/lib/asio/include  -g -O2 -fdebug-prefix-map=/<<BUILDDIR>>/spring-104.0+dfsg=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2  -std=gnu++11 -fdiagnostics-color=auto -mtune=generic -msse -mfpmath=sse -mno-sse2 -mno-sse3 -mno-ssse3 -mno-sse4.1 -mno-sse4.2 -mno-sse4 -mno-sse4a -mno-avx -mno-fma -mno-fma4 -mno-xop -mno-lwp -mno-avx2 -fsingle-precision-constant -frounding-math -mieee-fp -pipe -fno-strict-aliasing  -fvisibility=hidden  -fvisibility-inlines-hidden -pthread  -O2      -Wformat -Wformat-security -DNDEBUG -g   -DTHREADPOOL -DUNITSYNC -o CMakeFiles/test_ThreadPool.dir/engine/System/testThreadPool.cpp.o -c /<<BUILDDIR>>/spring-104.0+dfsg/test/engine/System/testThreadPool.cpp
In file included from /usr/include/unistd.h:1170,
                 from /usr/include/boost/config/stdlib/libstdcpp3.hpp:78,
                 from /usr/include/boost/config.hpp:49,
                 from /usr/include/boost/thread/detail/config.hpp:11,
                 from /usr/include/boost/thread/future.hpp:11,
                 from /<<BUILDDIR>>/spring-104.0+dfsg/test/engine/System/testThreadPool.cpp:12:
/usr/include/x86_64-linux-gnu/bits/unistd_ext.h:34:16: error: conflicting declaration of ‘__pid_t gettid()’ with ‘C’ linkage
   34 | extern __pid_t gettid (void) __THROW;
      |                ^~~~~~
In file included from /<<BUILDDIR>>/spring-104.0+dfsg/rts/System/Platform/Threading.h:9,
                 from /<<BUILDDIR>>/spring-104.0+dfsg/rts/System/Threading/ThreadPool.h:66,
                 from /<<BUILDDIR>>/spring-104.0+dfsg/test/engine/System/testThreadPool.cpp:3:
/<<BUILDDIR>>/spring-104.0+dfsg/rts/System/Platform/Linux/ThreadSupport.h:24:5: note: previous declaration with ‘C++’ linkage
   24 | int gettid ();
      |     ^~~~~~