### PR TITLE
Added pathRadiusMult.

### DIFF
--- a/rts/Sim/Features/Feature.cpp
+++ b/rts/Sim/Features/Feature.cpp
@@ -167,6 +167,7 @@ void CFeature::Initialize(const FeatureLoadParams& params)
 	resources = {def->metal, def->energy};
 
 	crushResistance = def->crushResistance;
+	pathRadiusMult = def->pathRadiusMult;
 
 	xsize = ((buildFacing & 1) == 0) ? def->xsize : def->zsize;
 	zsize = ((buildFacing & 1) == 1) ? def->xsize : def->zsize;

--- a/rts/Sim/Features/FeatureDefHandler.cpp
+++ b/rts/Sim/Features/FeatureDefHandler.cpp
@@ -137,6 +137,7 @@ FeatureDef* CFeatureDefHandler::CreateFeatureDef(const LuaTable& fdTable, const 
 
 	fd.mass = Clamp(fdTable.GetFloat("mass", defMass), minMass, maxMass);
 	fd.crushResistance = fdTable.GetFloat("crushResistance", fd.mass);
+	fd.pathRadiusMult = fdTable.GetFloat("pathRadiusMult", 1.0f);
 
 	fd.decalDef.Parse(fdTable);
 

--- a/rts/Sim/MoveTypes/GroundMoveType.cpp
+++ b/rts/Sim/MoveTypes/GroundMoveType.cpp
@@ -402,7 +402,7 @@ CGroundMoveType::CGroundMoveType(CUnit* owner):
 	// unit-gravity must always be negative
 	myGravity = mix(-math::fabs(ud->myGravity), mapInfo->map.gravity, ud->myGravity == 0.0f);
 
-	ownerRadius = md->CalcFootPrintMinExteriorRadius();
+	ownerRadius = owner->CalcFootPrintMinExteriorRadius();
 }
 
 CGroundMoveType::~CGroundMoveType()
