### PR TITLE
 LOAM: early bailout for visibility calculations on no change, reduce for_mt overhead

### DIFF
--- a/rts/Map/Ground.cpp
+++ b/rts/Map/Ground.cpp
@@ -361,7 +361,7 @@ float CGround::LineGroundCol(float3 from, float3 to, bool synced)
 			// advance to the next nearest edge in either x or z dir, or in the case we reached the end make sure
 			// we set it to the exact square positions (floating point precision sometimes hinders us to hit it)
 			if (xn >= 1.0f && zn >= 1.0f) {
-				assert(curx != nextx || curz != nextz);
+				//assert(curx != nextx || curz != nextz);
 				curx = nextx;
 				curz = nextz;
 			} else if (xn < zn) {

--- a/rts/Map/SMF/ROAM/Patch.cpp
+++ b/rts/Map/SMF/ROAM/Patch.cpp
@@ -186,10 +186,10 @@ void Patch::Reset()
 
 	
 	//Reset camera
-	lastCameraPosition.x = -10000000;
-	lastCameraPosition.y = -10000000;
-	lastCameraPosition.z = -10000000;
-	camDistanceLastTesselation = 10000000;
+	lastCameraPosition.x = -10000000.0f;
+	lastCameraPosition.y = -10000000.0f;
+	lastCameraPosition.z = -10000000.0f;
+	camDistanceLastTesselation = 10000000.0f;
 }
 
 

--- a/rts/Map/SMF/ROAM/Patch.cpp
+++ b/rts/Map/SMF/ROAM/Patch.cpp
@@ -180,11 +180,11 @@ void Patch::Reset()
 	//Connect the base triangles to their parent
 	baseLeft.parentPatch = this;
 	baseRight.parentPatch = this;
-
 	midPos.x = (coors.x + PATCH_SIZE / 2) * SQUARE_SIZE;
 	midPos.z = (coors.y + PATCH_SIZE / 2) * SQUARE_SIZE;
 	midPos.y = readMap->GetCurrAvgHeight();
 
+	
 	//Reset camera
 	lastCameraPosition.x = -10000000;
 	lastCameraPosition.y = -10000000;

--- a/rts/Map/SMF/ROAM/Patch.cpp
+++ b/rts/Map/SMF/ROAM/Patch.cpp
@@ -34,9 +34,12 @@ void CTriNodePool::InitPools(bool shadowPass, size_t newPoolSize)
 {
 	for (int j = 0, numThreads = ThreadPool::GetMaxThreads(); newPoolSize > 0; j++) {
 		try {
-			const size_t thrPoolSize = std::max((CUR_POOL_SIZE = newPoolSize) / numThreads, newPoolSize / 3);
 
+
+			size_t thrPoolSize =  std::max((CUR_POOL_SIZE = newPoolSize),newPoolSize); //the first pool should be larger, as only full retess uses threaded
 			for (int i = 0; i < numThreads; i++) {
+				if (i > 0) thrPoolSize = std::max((CUR_POOL_SIZE = newPoolSize) / numThreads, newPoolSize / 3);
+
 				pools[shadowPass][i].Reset();
 				pools[shadowPass][i].Resize(thrPoolSize + (thrPoolSize & 1));
 			}
@@ -83,6 +86,7 @@ void CTriNodePool::Resize(size_t poolSize)
 	// live outside the pool, but KISS)
 	assert((poolSize & 1) == 0);
 	assert(poolSize > 0);
+	LOG_L(L_INFO, "[TriNodePool::%s] to " _STPF_,__func__, poolSize);
 
 	tris.resize(poolSize);
 }
@@ -172,6 +176,15 @@ void Patch::Reset()
 	// attach the two base-triangles together
 	baseLeft.BaseNeighbor  = &baseRight;
 	baseRight.BaseNeighbor = &baseLeft;
+
+	//Connect the base triangles to their parent
+	baseLeft.parentPatch = this;
+	baseRight.parentPatch = this;
+
+	//Reset camera
+	lastCameraPosition.x = -10000000;
+	lastCameraPosition.y = -10000000;
+	lastCameraPosition.z = -10000000;
 }
 
 
@@ -208,9 +221,11 @@ bool Patch::Split(TriTreeNode* tri)
 		return true;
 
 	// if this triangle is not in a proper diamond, force split our base-neighbor
-	if (!tri->BaseNeighbor->IsDummy() && (tri->BaseNeighbor->BaseNeighbor != tri))
+	if (!tri->BaseNeighbor->IsDummy() && (tri->BaseNeighbor->BaseNeighbor != tri)){
 		Split(tri->BaseNeighbor);
-
+		if (tri->BaseNeighbor->parentPatch != this)
+			tri->BaseNeighbor->parentPatch->isChanged = true;
+	}
 	// create children and link into mesh, or make this triangle a leaf
 	if (!curTriPool->Allocate(tri->LeftChild, tri->RightChild))
 		return false;
@@ -222,6 +237,11 @@ bool Patch::Split(TriTreeNode* tri)
 	TriTreeNode* tln = tri->LeftNeighbor;
 	TriTreeNode* trn = tri->RightNeighbor;
 	TriTreeNode* tbn = tri->BaseNeighbor;
+
+	// Set up parent patches so they notify them of changes
+	tri->LeftChild->parentPatch = tri->parentPatch;
+	tri->RightChild->parentPatch = tri->parentPatch;
+	tri->parentPatch->isChanged = true;
 
 	assert(!tlc->IsDummy());
 	assert(!trc->IsDummy());
@@ -275,6 +295,9 @@ bool Patch::Split(TriTreeNode* tri)
 			// base Neighbor (in a diamond with us) was not split yet, do so now
 			// FIXME: if pool ran out above, this will fail and leave a LOD-crack
 			Split(tbn);
+			if (tbn->parentPatch != this)
+				tbn->parentPatch->isChanged = true;
+
 		}
 	} else {
 		// edge triangle, trivial case
@@ -314,9 +337,13 @@ void Patch::RecursTessellate(TriTreeNode* tri, const int2 left, const int2 right
 	if (triVariance <= 1.0f)
 		return;
 
-	if ((Split(tri), !tri->IsBranch()))
-		return;
-
+	// since we can 'retesselate' to a deeper depth, to preserve the trinodepool we will only split if its unsplit
+	if (!tri->IsBranch()){
+		Split(tri);
+		// we perform the split, and if the result is not a branch (e.g. couldnt split) we bail
+		if(!tri->IsBranch())
+			return;
+	}
 	// triangle was split, also try to split its children
 	const int2 center = {(left.x + right.x) >> 1, (left.y + right.y) >> 1};
 
@@ -590,6 +617,11 @@ bool Patch::Tessellate(const float3& camPos, int viewRadius, bool shadowPass)
 		RecursTessellate(&baseRight, left, rght, apex, 1, 1);
 	}
 
+	// mark patches that are totally flat and did not get split in RecursTessellate
+	// as 'changed', so their vertices can be updated
+	if (baseLeft.IsLeaf() && baseRight.IsLeaf()) isChanged = true;
+
+    lastCameraPosition = camPos;
 	return (!curTriPool->OutOfNodes());
 }
 
