### PR TITLE
Fix ROAM bug 6340 https://springrts.com/mantis/view.php?id=6340, any change in…

### DIFF
--- a/rts/Map/SMF/ROAM/RoamMeshDrawer.cpp
+++ b/rts/Map/SMF/ROAM/RoamMeshDrawer.cpp
@@ -205,8 +205,10 @@ void CRoamMeshDrawer::Update()
 			if (p.IsVisible(cam)) {
 				if (tesselMesh |= (pvflags[i] == 0))
 					pvflags[i] = 1;
-				if (tesselMesh |= p.IsDirty())
+				if (p.IsDirty()){
 					p.ComputeVariance();
+					tesselMesh = true;
+				}
 			} else {
 				pvflags[i] = 0;
 			}

--- a/rts/Map/SMF/ROAM/RoamMeshDrawer.cpp
+++ b/rts/Map/SMF/ROAM/RoamMeshDrawer.cpp
@@ -205,7 +205,7 @@ void CRoamMeshDrawer::Update()
 			if (p.IsVisible(cam)) {
 				if (tesselMesh |= (pvflags[i] == 0))
 					pvflags[i] = 1;
-				if (p.IsDirty()){
+				if (p.IsDirty()) {
 					p.ComputeVariance();
 					tesselMesh = true;
 				}
@@ -217,7 +217,7 @@ void CRoamMeshDrawer::Update()
 
 			if (tesselMesh |= (uint8_t(p.IsVisible(cam)) != pvflags[i]))
 				pvflags[i] = uint8_t(p.IsVisible(cam));
-			if (p.IsVisible(cam) && p.IsDirty()){
+			if (p.IsVisible(cam) && p.IsDirty()) {
 				p.ComputeVariance();
 				tesselMesh = true;
 			}

--- a/rts/Map/SMF/ROAM/RoamMeshDrawer.cpp
+++ b/rts/Map/SMF/ROAM/RoamMeshDrawer.cpp
@@ -215,9 +215,10 @@ void CRoamMeshDrawer::Update()
 
 			if (tesselMesh |= (uint8_t(p.IsVisible(cam)) != pvflags[i]))
 				pvflags[i] = uint8_t(p.IsVisible(cam));
-
-			if (tesselMesh |= (p.IsVisible(cam) && p.IsDirty()))
+			if (p.IsVisible(cam) && p.IsDirty()){
 				p.ComputeVariance();
+				tesselmesh = true;
+			}
 		#endif
 		}
 	}

--- a/rts/Map/SMF/ROAM/RoamMeshDrawer.cpp
+++ b/rts/Map/SMF/ROAM/RoamMeshDrawer.cpp
@@ -217,7 +217,7 @@ void CRoamMeshDrawer::Update()
 				pvflags[i] = uint8_t(p.IsVisible(cam));
 			if (p.IsVisible(cam) && p.IsDirty()){
 				p.ComputeVariance();
-				tesselmesh = true;
+				tesselMesh = true;
 			}
 		#endif
 		}


### PR DESCRIPTION
… visibity forces subsequence patches Computevariance to be called again.

Patch::ComputeVariance only needs to be called if patch is visible and dirty. Before this change it was called even if tesselMesh was true, as the return value of |= is equal to tesselMesh. 
Thus if tesselMesh was set to true previously by a visibility change, then all subsequence patches would get their variance recomputed (which is quite expensive)