### PR TITLE
Fix non-visible enemy units and structures not blocking construction

### DIFF
--- a/rts/Sim/Units/UnitTypes/Builder.cpp
+++ b/rts/Sim/Units/UnitTypes/Builder.cpp
@@ -748,7 +748,7 @@ bool CBuilder::StartBuild(BuildInfo& buildInfo, CFeature*& feature, bool& inWait
 
 				if (cu == nullptr)
 					continue;
-				if (allyteam != cu->allyteam)
+				if (!teamHandler.Ally(allyteam, cu->allyteam)
 					return false; // Enemy units that block always block the cell
 				if (!CanAssistUnit(cu, buildInfo.def))
 					continue;

--- a/rts/Sim/Units/UnitTypes/Builder.cpp
+++ b/rts/Sim/Units/UnitTypes/Builder.cpp
@@ -711,7 +711,7 @@ bool CBuilder::StartBuild(BuildInfo& buildInfo, CFeature*& feature, bool& inWait
 		case CGameHelper::BUILDSQUARE_OPEN: {
 			// <pos> might map to a non-blocking portion
 			// of the buildee's yardmap, fallback check
-			const CUnit* u = CGameHelper::GetClosestFriendlyUnit(nullptr, buildInfo.pos, 8.0f, allyteam);
+			const CUnit* u = CGameHelper::GetClosestFriendlyUnit(nullptr, buildInfo.pos, static_cast<float>(SQUARE_SIZE), allyteam);
 			if (u != nullptr) {
 				if (CanAssistUnit(u, buildInfo.def)) {
 					// StopBuild sets this to false, fix it here if picking up the same buildee again


### PR DESCRIPTION
This PR does two things:
- Fix a common structure stacking bug noticed since 104.0.1-1477-g8ecf38a was adopted by ZK.
- Fix a case related to https://springrts.com/mantis/view.php?id=6346

Currently it is possible to start construction on a location blocked by an enemy structure provided that the enemy structure is not within LOS. This can be done with luaui disabled and I expect that it could be done with luarules disabled as well.

![image](https://user-images.githubusercontent.com/1318249/79063393-d7046a80-7ce4-11ea-8c4c-a1398d4cc588.png)

The cause is the fix for https://springrts.com/mantis/view.php?id=6346 by https://github.com/spring/spring/commit/7cd04e709d52cec18231cff4413f8ddaefb5adb7.

Prior to https://github.com/spring/spring/commit/7cd04e709d52cec18231cff4413f8ddaefb5adb7 'u' could be any unit that was blocking the square. If 'u' could not be assisted there was a buildInfo.FootPrintOverlap check that caused StartBuild to return false, blocking construction. It seems like this was the only check stopping units from starting constructions on unseen enemy units, and this makes sense because blocking the construction earlier (such as when the order is given) would open the door for maphax.

After https://github.com/spring/spring/commit/7cd04e709d52cec18231cff4413f8ddaefb5adb7 the only values that the variable 'u' can take are nullptr or that of an assistable unit or of a friendly unit. The buildInfo.FootPrintOverlap is never reached for enemy units so StartBuild cannot return false in the CGameHelper::BUILDSQUARE_OCCUPIED case if enemy units are the only blockers.

While checking whether this PR caused a regression of https://springrts.com/mantis/view.php?id=6346 I found a case of structure stacking that had not been fixed. It can be reproduced on South-East corners on Fifteen Platforms.

![image](https://user-images.githubusercontent.com/1318249/79065967-8b0ef100-7cf7-11ea-9bc2-293880a0ef52.png)

The code added to the CGameHelper::BUILDSQUARE_OPEN case prevents the previously unfixed case of structure stacking.