@@ -625,6 +657,8 @@ void Patch::UploadVertices()
 	glBindBuffer(GL_ARRAY_BUFFER, 0);
 	glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
 	glDisableVertexAttribArray(0);
+
+	isChanged = false;
 }
 
 void Patch::UploadBorderVertices()

--- a/rts/Map/SMF/ROAM/Patch.h
+++ b/rts/Map/SMF/ROAM/Patch.h
@@ -56,7 +56,7 @@ struct TriTreeNode
 	TriTreeNode*  BaseNeighbor = &dummyNode;
 	TriTreeNode*  LeftNeighbor = &dummyNode;
 	TriTreeNode* RightNeighbor = &dummyNode;
-	
+
 	Patch* parentPatch = NULL; //triangles know their parent patch so they know of a neighbour's Split() func caused changes to them
 };
 
@@ -80,7 +80,7 @@ public:
 
 	bool ValidNode(const TriTreeNode* n) const { return (n >= &tris.front() && n <= &tris.back()); }
 	bool OutOfNodes() const { return (nextTriNodeIdx >= tris.size()); }
-	
+
 	size_t getPoolSize() { return tris.size(); }
 	size_t getNextTriNodeIdx() { return nextTriNodeIdx; }
 private:
@@ -114,7 +114,11 @@ public:
 	void UpdateHeightMap(const SRectangle& rect = SRectangle(0, 0, PATCH_SIZE, PATCH_SIZE));
 
 	float3 lastCameraPosition ; //the last camera position this patch was tesselated from
-	
+
+	//this specifies the manhattan distance from the camera during the last tesselation
+	//note that this can only become lower, as we can only increase tesselation levels while maintaining no cracks
+	float camDistanceLastTesselation;
+
 	// create an approximate mesh
 
 	bool Tessellate(const float3& camPos, int viewRadius, bool shadowPass);
@@ -171,7 +175,7 @@ private:
 
 	// pool used during Tessellate; each invoked Split allocates from this
 	CTriNodePool* curTriPool = nullptr;
-
+	float3 midPos;
 	// does the variance-tree need to be recalculated for this Patch?
 	bool isDirty = true;
 	bool isTesselated = false;

--- a/rts/Map/SMF/ROAM/RoamMeshDrawer.cpp
+++ b/rts/Map/SMF/ROAM/RoamMeshDrawer.cpp
@@ -217,7 +217,7 @@ void CRoamMeshDrawer::Update()
 
 	CCamera* playerCamera = CCameraHandler::GetCamera(CCamera::CAMTYPE_PLAYER);
 	float3 playerCameraPosition = playerCamera->GetPos();
-	float totalCameraDistanceRatioInv = 0;
+	float totalCameraDistanceRatioInv = 0.0f ;
 	std::vector<bool> patchesToTesselate(numPatchesX * numPatchesY);
 	std::fill(patchesToTesselate.begin(),patchesToTesselate.end(),0);
 

--- a/rts/Map/SMF/ROAM/RoamMeshDrawer.cpp
+++ b/rts/Map/SMF/ROAM/RoamMeshDrawer.cpp
@@ -35,8 +35,10 @@ LOG_REGISTER_SECTION_GLOBAL(LOG_SECTION_ROAM)
 
 //tessmode can be 1,2,(3 is LOAM)
 #define RETESSELLATE_MODE 3
-#define RETESSELLATE_TO_FREE_INVISIBLE_PATCHES 2
+#define RETESSELLATE_TO_FREE_INVISIBLE_PATCHES 50
 #define MAGIC_RETESSELATE_RETURNING_PATCH_CAMDIST (1000.0f * 1000.0f)
