### PR TITLE
Fixed invalid collideeMD usage when modInfo.allowSepAxisCollisionTest = true (maintenance)

### DIFF
--- a/rts/Sim/MoveTypes/GroundMoveType.cpp
+++ b/rts/Sim/MoveTypes/GroundMoveType.cpp
@@ -2038,7 +2038,7 @@ void CGroundMoveType::HandleUnitCollisions(
 		const float2 collideeParams = {collidee->speed.w, collideeMobile? collideeMD->CalcFootPrintMaxInteriorRadius(): collidee->CalcFootPrintMaxInteriorRadius()};
 		const float4 separationVect = {collider->pos - collidee->pos, Square(colliderParams.y + collideeParams.y)};
 
-		if (!checkCollisionFuncs[allowSAT && (forceSAT || (collideeMD->CalcFootPrintAxisStretchFactor() > 0.1f))](separationVect, collider, collidee, colliderMD, collideeMD))
+		if (!checkCollisionFuncs[allowSAT && (forceSAT || (collideeMobile ? collideeMD->CalcFootPrintAxisStretchFactor() > 0.1f : false))](separationVect, collider, collidee, colliderMD, collideeMD)) {
 			continue;
 
 

--- a/rts/Sim/MoveTypes/GroundMoveType.cpp
+++ b/rts/Sim/MoveTypes/GroundMoveType.cpp
@@ -2038,7 +2038,7 @@ void CGroundMoveType::HandleUnitCollisions(
 		const float2 collideeParams = {collidee->speed.w, collideeMobile? collideeMD->CalcFootPrintMaxInteriorRadius(): collidee->CalcFootPrintMaxInteriorRadius()};
 		const float4 separationVect = {collider->pos - collidee->pos, Square(colliderParams.y + collideeParams.y)};
 
-		if (!checkCollisionFuncs[allowSAT && (forceSAT || (collideeMobile ? collideeMD->CalcFootPrintAxisStretchFactor() > 0.1f : false))](separationVect, collider, collidee, colliderMD, collideeMD))
+		if (!checkCollisionFuncs[allowSAT && (forceSAT || (collideeMobile && collideeMD->CalcFootPrintAxisStretchFactor() > 0.1f))](separationVect, collider, collidee, colliderMD, collideeMD))
 			continue;
 
 

--- a/rts/Sim/MoveTypes/GroundMoveType.cpp
+++ b/rts/Sim/MoveTypes/GroundMoveType.cpp
@@ -2038,7 +2038,7 @@ void CGroundMoveType::HandleUnitCollisions(
 		const float2 collideeParams = {collidee->speed.w, collideeMobile? collideeMD->CalcFootPrintMaxInteriorRadius(): collidee->CalcFootPrintMaxInteriorRadius()};
 		const float4 separationVect = {collider->pos - collidee->pos, Square(colliderParams.y + collideeParams.y)};
 
-		if (!checkCollisionFuncs[allowSAT && (forceSAT || (collideeMobile ? collideeMD->CalcFootPrintAxisStretchFactor() > 0.1f : false))](separationVect, collider, collidee, colliderMD, collideeMD)) {
+		if (!checkCollisionFuncs[allowSAT && (forceSAT || (collideeMobile ? collideeMD->CalcFootPrintAxisStretchFactor() > 0.1f : false))](separationVect, collider, collidee, colliderMD, collideeMD))
 			continue;
 
 


### PR DESCRIPTION
collideeMD can be a nullptr, as it is stated in https://github.com/spring/spring/blob/develop/rts/Sim/MoveTypes/GroundMoveType.cpp#L2008:

		const bool collideeMobile = (collideeMD != nullptr); // maybe true

And indeed it happens with every single unit which does not needs SAT, right after building it in a factory. Thus, calling to collideeMD->CalcFootPrintAxisStretchFactor() is making the engine crash.