### PR TITLE
Added the modrule decloakRequiresLineOfSight

### DIFF
--- a/rts/Sim/Misc/ModInfo.cpp
+++ b/rts/Sim/Misc/ModInfo.cpp
@@ -85,6 +85,7 @@ void CModInfo::ResetState()
 
 		requireSonarUnderWater = true;
 		alwaysVisibleOverridesCloaked = false;
+		decloakRequiresLineOfSight = false;
 		separateJammers = true;
 	}
 	{
@@ -252,6 +253,7 @@ void CModInfo::Init(const std::string& modFileName)
 
 		requireSonarUnderWater = sensors.GetBool("requireSonarUnderWater", requireSonarUnderWater);
 		alwaysVisibleOverridesCloaked = sensors.GetBool("alwaysVisibleOverridesCloaked", alwaysVisibleOverridesCloaked);
+		decloakRequiresLineOfSight = sensors.GetBool("decloakRequiresLineOfSight", decloakRequiresLineOfSight);
 		separateJammers = sensors.GetBool("separateJammers", separateJammers);
 
 		// losMipLevel is used as index to readMap->mipHeightmaps,

--- a/rts/Sim/Misc/ModInfo.h
+++ b/rts/Sim/Misc/ModInfo.h
@@ -136,8 +136,10 @@ public:
 
 	/// when underwater, units are not in LOS unless also in sonar
 	bool requireSonarUnderWater;
-	///
+	/// when unit->alwaysVisible is true, it is visible even when cloaked
 	bool alwaysVisibleOverridesCloaked;
+	/// ignore enemies when checking decloak if they are further than their spherical sight range
+	bool decloakRequiresLineOfSight;
 	/// should _all_ allyteams share the same jammermap
 	bool separateJammers;
 

--- a/rts/Sim/Units/Unit.cpp
+++ b/rts/Sim/Units/Unit.cpp
@@ -2395,7 +2395,7 @@ bool CUnit::GetNewCloakState(bool stunCheck) {
 	const CUnit* closestEnemy = this;
 
 	if (!stunCheck)
-		closestEnemy = CGameHelper::GetClosestEnemyUnitNoLosTest(this, midPos, decloakDistance, allyteam, unitDef->decloakSpherical, false);
+		closestEnemy = CGameHelper::GetClosestEnemyUnitNoLosTest(this, midPos, decloakDistance, allyteam, unitDef->decloakSpherical, modInfo.decloakRequiresLineOfSight);
 
 	return (eventHandler.AllowUnitCloak(this, closestEnemy));
 }


### PR DESCRIPTION
This controls whether sight distance is used as a filter on proximity cloak checks, allowing for cheap implementations of the behaviour desired by FLOZi for s44 and myself for ZK.
Added a missing comment for alwaysVisibleOverridesCloaked.

See:
 * https://springrts.com/mantis/view.php?id=6306 - Behaviour change requested by FLOZi.
 * https://github.com/spring/spring/commit/ca1557cdee3fe4075ff9d987dfe0926a229146d6 - Behaviour change implemented.
 * https://springrts.com/mantis/view.php?id=6374 - My ticket when I noticed that the behaviour changed.
 * http://zero-k.info/Forum/Thread/29941 - Thread reporting the change.