+#define MAGIC_RETESSELATE_CAMERA_RATIO 1.5f
+#define MAGIC_TOTAL_CAMDIST_RETESSELATE 2.5f
 #define TESSMODE_3_DEBUG 0
 
 bool CRoamMeshDrawer::forceNextTesselation[2] = {false, false};
@@ -61,6 +63,9 @@ CRoamMeshDrawer::CRoamMeshDrawer(CSMFGroundDrawer* gd)
 	ForceNextTesselation(true, true);
 	UseThreadTesselation(numPatchesX >= 4 && numPatchesY >= 4, numPatchesX >= 4 && numPatchesY >= 4);
 
+	#ifdef DRAW_DEBUG_IN_MINIMAP
+		debugColors.resize(numPatchesX*numPatchesY);
+	#endif
 
 	tesselateFuncs[true] = [this](std::vector<Patch>& patches, const CCamera* cam, int viewRadius, bool shadowPass) {
 		// create an approximate tessellated mesh of the landscape
@@ -213,7 +218,7 @@ void CRoamMeshDrawer::Update()
 
 	CCamera* playerCamera = CCameraHandler::GetCamera(CCamera::CAMTYPE_PLAYER);
 	float3 playerCameraPosition = playerCamera->GetPos();
-
+	float totalCameraDistanceRatioInv = 0;
 	std::vector<bool> patchesToTesselate(numPatchesX * numPatchesY);
 	std::fill(patchesToTesselate.begin(),patchesToTesselate.end(),0);
 
@@ -340,38 +345,47 @@ void CRoamMeshDrawer::Update()
 					// here we can do incremental retesselation?
 					patchesToTesselate[i] = true;
 				}
-
-				if (!wasVisible){
+				if (!wasVisible )
 					numPatchesEnterVisibility++;
-					if ((p.lastCameraPosition - lastCamPos[shadowPass]).SqLength() > MAGIC_RETESSELATE_RETURNING_PATCH_CAMDIST){
+
+
+				const float currentDistanceFromCamera = playerCameraPosition.distance(p.midPos);
+
+				//high numbers means we zoomed in more:
+				const float distanceFromCameraRatio = p.camDistanceLastTesselation  / currentDistanceFromCamera;
+
+				if((currentDistanceFromCamera > 500.0f ) && (distanceFromCameraRatio > MAGIC_RETESSELATE_CAMERA_RATIO)){
 						patchesToTesselate[i] = true;
-
-					}else{
-						#if TESSMODE_3_DEBUG
-							LOG("Skip:%i oldcam: %.1f:%.1f:%.1f nowcam %.1f:%.1f:%.1f dist=%.1f",
-								i,
-								p.lastCameraPosition.x,
-								p.lastCameraPosition.y,
-								p.lastCameraPosition.y,
-								lastCamPos[shadowPass].x,
-								lastCamPos[shadowPass].y,
-								lastCamPos[shadowPass].z,
-								(p.lastCameraPosition - lastCamPos[shadowPass]).SqLength()
-
-								);
-						#endif // TESSMODE_3_DEBUG
-						numPatchesEnteredSkipped++;
+						numPatchesZoomChanged++;
+						// Since we just retesselated,
+						totalCameraDistanceRatioInv += 1.0;
+						//LOG("Zoom%i currdist=%.1f lastdist=%.1f ratio=%.1f",i,currentDistanceFromCamera,p.camDistanceLastTesselation,distanceFromCameraRatio);
 					}
-				// do the zoom check.
+				else{
+					totalCameraDistanceRatioInv += 1.0/distanceFromCameraRatio;
+				}
+
+			}
+
+
+
+			#ifdef DRAW_DEBUG_IN_MINIMAP
+				if (isVisibleNow){
+					if (shadowPass){
+						debugColors[i].z = 1.0;
+					}else{
+						debugColors[i].y = 1.0;
+					}
+
 				}else{
-					float currentDistanceFromCamera = playerCameraPosition.distance(p.midPos);
-					if((currentDistanceFromCamera > 500.0f ) && (p.camDistanceLastTesselation > 1.5*playerCameraPosition.distance(p.midPos))){
-							patchesToTesselate[i] = true;
-							numPatchesZoomChanged++;
-						}
+					if (shadowPass){
+						debugColors[i].z = 0.0;
+					}else{
+						debugColors[i].y = 0.0;
+					}
 
 				}
-			}
+			#endif
 
 		#elif (RETESSELLATE_MODE == 1)
 			const bool isVisibleNow = p.IsVisible(cam);
@@ -414,6 +428,13 @@ void CRoamMeshDrawer::Update()
 #if (RETESSELLATE_MODE == 3)
 	int actualTesselations = 0;
 	int actualUploads = 0;
