### PR TITLE
AllowSpectatorJoin defaults to 0 for dedi

### DIFF
--- a/rts/Net/GameServer.cpp
+++ b/rts/Net/GameServer.cpp
@@ -69,7 +69,7 @@ CONFIG(int, AutohostPort).defaultValue(0);
 CONFIG(int, ServerSleepTime).defaultValue(5).description("number of milliseconds to sleep per tick");
 CONFIG(int, SpeedControl).defaultValue(1).minimumValue(1).maximumValue(2)
 	.description("Sets how server adjusts speed according to player's load (CPU), 1: use average, 2: use highest");
-CONFIG(bool, AllowSpectatorJoin).defaultValue(true).description("allow any unauthenticated clients to join as spectator with any name, name will be prefixed with ~");
+CONFIG(bool, AllowSpectatorJoin).defaultValue(true).dedicatedValue(false).description("allow any unauthenticated clients to join as spectator with any name, name will be prefixed with ~");
 CONFIG(bool, WhiteListAdditionalPlayers).defaultValue(true);
 CONFIG(bool, ServerRecordDemos).defaultValue(false).dedicatedValue(true);
 CONFIG(bool, ServerLogInfoMessages).defaultValue(false);


### PR DESCRIPTION
According to @abma this setting should ideally be disabled for autohosts, https://github.com/ZeroK-RTS/Zero-K-Infrastructure/issues/789#issuecomment-139229098