@@ -1298,7 +1298,7 @@ float3 CGroundMoveType::GetObstacleAvoidanceDir(const float3& desiredDir) {
 	// avoider always uses its never-rotated MoveDef footprint
 	// note: should increase radius for smaller turnAccel values
 	const float avoidanceRadius = std::max(currentSpeed, 1.0f) * (avoider->radius * 2.0f);
-	const float avoiderRadius = avoiderMD->CalcFootPrintMinExteriorRadius();
+	const float avoiderRadius = avoider->CalcFootPrintMinExteriorRadius();
 
 	QuadFieldQuery qfQuery;
 	quadField.GetSolidsExact(qfQuery, avoider->pos, avoidanceRadius, 0xFFFFFFFF, CSolidObject::CSTATE_BIT_SOLIDOBJECTS);
@@ -1761,8 +1761,8 @@ void CGroundMoveType::HandleObjectCollisions()
 		// NOTE:
 		//   use the collider's MoveDef footprint as radius since it is
 		//   always mobile (its UnitDef footprint size may be different)
-		const float colliderFootPrintRadius = colliderMD->CalcFootPrintMaxInteriorRadius(); // ~= CalcFootPrintMinExteriorRadius(0.75f)
-		const float colliderAxisStretchFact = colliderMD->CalcFootPrintAxisStretchFactor();
+		const float colliderFootPrintRadius = collider->CalcFootPrintMaxInteriorRadius(); // ~= CalcFootPrintMinExteriorRadius(0.75f)
+		const float colliderAxisStretchFact = collider->CalcFootPrintAxisStretchFactor();
 
 		HandleUnitCollisions(collider, {collider->speed.w, colliderFootPrintRadius, colliderAxisStretchFact}, colliderUD, colliderMD);
 		HandleFeatureCollisions(collider, {collider->speed.w, colliderFootPrintRadius, colliderAxisStretchFact}, colliderUD, colliderMD);

--- a/rts/Sim/Objects/SolidObject.cpp
+++ b/rts/Sim/Objects/SolidObject.cpp
@@ -22,6 +22,7 @@ CR_REG_METADATA(CSolidObject,
 
 	CR_MEMBER(mass),
 	CR_MEMBER(crushResistance),
+	CR_MEMBER(pathRadiusMult),
 
 	CR_MEMBER(crushable),
 	CR_MEMBER(immobile),
@@ -448,8 +449,8 @@ void CSolidObject::Kill(CUnit* killer, const float3& impulse, bool crushed)
 
 
 
-float CSolidObject::CalcFootPrintMinExteriorRadius(float scale) const { return ((math::sqrt((xsize * xsize + zsize * zsize)) * 0.5f * SQUARE_SIZE) * scale); }
-float CSolidObject::CalcFootPrintMaxInteriorRadius(float scale) const { return ((std::max(xsize, zsize) * 0.5f * SQUARE_SIZE) * scale); }
+float CSolidObject::CalcFootPrintMinExteriorRadius(float scale) const { return ((pathRadiusMult * math::sqrt((xsize * xsize + zsize * zsize)) * 0.5f * SQUARE_SIZE) * scale); }
+float CSolidObject::CalcFootPrintMaxInteriorRadius(float scale) const { return ((pathRadiusMult * std::max(xsize, zsize) * 0.5f * SQUARE_SIZE) * scale); }
 float CSolidObject::CalcFootPrintAxisStretchFactor() const
 {
 	return (std::abs(xsize - zsize) * 1.0f / (xsize + zsize));

--- a/rts/Sim/Objects/SolidObject.h
+++ b/rts/Sim/Objects/SolidObject.h
@@ -317,6 +317,8 @@ public:
 	float mass = DEFAULT_MASS;
 	///< how much MoveDef::crushStrength is required to crush this object (run-time constant)
 	float crushResistance = 0.0f;
+	///< Modifies the radius used by the path follower for avoidance and push-collisions.
+	float pathRadiusMult = 01.0f;
 
 	///< whether this object can potentially be crushed during a collision with another object
 	bool crushable = false;

--- a/rts/Sim/Objects/SolidObjectDef.cpp
+++ b/rts/Sim/Objects/SolidObjectDef.cpp
@@ -51,6 +51,7 @@ SolidObjectDef::SolidObjectDef()
 	, health(0.0f)
 	, mass(0.0f)
 	, crushResistance(0.0f)
+	, pathRadiusMult(1.0f)
 
 	, collidable(false)
 	, selectable(true)

--- a/rts/Sim/Objects/SolidObjectDef.h
+++ b/rts/Sim/Objects/SolidObjectDef.h
@@ -61,6 +61,7 @@ public:
 	float health;
 	float mass;
 	float crushResistance;
+	float pathRadiusMult;
 
 	///< if false, object can NOT be collided with by SolidObject's
 	///< (but projectiles and raytraces will still interact with it)

--- a/rts/Sim/Units/Unit.cpp
+++ b/rts/Sim/Units/Unit.cpp
@@ -256,6 +256,7 @@ void CUnit::PreInit(const UnitLoadParams& params)
 	beingBuilt = params.beingBuilt;
 	mass = (beingBuilt)? mass: unitDef->mass;
 	crushResistance = unitDef->crushResistance;
+	pathRadiusMult = unitDef->pathRadiusMult;
 	power = unitDef->power;
 	maxHealth = unitDef->health;
 	health = beingBuilt? 0.1f: unitDef->health;

--- a/rts/Sim/Units/UnitDef.cpp
+++ b/rts/Sim/Units/UnitDef.cpp
@@ -581,6 +581,16 @@ UnitDef::UnitDef(const LuaTable& udTable, const std::string& unitName, int id)
 	xsize = std::max(1 * SPRING_FOOTPRINT_SCALE, (udTable.GetInt("footprintX", 1) * SPRING_FOOTPRINT_SCALE));
 	zsize = std::max(1 * SPRING_FOOTPRINT_SCALE, (udTable.GetInt("footprintZ", 1) * SPRING_FOOTPRINT_SCALE));
 
+	if (RequireMoveDef()) {
+		// Reverse compatibility for collision radii that are derived from the moveDef footprint. The typical case is
+		// a square unit with (xsize == moveDef->xsize + 1). This multiplier makes the conversion to the same radius
+		// as the previous behaviour.
+		pathRadiusMult = udTable.GetFloat("pathRadiusMult", (xsize - 1)/xsize);
+		
+	} else {
+		pathRadiusMult = udTable.GetFloat("pathRadiusMult", 1.0f);
+	}
+
 	buildingMask = (std::uint16_t)udTable.GetInt("buildingMask", 1); //1st bit set to 1 constitutes for "normal building"
 	if (IsImmobileUnit())
 		CreateYardMap(udTable.GetString("yardMap", ""));


### PR DESCRIPTION
This PR adds and exposes a multiplier to the sphere of repulsive force between units. This is part of my attempt to fix pushResistant and give Spring the parameters required to make more starcraft-style units. A multiplier of around 1.3 does not appear to break pathfinding and makes units less clumped. Simply increasing their footprint is a problem with pushResistant, since it blocks and area based on footprint size.

If adding an extra float to SolidObject is somehow terrible for performance then I'd consider adding it to movedefs instead.