+	totalCameraDistanceRatioInv = totalCameraDistanceRatioInv / numPatchesVisible;
+	if (totalCameraDistanceRatioInv > MAGIC_TOTAL_CAMDIST_RETESSELATE){
+		#if TESSMODE_3_DEBUG
+			LOG("Zoomed out too far, retesselating all to save tris: Visible=%i pass=%i ratio=%.2f",numPatchesVisible,shadowPass,totalCameraDistanceRatioInv);
+		#endif
+		forceNextTesselation[shadowPass] = true;
+	}
 	 {
 		//SCOPED_TIMER("ROAM::Tessellate");
 
@@ -423,14 +444,21 @@ void CRoamMeshDrawer::Update()
 		if (!forceNextTesselation[shadowPass] ){
 			int pi = 0;
 			for (Patch& p: patches) {
+				#ifdef DRAW_DEBUG_IN_MINIMAP
+					debugColors[pi].x = std::max (debugColors[pi].x -0.002f,0.0f);
+				#endif
 				if (patchesToTesselate[pi]){
 					actualTesselations++;
 					tesselationsSinceLastReset[shadowPass]++;
+					#ifdef DRAW_DEBUG_IN_MINIMAP
+						debugColors[pi].x = 1.0;
+					#endif
 					if(!p.Tessellate(playerCameraPosition, smfGroundDrawer->GetGroundDetail(), shadowPass)){
 						tessSuccess = false;
 						#if TESSMODE_3_DEBUG
 							LOG("Lazy tesselation ran out of trinodes, trying again after a reset #Visible=%i #tesssincelastreset=%i, shadow=%i" , numPatchesVisible,tesselationsSinceLastReset[shadowPass],shadowPass);
 						#endif // TESSMODE_3_DEBUG
+
 						break;
 					}
 
@@ -440,13 +468,18 @@ void CRoamMeshDrawer::Update()
 		}
 
 		if(forceNextTesselation[shadowPass] || !tessSuccess ){
+			int pi = 0;
 			Reset(shadowPass);
 			for (Patch& p: patches) {
 				if (p.IsVisible(cam)){
 					p.Tessellate(playerCameraPosition, smfGroundDrawer->GetGroundDetail(), shadowPass);
 					actualTesselations ++;
 					tesselationsSinceLastReset[shadowPass]++;
+					#ifdef DRAW_DEBUG_IN_MINIMAP
+							debugColors[pi].x = 1.0;
+					#endif
 				}
+				pi++;
 			}
 			forceNextTesselation[shadowPass] = false;
 		}
@@ -478,9 +511,9 @@ void CRoamMeshDrawer::Update()
 		}
 	}
 	#if TESSMODE_3_DEBUG
-	if (actualTesselations> 0 || numPatchesEnterVisibility> 0 || numPatchesExitVisibility > 0 ){
+	if (actualTesselations> 0){
 
-		LOG("#Visible=%i delta_in=%i out=%i in df:#%i shadow:%i Z+%i actual_retess=%i up=%i skip=%i poolsize=%iK pooluse=%iK" ,
+		LOG("#V=%i d_in=%i d_out=%i in df:#%i shadow:%i Z+%i actual=%i up=%i skip=%i mratio = %.2f, P=%iK/%iK" ,
 			numPatchesVisible,
 			numPatchesEnterVisibility,
 			numPatchesExitVisibility,
@@ -490,11 +523,12 @@ void CRoamMeshDrawer::Update()
 			actualTesselations,
 			actualUploads,
 			numPatchesEnteredSkipped,
-			patches[0].curTriPool->getPoolSize()/1024,
-			patches[0].curTriPool->getNextTriNodeIdx()/1024);
+			totalCameraDistanceRatioInv,
+			patches[0].curTriPool->getNextTriNodeIdx()/1024,
+			patches[0].curTriPool->getPoolSize()/1024);
 
 		float3 nowcampos = cam->GetPos();
-		LOG("Camera pass=%i pos= %.1f, %.1f, %.1f", shadowPass, nowcampos.x, nowcampos.y, nowcampos.z );
+		//LOG("Camera pass=%i pos= %.1f, %.1f, %.1f", shadowPass, nowcampos.x, nowcampos.y, nowcampos.z );
 	}
 	#endif // TESSMODE_3_DEBUG
 
@@ -610,9 +644,25 @@ void CRoamMeshDrawer::DrawInMiniMap()
 	const CMatrix44f& projMat = minimap->GetProjMat(1);
 
 	prog->Enable();
-	prog->SetUniformMatrix4x4<const char*, float>("u_movi_mat", false, viewMat);
-	prog->SetUniformMatrix4x4<const char*, float>("u_proj_mat", false, projMat);
+	//prog->SetUniformMatrix4x4<const char*, float>("u_movi_mat", false, viewMat);
+	//prog->SetUniformMatrix4x4<const char*, float>("u_proj_mat", false, projMat);
+	prog->SetUniformMatrix4x4<float>("u_movi_mat", false, viewMat);
+	prog->SetUniformMatrix4x4<float>("u_proj_mat", false, projMat);
+	#if (RETESSELLATE_MODE == 3)
+	int pi = 0;
+	for (const Patch& p: patchMeshGrid[MESH_NORMAL]) {
+		const float2 patchPos = {p.coors.x * 1.0f, p.coors.y * 1.0f};
 
+		rdbc->SafeAppend({{patchPos.x                    , patchPos.y                    , 0.0f}, {debugColors[pi].x, debugColors[pi].y, debugColors[pi].z ,0.5f}}); // tl
+		rdbc->SafeAppend({{patchPos.x + PATCH_SIZE * 1.0f, patchPos.y                    , 0.0f}, {debugColors[pi].x, debugColors[pi].y, debugColors[pi].z ,0.5f}}); // tr
+		rdbc->SafeAppend({{patchPos.x + PATCH_SIZE * 1.0f, patchPos.y + PATCH_SIZE * 1.0f, 0.0f}, {debugColors[pi].x, debugColors[pi].y, debugColors[pi].z ,0.5f}}); // br
+
+		rdbc->SafeAppend({{patchPos.x + PATCH_SIZE * 1.0f, patchPos.y + PATCH_SIZE * 1.0f, 0.0f}, {debugColors[pi].x, debugColors[pi].y, debugColors[pi].z ,0.5f}}); // br
+		rdbc->SafeAppend({{patchPos.x                    , patchPos.y + PATCH_SIZE * 1.0f, 0.0f}, {debugColors[pi].x, debugColors[pi].y, debugColors[pi].z ,0.5f}}); // bl
+		rdbc->SafeAppend({{patchPos.x                    , patchPos.y                    , 0.0f}, {debugColors[pi].x, debugColors[pi].y, debugColors[pi].z ,0.5f}}); // tl
+		pi++;
+	}
+	#else
 	for (const Patch& p: patchMeshGrid[MESH_NORMAL]) {
 		const float2 patchPos = {p.coors.x * 1.0f, p.coors.y * 1.0f};
 
@@ -627,6 +677,7 @@ void CRoamMeshDrawer::DrawInMiniMap()
 		rdbc->SafeAppend({{patchPos.x                    , patchPos.y + PATCH_SIZE * 1.0f, 0.0f}, {0.0f, 0.0f, 0.0f, 0.5f}}); // bl
 		rdbc->SafeAppend({{patchPos.x                    , patchPos.y                    , 0.0f}, {0.0f, 0.0f, 0.0f, 0.5f}}); // tl
 	}
+	#endif
 
 	rdbc->Submit(GL_TRIANGLES);
 	prog->Disable();

--- a/rts/Map/SMF/ROAM/RoamMeshDrawer.cpp
+++ b/rts/Map/SMF/ROAM/RoamMeshDrawer.cpp
@@ -36,7 +36,6 @@ LOG_REGISTER_SECTION_GLOBAL(LOG_SECTION_ROAM)
 //tessmode can be 1,2,(3 is LOAM)
 #define RETESSELLATE_MODE 3
 #define RETESSELLATE_TO_FREE_INVISIBLE_PATCHES 50
-#define MAGIC_RETESSELATE_RETURNING_PATCH_CAMDIST (1000.0f * 1000.0f)
 #define MAGIC_RETESSELATE_CAMERA_RATIO 1.5f
 #define MAGIC_TOTAL_CAMDIST_RETESSELATE 2.5f
 #define TESSMODE_3_DEBUG 0
@@ -513,7 +512,7 @@ void CRoamMeshDrawer::Update()
 	#if TESSMODE_3_DEBUG
 	if (actualTesselations> 0){
 
-		LOG("#V=%i d_in=%i d_out=%i in df:#%i shadow:%i Z+%i actual=%i up=%i skip=%i mratio = %.2f, P=%iK/%iK" ,
+		LOG("#V=%i d_in=%i d_out=%i in df:#%i shadow:%i Z+%i actual=%i up=%i skip=%i mratio = %.2f, P="  _STPF_  "K/" _STPF_  "K" ,
 			numPatchesVisible,
 			numPatchesEnterVisibility,
 			numPatchesExitVisibility,
@@ -644,8 +643,6 @@ void CRoamMeshDrawer::DrawInMiniMap()
 	const CMatrix44f& projMat = minimap->GetProjMat(1);
 
 	prog->Enable();
-	//prog->SetUniformMatrix4x4<const char*, float>("u_movi_mat", false, viewMat);
-	//prog->SetUniformMatrix4x4<const char*, float>("u_proj_mat", false, projMat);
 	prog->SetUniformMatrix4x4<float>("u_movi_mat", false, viewMat);
 	prog->SetUniformMatrix4x4<float>("u_proj_mat", false, projMat);
 	#if (RETESSELLATE_MODE == 3)

--- a/rts/Map/SMF/ROAM/RoamMeshDrawer.cpp
+++ b/rts/Map/SMF/ROAM/RoamMeshDrawer.cpp
@@ -33,6 +33,11 @@ LOG_REGISTER_SECTION_GLOBAL(LOG_SECTION_ROAM)
 #define LOG_SECTION_CURRENT LOG_SECTION_ROAM
 
 
+//tessmode can be 1,2,(3 is LOAM)
+#define RETESSELLATE_MODE 3
+#define RETESSELLATE_TO_FREE_INVISIBLE_PATCHES 2
+#define MAGIC_RETESSELATE_RETURNING_PATCH_CAMDIST (1000.0f * 1000.0f)
+#define TESSMODE_3_DEBUG 0
 
 bool CRoamMeshDrawer::forceNextTesselation[2] = {false, false};
 bool CRoamMeshDrawer::useThreadTesselation[2] = {false, false};
@@ -122,6 +127,10 @@ CRoamMeshDrawer::CRoamMeshDrawer(CSMFGroundDrawer* gd)
 		return forceTess;
 	};
 
+	//TODO: rip out MT completely, LOAM doesn't need/cant use/wont use it
+	#if (RETESSELLATE_MODE == 3)
+		tesselateFuncs[true] = tesselateFuncs[false];
+	#endif
 
 	for (unsigned int i = MESH_NORMAL; i <= MESH_SHADOW; i++) {
 		patchMeshGrid[i].resize(numPatchesX * numPatchesY);
@@ -185,13 +194,78 @@ void CRoamMeshDrawer::Update()
 
 	bool shadowPass = (cam->GetCamType() == CCamera::CAMTYPE_SHADOW);
 	bool tesselMesh = forceNextTesselation[shadowPass];
+	bool fullRetesselate = false;
 
 	auto& patches = patchMeshGrid[shadowPass];
 	auto& pvflags = patchVisFlags[shadowPass];
 
 	Patch::UpdateVisibility(cam, patches, numPatchesX);
+	size_t numPatchesVisible = 0;
+	size_t numPatchesEnterVisibility = 0;
+	size_t numPatchesEnteredSkipped = 0;
+	size_t numPatchesExitVisibility = 0;
+	size_t numPatchesRetesselated = 0;
 
-#define RETESSELLATE_MODE 1
+	std::vector<bool> patchesToTesselate(numPatchesX * numPatchesY);
+	std::fill(patchesToTesselate.begin(),patchesToTesselate.end(),0);
+
+    // Notes for Tessmode 3, e.g. LOAM (Lazy Optimally Adapting Meshes).
+    // Dear reader, consider yourself a rubber ducky.
+
+    // 1. a dirty patch can be retesselated by just running tessellate
+    // --needs the ability to 'resume' tesselation
+    // --after retesselation, only update the vertex buffers of the stuff that changed
+
+    // 2. when a patch goes out of view, dont force a reset on the whole thing
+
+    // 3. visibility checking needs some serious rework, and the groundwork for that is already laid out above
+    //  -- 3x as many shadow patches rendered as regular!
+
+    // MT roam is not appreciably faster than ST roam, gut it
+    // MT roam easily runs out of pool space, and crashes due to:
+    // not guaranteed that two threads do not tesselate patches that dont share neighbours
+    // unbalanced use of trinodepools
+    // wasteful of RAM
+    // Easy to run out of, completely nondeterministic that a resized pool will not fuck up
+
+    // we need to get rid of the malloc errors that come from MT roam
+
+    // Why do we even keep a separate set of meshes for shadow and regular?
+    // we could easily half the load again by reusing the same meshes (especiallally the ram load)
+    // we need to use visible in shadowORmain
+
+    // fix pool.resize failing, either by retrying with a tiny bit smaller window, or by stopping tesselation straight up
+
+    // How can we retessellate patches entering view sanely?
+    // The same way we do it for dirty patches? does this mean that they might be forced to be at a lower resolution?
+    // can they be at a lower resolution even?
+
+    // Tricky cases:
+    // going from full view to zoomed in state:
+    // theoretically, full view should be tesselated at a low degree, so not all of the trinodepool should be exhausted
+    // when zooming in further, an increase in detail should be forced , but this 1. further exhausts the tripool, and should not be done too often.
+    // we can call retesselate of a patch,
+
+    // an exhaustion of the tritreenodepool should instantly trigger a reset and retesselate
+
+    // 4. Shadowpass seems to have on average 3x more patches than regular.
+    //  - also, its 'camera' is quite static, only really changes along one axis, and is unreliable:
+    // [f=0002142] [RoamMeshDrawer] Skip:37 oldcam: 4334.830078:-259.387939:-259.387939 nowcam 5011.015137:-259.387939:1593.139526 dist=924793.375000
+    // [f=0002142] [RoamMeshDrawer] Skip:50 oldcam: 4334.830078:-259.387939:-259.387939 nowcam 5011.015137:-259.387939:1593.139526 dist=924793.375000
+    // [f=0002142] [RoamMeshDrawer] Skip:63 oldcam: 4334.830078:-259.387939:-259.387939 nowcam 5011.015137:-259.387939:1593.139526 dist=924793.375000
+    // [f=0002142] [RoamMeshDrawer] Skip:76 oldcam: 4334.830078:-259.387939:-259.387939 nowcam 5011.015137:-259.387939:1593.139526 dist=924793.375000
+
+    // TODO:
+    // unintialized memory read in Patch::IsVisible!
+
+    // TODO tritreenodepool:
+    // allow growth
+    // handle bad allocs
+
+    #if TESSMODE_3_DEBUG
+        if(tesselMesh) LOG("Tesselation forced for pass %i in frame %i", shadowPass,globalRendering->drawFrame);
+
+    #endif //TESSMODE_3_DEBUG
 
 	{
 		// Check if a retessellation is needed
@@ -205,32 +279,202 @@ void CRoamMeshDrawer::Update()
 			if (p.IsVisible(cam)) {
 				if (tesselMesh |= (pvflags[i] == 0))
 					pvflags[i] = 1;
-				if (tesselMesh |= p.IsDirty())
+				if (p.IsDirty()) {
 					p.ComputeVariance();
+					tesselMesh = true;
+				}
 			} else {
 				pvflags[i] = 0;
 			}
 
-		#else
+		#elif (RETESSELLATE_MODE == 3)
+			const bool isVisibleNow = p.IsVisible(cam);
+			const bool wasVisible = pvflags[i];
+			pvflags[i] = uint8_t(p.IsVisible(cam));
 
+			// first case: a patch left visibility;
+			// do nothing, just count the number of patches in total that have done so, as they still use the trinodepools
+			// when a sufficient number of patches have left visibility, we are going to have to force a reset.
+			if (!isVisibleNow && wasVisible){
+				numPatchesExitVisibility ++;
+				numPatchesLeftVisibility[shadowPass]++;
+				if (numPatchesLeftVisibility[shadowPass] > numPatchesX*numPatchesY*RETESSELLATE_TO_FREE_INVISIBLE_PATCHES){
+
+					// Be even lazier, and only force full retesselation once zoomed back in
+					if ((numPatchesVisible *(5-3*shadowPass)  < numPatchesX*numPatchesY) ||
+						(numPatchesLeftVisibility[shadowPass] > 2*numPatchesX*numPatchesY*RETESSELLATE_TO_FREE_INVISIBLE_PATCHES)){
+						#if TESSMODE_3_DEBUG
+							LOG("Too many patches (%i) left visibility, forcing retess on this df #%i! poolsize=%i used=%i",numPatchesLeftVisibility[shadowPass],globalRendering->drawFrame,p.curTriPool->getPoolSize(),p.curTriPool->getNextTriNodeIdx());
+						#endif
+						forceNextTesselation[shadowPass] = true;
+						numPatchesLeftVisibility[shadowPass] = 0;
+					}
+				}
+			}
+
+
+			// second case, a patch entered visibility:
+			if (isVisibleNow){
+				numPatchesVisible ++;
+				// if it was dirty(had heightmap change) then recompute variances.
+				if (p.IsDirty()){
+					p.ComputeVariance();
+					// here we can do incremental retesselation?
+					patchesToTesselate[i] = true;
+				}
+
+				if (!wasVisible){
+					numPatchesEnterVisibility++;
+					if ((p.lastCameraPosition - lastCamPos[shadowPass]).SqLength() > MAGIC_RETESSELATE_RETURNING_PATCH_CAMDIST){
+						patchesToTesselate[i] = true;
+
+					}else{
+						#if TESSMODE_3_DEBUG
+							LOG("Skip:%i oldcam: %.1f:%.1f:%.1f nowcam %.1f:%.1f:%.1f dist=%.1f",
+								i,
+								p.lastCameraPosition.x,
+								p.lastCameraPosition.y,
+								p.lastCameraPosition.y,
+								lastCamPos[shadowPass].x,
+								lastCamPos[shadowPass].y,
+								lastCamPos[shadowPass].z,
+								(p.lastCameraPosition - lastCamPos[shadowPass]).SqLength()
+
+								);
+						#endif // TESSMODE_3_DEBUG
+						numPatchesEnteredSkipped++;
+					}
+				}
+			}
+
+		#elif (RETESSELLATE_MODE == 1)
+			const bool isVisibleNow = p.IsVisible(cam);
+			const bool wasVisible = pvflags[i];
+			
+			if (isVisibleNow && !wasVisible)
+				numPatchesEnterVisibility++;
+			
+			if (!isVisibleNow && wasVisible)
+				numPatchesExitVisibility ++;
+			
+			if (isVisibleNow)
+				numPatchesVisible ++;
+			
+			if(p.IsVisible(cam) != pvflags[i]){
+				if (pvflags[i]) {
+					numPatchesExitVisibility++;
+				}else {
+					numPatchesEnterVisibility++;
+					p.Tessellate(cam->GetPos(), smfGroundDrawer->GetGroundDetail(), shadowPass);
+				}
+			}
 			if (tesselMesh |= (uint8_t(p.IsVisible(cam)) != pvflags[i]))
 				pvflags[i] = uint8_t(p.IsVisible(cam));
-
-			if (tesselMesh |= (p.IsVisible(cam) && p.IsDirty()))
+            numPatchesVisible+=pvflags[i];
+			if (p.IsVisible(cam) && p.IsDirty()) {
 				p.ComputeVariance();
+				tesselMesh = true;
+			}
 		#endif
 		}
 	}
+
 
 	// Further conditions that can cause a retessellation
 #if (RETESSELLATE_MODE == 2)
 	tesselMesh |= ((cam->GetPos() - lastCamPos[shadowPass]).SqLength() > (500.0f * 500.0f));
 #endif
+
+#if (RETESSELLATE_MODE == 3)
+	int actualTesselations = 0;
+	int actualUploads = 0;
+	 {
+		//SCOPED_TIMER("ROAM::Tessellate");
+
+		// tesselate all the patches patches that are marked for it, but if we run out of trinodes,
+		// then reset all of them and try again
+		bool tessSuccess = true;
+		if (!forceNextTesselation[shadowPass] ){
+			int pi = 0;
+			for (Patch& p: patches) {
+				if (patchesToTesselate[pi]){
+					actualTesselations++;
+					tesselationsSinceLastReset[shadowPass]++;
+					if(!p.Tessellate(cam->GetPos(), smfGroundDrawer->GetGroundDetail(), shadowPass)){
+						tessSuccess = false;
+						#if TESSMODE_3_DEBUG
+							LOG("Lazy tesselation ran out of trinodes, trying again after a reset #Visible=%i #tesssincelastreset=%i, shadow=%i" , numPatchesVisible,tesselationsSinceLastReset[shadowPass],shadowPass);
+						#endif // TESSMODE_3_DEBUG
+						break;
+					}
+
+				}
+				pi++; //whoops
+			}
+		}
+
+		if(forceNextTesselation[shadowPass] || !tessSuccess ){
+			Reset(shadowPass);
+			for (Patch& p: patches) {
+				if (p.IsVisible(cam)){
+					p.Tessellate(cam->GetPos(), smfGroundDrawer->GetGroundDetail(), shadowPass);
+					actualTesselations ++;
+					tesselationsSinceLastReset[shadowPass]++;
+				}
+			}
+			forceNextTesselation[shadowPass] = false;
+		}
+	}
+
+	{
+		//SCOPED_TIMER("ROAM::GenerateIndexArray");
+		for_mt(0, patches.size(), [&patches, &cam](const int i) {
+			Patch* p = &patches[i];
+			if (p->IsVisible(cam)){
+				if (p->isChanged ){
+					p->GenerateIndices();
+					p->GenerateBorderVertices();
+				}
+			}
+		});
+	}
+	{
+		//SCOPED_TIMER("ROAM::Upload");
+
+		for (Patch& p: patches) {
+			if (p.IsVisible(cam)){
+				if (p.isChanged ){
+					p.UploadIndices();
+					p.UploadBorderVertices();
+					actualUploads++;
+				}
+			}
+		}
+	}
+	#if TESSMODE_3_DEBUG
+	if (actualTesselations> 0 || numPatchesEnterVisibility> 0 || numPatchesExitVisibility > 0 ){
+		LOG("#Visible=%i delta_in=%i out=%i in df:#%i shadow:%i mthread?=%i actual_retess=%i up=%i skip=%i poolsize=%iK pooluse=%iK" ,
+			numPatchesVisible,
+			numPatchesEnterVisibility,
+			numPatchesExitVisibility,
+			globalRendering->drawFrame,
+			shadowPass,
+			useThreadTesselation[shadowPass],
+			actualTesselations,
+			actualUploads,
+			numPatchesEnteredSkipped,
+			patches[0].curTriPool->getPoolSize()/1024,
+			patches[0].curTriPool->getNextTriNodeIdx()/1024);
+	}
+	#endif // TESSMODE_3_DEBUG
+
+
+#else
 	tesselMesh |= (lastGroundDetail[shadowPass] != smfGroundDrawer->GetGroundDetail());
 
 	if (!tesselMesh)
 		return;
-
+		\\LOG("Retesselating %i delta in:%i out: %iin df :%i pass:%i threads:%i" , numPatchesVisible,numPatchesEnterVisibility, numPatchesExitVisibility, globalRendering->drawFrame, shadowPass, useThreadTesselation[shadowPass]);
 	{
 		//SCOPED_TIMER("ROAM::Tessellate");
 
@@ -263,6 +507,7 @@ void CRoamMeshDrawer::Update()
 			p.UploadBorderVertices();
 		}
 	}
+#endif
 
 	lastGroundDetail[shadowPass] = smfGroundDrawer->GetGroundDetail();
 	lastCamPos[shadowPass] = cam->GetPos();
@@ -387,6 +632,7 @@ void CRoamMeshDrawer::Reset(bool shadowPass)
 			if (y < (numPatchesY - 1)) pbr->RightNeighbor = patches[(y + 1) * numPatchesX + x].GetBaseLeft();
 		}
 	}
+	tesselationsSinceLastReset[shadowPass] = 0;
 }
 
 

