### PR TITLE
Fix non-visible enemy units and structures not blocking construction, now small enough to have a chance of being pulled.

### DIFF
--- a/rts/Sim/Units/UnitTypes/Builder.cpp
+++ b/rts/Sim/Units/UnitTypes/Builder.cpp
@@ -731,11 +731,12 @@ bool CBuilder::StartBuild(BuildInfo& buildInfo, CFeature*& feature, bool& inWait
 
 				if (cu == nullptr)
 					continue;
+				if (allyteam != cu->allyteam)
+					return false; // Enemy units that block always block the cell
 				if (!CanAssistUnit(cu, buildInfo.def))
 					continue;
 
 				u = cu;
-				break;
 			}
 
 			// <pos> might map to a non-blocking portion


### PR DESCRIPTION
See https://github.com/spring/spring/pull/516

`!teamHandler.Ally(allyteam, cu->allyteam)` is incorrect because allied allyteams do not necessarily share LOS. This loop only needs to detect units 'u' that people would like to assist when they find it blocking their own construction.