### PR TITLE
Fix to #6376 (development version)

### DIFF
--- a/rts/Lua/LuaVFS.cpp
+++ b/rts/Lua/LuaVFS.cpp
@@ -390,7 +390,7 @@ int LuaVFS::UseArchive(lua_State* L)
 	// could be mod,map,etc
 	vfsHandler->AddArchive(archiveName, false);
 
-	callError = lua_pcall(L, lua_gettop(L) - funcIndex, LUA_MULTRET, 0);
+	const int callError = lua_pcall(L, lua_gettop(L) - funcIndex, LUA_MULTRET, 0);
 
 	vfsHandler->RemoveArchive(archiveName);
 	vfsHandler->ReMapArchives(false);


### PR DESCRIPTION
This is the best way (or the most robust at least) I found to fix the problem.

With these changes my widget may works either using...

* the archive name (e.g. 1944_Moro_River_V1)
* the file name (e.g. 1944_moro_river_v1.sd7)
* the local filepath (e.g. maps/1944_moro_river_v1.sd7)
* ~~the absolute filepath (e.g. /home/user/.spring/maps/1944_moro_river_v1.sd7)~~ (This was actually a widget trick)

**Tested just on maintenance version**