### PR TITLE
Coerce to number less often in *SetRulesParam

### DIFF
--- a/rts/Lua/LuaSyncedCtrl.cpp
+++ b/rts/Lua/LuaSyncedCtrl.cpp
@@ -1030,7 +1030,7 @@ void SetRulesParam(lua_State* L, const char* caller, int offset,
 	LuaRulesParams::Param& param = params[key];
 
 	// set the value of the parameter
-	if (lua_isnumber(L, valIndex)) {
+	if (lua_israwnumber(L, valIndex)) {
 		param.valueInt = lua_tofloat(L, valIndex);
 		param.valueString.resize(0);
 	} else if (lua_isstring(L, valIndex)) {


### PR DESCRIPTION
Unlike most lua_is* functions, lua_isnumber checks to see if the
given value *can* be a number, rather than if it currently is one:

> Returns 1 if the value at the given acceptable index is a number or
> a string convertible to a number, and 0 otherwise.

This means that even if a lua caller expressly coerces to string
beforehand, as long as the string looks like a number, it gets stored
as a number. This can cause problems if, for example, a player name
that looks like a very large number loses precision.

See esainane/zkstats@99ddb35 for an example.

Explicitly checking using the lua_israwnumber variant allows the caller
to provide either a string or a number, and have it be stored as such.


`develop` variant of #503.