### PR TITLE
 LOAM: early bailout for visibility calculations on no change, reduce…

### DIFF
--- a/rts/Map/SMF/ROAM/RoamMeshDrawer.h
+++ b/rts/Map/SMF/ROAM/RoamMeshDrawer.h
@@ -75,7 +75,10 @@ private:
 	int numPatchesY = 0;
 	int lastGroundDetail[MESH_COUNT] = {0, 0};
 
+	bool heightMapChanged = false;
+
 	float3 lastCamPos[MESH_COUNT];
+	float3 lastCamDir[MESH_COUNT];
 
 	int numPatchesLeftVisibility[MESH_COUNT] = {};
 	std::array <int, MESH_COUNT> tesselationsSinceLastReset = {};


### PR DESCRIPTION
… for_mt overhead


A. There are 4 conditions that can require a visibility/retess check:
1. Camera position change
2. camera direction change
3. heightmap change
4. grounddetail param change
Otherwise we can bail on a lot of expensive things

B. for_mt seems to have a high setup cost, and spins threads needlessly.
for_mt vertex index generation is only useful when a full retesselation is performed, otherwise the number of patches that need their indices regenerated is likely less than the number of threads.

C. side note: /debugview performance is now not strongly affected, side effect of less for_mt?