### PR TITLE
Port ROAM computevariance fix to maintainance.

### DIFF
--- a/rts/Map/SMF/ROAM/RoamMeshDrawer.cpp
+++ b/rts/Map/SMF/ROAM/RoamMeshDrawer.cpp
@@ -208,8 +208,10 @@ void CRoamMeshDrawer::Update()
 			if (p.IsVisible(cam)) {
 				if (tesselMesh |= (pvflags[i] == 0))
 					pvflags[i] = 1;
-				if (tesselMesh |= p.IsDirty())
+				if (p.IsDirty()) {
 					p.ComputeVariance();
+					tesselMesh = true;
+				}
 			} else {
 				pvflags[i] = 0;
 			}
@@ -218,8 +220,10 @@ void CRoamMeshDrawer::Update()
 
 			if (tesselMesh |= (uint8_t(p.IsVisible(cam)) != pvflags[i]))
 				pvflags[i] = uint8_t(p.IsVisible(cam));
-			if (tesselMesh |= (p.IsVisible(cam) && p.IsDirty()))
+			if (p.IsVisible(cam) && p.IsDirty()) {
 				p.ComputeVariance();
+				tesselMesh = true;
+			}
 		#endif
 		}
 	}


### PR DESCRIPTION
Patch::ComputeVariance only needs to be called if patch is visible and dirty. Before this change it was called even if tesselMesh was true, as the return value of |= is equal to tesselMesh. 
Thus if tesselMesh was set to true previously by a visibility change, then all subsequence patches would get their variance recomputed (which is quite expensive)