### PR TITLE
LOAM (Lazy ROAM) testing PR

### DIFF
--- a/rts/Map/SMF/ROAM/Patch.cpp
+++ b/rts/Map/SMF/ROAM/Patch.cpp
@@ -212,7 +212,7 @@ void Patch::UpdateHeightMap(const SRectangle& rect)
 			averageHeight += height;
 		}
 	}
-	
+
 	midPos.y = averageHeight/((PATCH_SIZE+1)*(PATCH_SIZE+1));
 	VBOUploadVertices();
 	isDirty = true;
@@ -521,11 +521,6 @@ void Patch::ComputeVariance()
 //
 bool Patch::Tessellate(const float3& camPos, int viewRadius, bool shadowPass)
 {
-	// Set/Update LOD params (FIXME: wrong height?)
-	float3 midPos;
-	midPos.x = (coors.x + PATCH_SIZE / 2) * SQUARE_SIZE;
-	midPos.z = (coors.y + PATCH_SIZE / 2) * SQUARE_SIZE;
-	midPos.y = readMap->GetCurrAvgHeight();
 
 	// Tessellate is called from multiple threads during both passes
 	// caller ensures that two patches that are neighbors or share a

--- a/rts/Map/SMF/ROAM/Patch.cpp
+++ b/rts/Map/SMF/ROAM/Patch.cpp
@@ -40,7 +40,7 @@ void CTriNodePool::InitPools(bool shadowPass, size_t newPoolSize)
 	for (int j = 0, numThreads = ThreadPool::GetMaxThreads(); newPoolSize > 0; j++) {
 		try {
 
-            size_t thrPoolSize =  std::max((CUR_POOL_SIZE = newPoolSize),newPoolSize); //the first pool should be larger, as only full retess uses threaded
+			size_t thrPoolSize =  std::max((CUR_POOL_SIZE = newPoolSize),newPoolSize); //the first pool should be larger, as only full retess uses threaded
 			for (int i = 0; i < numThreads; i++) {
 				if (i > 0) thrPoolSize = std::max((CUR_POOL_SIZE = newPoolSize) / numThreads, newPoolSize / 3);
 
@@ -48,7 +48,7 @@ void CTriNodePool::InitPools(bool shadowPass, size_t newPoolSize)
 				pools[shadowPass][i].Resize(thrPoolSize + (thrPoolSize & 1));
 			}
 
-      LOG_L(L_INFO, "[TriNodePool::%s] newPoolSize=" _STPF_ " thrPoolSize=" _STPF_ " (numThreads=%d shadowPass=%d)", __func__, newPoolSize, thrPoolSize, numThreads, shadowPass);
+			LOG_L(L_INFO, "[TriNodePool::%s] newPoolSize=" _STPF_ " thrPoolSize=" _STPF_ " (numThreads=%d shadowPass=%d)", __func__, newPoolSize, thrPoolSize, numThreads, shadowPass);
 			break;
 		} catch (const std::bad_alloc& e) {
 			LOG_L(L_FATAL, "[TriNodePool::%s] exception \"%s\" (numThreads=%d shadowPass=%d)", __func__, e.what(), numThreads, shadowPass);
@@ -90,7 +90,7 @@ void CTriNodePool::Resize(size_t poolSize)
 	// live outside the pool, but KISS)
 	assert((poolSize & 1) == 0);
 	assert(poolSize > 0);
-	LOG_L(L_INFO, "[TriNodePool::%s] to %i ",__func__, poolSize);
+	LOG_L(L_INFO, "[TriNodePool::%s] to " _STPF_,__func__, poolSize);
 
 	tris.resize(poolSize);
 }
@@ -179,7 +179,7 @@ void Patch::Reset()
 	baseLeft.BaseNeighbor  = &baseRight;
 	baseRight.BaseNeighbor = &baseLeft;
 
-    //Connect the base triangles to their parent
+	//Connect the base triangles to their parent
 	baseLeft.parentPatch = this;
 	baseRight.parentPatch = this;
 
@@ -242,9 +242,8 @@ bool Patch::Split(TriTreeNode* tri)
 	// if this triangle is not in a proper diamond, force split our base-neighbor
 	if (!tri->BaseNeighbor->IsDummy() && (tri->BaseNeighbor->BaseNeighbor != tri)){
 		Split(tri->BaseNeighbor);
-        if (tri->BaseNeighbor->parentPatch != this){
-            tri->BaseNeighbor->parentPatch->isChanged = true;
-        }
+		if (tri->BaseNeighbor->parentPatch != this)
+			tri->BaseNeighbor->parentPatch->isChanged = true;
 	}
 
 	// create children and link into mesh, or make this triangle a leaf
@@ -317,9 +316,9 @@ bool Patch::Split(TriTreeNode* tri)
 			// base Neighbor (in a diamond with us) was not split yet, do so now
 			// FIXME: if pool ran out above, this will fail and leave a LOD-crack
 			Split(tbn);
-			if (tbn->parentPatch != this){
-                tbn->parentPatch->isChanged = true;
-			}
+			if (tbn->parentPatch != this)
+				tbn->parentPatch->isChanged = true;
+			
 		}
 	} else {
 		// edge triangle, trivial case
@@ -362,13 +361,13 @@ void Patch::RecursTessellate(TriTreeNode* tri, const int2 left, const int2 right
 	if (triVariance <= 1.0f)
 		return;
 
-    // since we can 'retesselate' to a deeper depth, to preserve the trinodepool we will only split if its unsplit
-    if (!tri->IsBranch()){
-        Split(tri);
-        // we perform the split, and if the result is not a branch (e.g. couldnt split) we bail
-        if(!tri->IsBranch())
-            return;
-    }
+	// since we can 'retesselate' to a deeper depth, to preserve the trinodepool we will only split if its unsplit
+	if (!tri->IsBranch()){
+		Split(tri);
+		// we perform the split, and if the result is not a branch (e.g. couldnt split) we bail
+		if(!tri->IsBranch())
+			return;
+	}
 	// triangle was split, also try to split its children
 	const int2 center = {(left.x + right.x) >> 1, (left.y + right.y) >> 1};
 

--- a/rts/Map/SMF/ROAM/Patch.cpp
+++ b/rts/Map/SMF/ROAM/Patch.cpp
@@ -188,10 +188,10 @@ void Patch::Reset()
 	midPos.z = (coors.y + PATCH_SIZE / 2) * SQUARE_SIZE;
 	midPos.y = readMap->GetCurrAvgHeight();
 	//Reset camera
-	lastCameraPosition.x = -10000000;
-	lastCameraPosition.y = -10000000;
-	lastCameraPosition.z = -10000000;
-	camDistanceLastTesselation = 10000000;
+	lastCameraPosition.x = -10000000.0f;
+	lastCameraPosition.y = -10000000.0f;
+	lastCameraPosition.z = -10000000.0f;
+	camDistanceLastTesselation = 10000000.0f;
 }
 
 

--- a/rts/Map/SMF/ROAM/Patch.h
+++ b/rts/Map/SMF/ROAM/Patch.h
@@ -23,7 +23,8 @@ class CCamera;
 #define VARIANCE_DEPTH (12)
 
 // how many TriTreeNodes should be reserved per pool
-// (1M is a reasonable baseline for most large maps)
+// (2M is a reasonable baseline for most large maps)
+// if a 32bit TriTreeNode struct is 28 bytes, the total ram usage of LOAM is 2M*28*2 = 104 MB
 #define NEW_POOL_SIZE (1 << 21)
 // debug (simulates fast pool exhaustion)
 // #define NEW_POOL_SIZE (1 << 2)
@@ -122,6 +123,10 @@ public:
 
 	float3 lastCameraPosition ; //the last camera position this patch was tesselated from
 
+	//this specifies the manhattan distance from the camera during the last tesselation
+	//note that this can only become lower, as we can only increase tesselation levels while maintaining no cracks
+	float camDistanceLastTesselation;
+
 	bool Tessellate(const float3& camPos, int viewRadius, bool shadowPass);
 	void ComputeVariance();
 
@@ -178,7 +183,7 @@ private:
 
 	// pool used during Tessellate; each invoked Split allocates from this
 	CTriNodePool* curTriPool = nullptr;
-
+	float3 midPos;
 	// does the variance-tree need to be recalculated for this Patch?
 	bool isDirty = true;
 	bool vboVerticesUploaded = false;
@@ -207,7 +212,7 @@ private:
 	// NOTE:
 	//   shadow-mesh patches are only ever viewed by one camera
 	//   normal-mesh patches can be viewed by *multiple* types!
-	std::array<unsigned int, CCamera::CAMTYPE_VISCUL> lastDrawFrames = { 0 };
+	std::array<unsigned int, CCamera::CAMTYPE_VISCUL> lastDrawFrames = {};
 
 
 	GLuint triList = 0;

--- a/rts/Map/SMF/ROAM/RoamMeshDrawer.cpp
+++ b/rts/Map/SMF/ROAM/RoamMeshDrawer.cpp
@@ -648,7 +648,7 @@ void CRoamMeshDrawer::DrawInMiniMap()
 	#if (RETESSELLATE_MODE == 3)
 	int pi = 0;
 	for (const Patch& p: patchMeshGrid[MESH_NORMAL]) {
-		glColor4f(debugColors[pi].x,debugColors[pi].y,debugColors[pi].z,0.5f);
+		glColor4f(debugColors[pi].x, debugColors[pi].y, debugColors[pi].z ,0.5f);
 		pi++;
 		glRectf(p.coors.x, p.coors.y, p.coors.x + PATCH_SIZE, p.coors.y + PATCH_SIZE);
 	}

--- a/rts/Map/SMF/ROAM/RoamMeshDrawer.cpp
+++ b/rts/Map/SMF/ROAM/RoamMeshDrawer.cpp
@@ -218,7 +218,7 @@ void CRoamMeshDrawer::Update()
 
 	CCamera* playerCamera = CCameraHandler::GetCamera(CCamera::CAMTYPE_PLAYER);
 	float3 playerCameraPosition = playerCamera->GetPos();
-	float totalCameraDistanceRatioInv = 0;
+	float totalCameraDistanceRatioInv = 0.0f;
 	std::vector<bool> patchesToTesselate(numPatchesX * numPatchesY);
 	std::fill(patchesToTesselate.begin(),patchesToTesselate.end(),0);
 

--- a/rts/Map/SMF/ROAM/RoamMeshDrawer.h
+++ b/rts/Map/SMF/ROAM/RoamMeshDrawer.h
@@ -77,8 +77,8 @@ private:
 
 	float3 lastCamPos[MESH_COUNT];
 
-	int numPatchesLeftVisibility[MESH_COUNT] = {0};
-	int tesselationsSinceLastReset[MESH_COUNT] = {0};
+	int numPatchesLeftVisibility[MESH_COUNT] = {};
+	std::array <int, MESH_COUNT> tesselationsSinceLastReset = {};
 
 	std::function<bool(std::vector<Patch>&, const CCamera*, int, bool)> tesselateFuncs[2];
 

--- a/rts/Map/SMF/ROAM/RoamMeshDrawer.h
+++ b/rts/Map/SMF/ROAM/RoamMeshDrawer.h
@@ -77,6 +77,9 @@ private:
 
 	float3 lastCamPos[MESH_COUNT];
 
+	int numPatchesLeftVisibility[MESH_COUNT] = {0};
+	int tesselationsSinceLastReset[MESH_COUNT] = {0};
+
 	std::function<bool(std::vector<Patch>&, const CCamera*, int, bool)> tesselateFuncs[2];
 
 	// [1] is used for the shadow pass, [0] is used for all other passes

--- a/rts/Map/SMF/ROAM/RoamMeshDrawer.h
+++ b/rts/Map/SMF/ROAM/RoamMeshDrawer.h
@@ -18,7 +18,7 @@ class CCamera;
 
 
 // Visualize visible patches in Minimap for debugging?
-// #define DRAW_DEBUG_IN_MINIMAP
+//#define DRAW_DEBUG_IN_MINIMAP
 
 
 /**
@@ -93,6 +93,10 @@ private:
 	static bool forceNextTesselation[MESH_COUNT];
 	// whether tessellation should be performed with threads
 	static bool useThreadTesselation[MESH_COUNT];
+
+	#ifdef DRAW_DEBUG_IN_MINIMAP
+		std::vector<float3> debugColors;
+	#endif
 };
 
 #endif // _ROAM_MESH_DRAWER_H_


### PR DESCRIPTION
Forgive the ugliness, heres the down low:

ROAM frees up the entire triangle pool that stores the triangles of each tesselated patch (129*129 hmap pixels) and retesselates all patches whenever any in the visibility of patches occures, or if the unsynced heightmap changes (e.g.) explosion
LOAM does nothing when patches only go out of view, or when patches go into view, and a not-too-stale tesselation is aviable
when a 'stale' patch comes into view, only it is retesselated, and retesselation can affect neighbours, which is tracked and updated accordingly
when a heightmap change occurs, only that patch is retesselated, and if the neighbours are affected, that is updated accordingly
The cost: the mildly increased memory cost of keeping a larger triangle pool updated
the advantage is lag-free scrolling on a map
If the LOAM triangle pool runs out for any reason, then all the stored patches are all reset, and the whole view retesselated (exactly like it happens with ROAM on every visibility change)