--- a/rts/Map/SMF/ROAM/RoamMeshDrawer.h
+++ b/rts/Map/SMF/ROAM/RoamMeshDrawer.h
@@ -92,6 +92,10 @@ private:
 	static bool forceNextTesselation[MESH_COUNT];
 	// whether tessellation should be performed with threads
 	static bool useThreadTesselation[MESH_COUNT];
+
+	#ifdef DRAW_DEBUG_IN_MINIMAP
+		std::vector<float3> debugColors;
+	#endif
 };
 
 #endif // _ROAM_MESH_DRAWER_H_

--- a/rts/Map/SMF/ROAM/RoamMeshDrawer.h
+++ b/rts/Map/SMF/ROAM/RoamMeshDrawer.h
@@ -75,7 +75,10 @@ private:
 	int numPatchesY = 0;
 	int lastGroundDetail[MESH_COUNT] = {0, 0};
 
+	bool heightMapChanged = false;
+
 	float3 lastCamPos[MESH_COUNT];
+	float3 lastCamDir[MESH_COUNT];
 
 	int numPatchesLeftVisibility[MESH_COUNT] = {};
 	std::array <int, MESH_COUNT> tesselationsSinceLastReset = {};

--- a/rts/Map/SMF/ROAM/RoamMeshDrawer.h
+++ b/rts/Map/SMF/ROAM/RoamMeshDrawer.h
@@ -77,6 +77,8 @@ private:
 
 	float3 lastCamPos[MESH_COUNT];
 
+	int numPatchesLeftVisibility[MESH_COUNT] = {};
+	std::array <int, MESH_COUNT> tesselationsSinceLastReset = {};
 	std::function<bool(std::vector<Patch>&, const CCamera*, int, bool)> tesselateFuncs[2];
 
 	// [1] is used for the shadow pass, [0] is used for all other passes


### PR DESCRIPTION
A. There are 4 conditions that can require a visibility/retess check:
1. Camera position change
2. camera direction change
3. heightmap change
4. grounddetail param change
Otherwise we can bail on a lot of expensive things

B. for_mt seems to have a high setup cost, and spins threads needlessly.
for_mt vertex index generation is only useful when a full retesselation is performed, otherwise the number of patches that need their indices regenerated is likely less than the number of threads.

C. side note: /debugview performance is now not strongly affected, side effect of less for_mt?