### PR TITLE
Added stopToAttack 

### DIFF
--- a/rts/Lua/LuaUnitDefs.cpp
+++ b/rts/Lua/LuaUnitDefs.cpp
@@ -865,6 +865,7 @@ ADD_BOOL("canAttackWater",  canAttackWater); // CUSTOM
 
 	ADD_BOOL("levelGround", ud.levelGround);
 	ADD_BOOL("strafeToAttack", ud.strafeToAttack);
+	ADD_BOOL("stopToAttack", ud.stopToAttack);
 
 	ADD_BOOL( "useBuildingGroundDecal",  ud.decalDef.useGroundDecal);
 	ADD_INT(  "buildingDecalType",       ud.decalDef.groundDecalType);

--- a/rts/Sim/Units/CommandAI/MobileCAI.cpp
+++ b/rts/Sim/Units/CommandAI/MobileCAI.cpp
@@ -710,7 +710,7 @@ void CMobileCAI::ExecuteObjectAttack(Command& c)
 	// also make sure that we're not locked in close-in/in-range state
 	// loop due to rotates invoked by in-range or out-of-range states
 	if (tryTargetRotate) {
-		const bool canChaseTarget = (owner->moveState != MOVESTATE_HOLDPOS);
+		const bool canChaseTarget = (!owner->unitDef->stopToAttack) && (owner->moveState != MOVESTATE_HOLDPOS);
 		const bool targetBehind = (targetMidPosVec.dot(orderTarget->speed) < 0.0f);
 
 		if (canChaseTarget && tryTargetHeading && targetBehind && !owner->unitDef->IsHoveringAirUnit()) {

--- a/rts/Sim/Units/UnitDef.cpp
+++ b/rts/Sim/Units/UnitDef.cpp
@@ -110,6 +110,7 @@ UnitDef::UnitDef()
 	, floatOnWater(false)
 	, pushResistant(false)
 	, strafeToAttack(false)
+	, stopToAttack(false)
 	, minCollisionSpeed(0.0f)
 	, slideTolerance(0.0f)
 	, maxHeightDif(0.0f)
@@ -599,6 +600,7 @@ UnitDef::UnitDef(const LuaTable& udTable, const std::string& unitName, int id)
 	canLoopbackAttack = udTable.GetBool("canLoopbackAttack", false);
 	levelGround = udTable.GetBool("levelGround", true);
 	strafeToAttack = udTable.GetBool("strafeToAttack", false);
+	stopToAttack = udTable.GetBool("stopToAttack", false);
 
 
 	// initialize the (per-unitdef) collision-volume

--- a/rts/Sim/Units/UnitDef.h
+++ b/rts/Sim/Units/UnitDef.h
@@ -177,6 +177,7 @@ public:
 	bool floatOnWater;
 	bool pushResistant;
 	bool strafeToAttack;  /// should the unit move sideways when it can't shoot?
+	bool stopToAttack;
 	float minCollisionSpeed;
 	float slideTolerance;
 	float maxHeightDif;   /// maximum terraform height this building allows


### PR DESCRIPTION
The PR adds a tag to disable MobileCAI giving move orders while attacking. It is a step towards making polishing starcraft-style unit interactions.

Without this change units set to maneuver or roam move along with their target, even when in range.I do not want to use hold position because it removes idle target acquisition and affects fight.

This is a compatible changed cherry picked from the fork I referenced in this ticket: https://springrts.com/mantis/view.php?id=6199