### PR TITLE
Spring.SetUnitNoFoo: expose to LuaUI

### DIFF
--- a/doc/changelog.txt
+++ b/doc/changelog.txt
@@ -29,6 +29,7 @@ Lua:
 	 UnitCommand(..., cmdTag            ) -->  UnitCommand(..., cmdTag, playerID, fromSynced, fromLua)
  ! remove Game.mapHumanName
  ! remove UnitDefs[i].moveDef.{family,type}
+ - LuaUI now has access to Spring.SetUnitNo{Draw,Select,Minimap} and SetFeatureNoDraw
  - let Spring.SelectUnitArray select enemy units with godmode enabled
  - let Unit*Collision callins skip engine collision handling if true is returned (from any synced gadget)
  - call gadgetHandler:Explosion for unsynced gadgets (but discard the return value)

--- a/rts/Lua/LuaHandle.h
+++ b/rts/Lua/LuaHandle.h
@@ -66,8 +66,6 @@ class CLuaHandle : public CEventClient
 
 		bool GetUserMode() const { return userMode; }
 
-		static bool GetHandleUserMode(lua_State* L) { return (GetHandle(L))->GetUserMode(); }
-
 		static int GetHandleAllowChanges(const lua_State* L) { return GetLuaContextData(L)->allowChanges; }
 
 		static CLuaHandle* GetHandle(lua_State* L) { return (GetLuaContextData(L)->owner); }

--- a/rts/Lua/LuaUnsyncedCtrl.cpp
+++ b/rts/Lua/LuaUnsyncedCtrl.cpp
@@ -1666,9 +1666,6 @@ int LuaUnsyncedCtrl::SetSkyBoxTexture(lua_State* L)
 
 int LuaUnsyncedCtrl::SetUnitNoDraw(lua_State* L)
 {
-	if (CLuaHandle::GetHandleUserMode(L))
-		return 0;
-
 	CUnit* unit = ParseCtrlUnit(L, __func__, 1);
 
 	if (unit == nullptr)
@@ -1681,9 +1678,6 @@ int LuaUnsyncedCtrl::SetUnitNoDraw(lua_State* L)
 
 int LuaUnsyncedCtrl::SetUnitNoMinimap(lua_State* L)
 {
-	if (CLuaHandle::GetHandleUserMode(L))
-		return 0;
-
 	CUnit* unit = ParseCtrlUnit(L, __func__, 1);
 
 	if (unit == nullptr)
@@ -1696,9 +1690,6 @@ int LuaUnsyncedCtrl::SetUnitNoMinimap(lua_State* L)
 
 int LuaUnsyncedCtrl::SetUnitNoSelect(lua_State* L)
 {
-	if (CLuaHandle::GetHandleUserMode(L))
-		return 0;
-
 	CUnit* unit = ParseCtrlUnit(L, __func__, 1);
 
 	if (unit == nullptr)
@@ -1743,9 +1734,6 @@ int LuaUnsyncedCtrl::SetUnitSelectionVolumeData(lua_State* L)
 
 int LuaUnsyncedCtrl::SetFeatureNoDraw(lua_State* L)
 {
-	if (CLuaHandle::GetHandleUserMode(L))
-		return 0;
-
 	CFeature* feature = ParseCtrlFeature(L, __func__, 1);
 
 	if (feature == nullptr)


### PR DESCRIPTION
Games which don't want those functions used can just do `Spring.SetUnitNoFoo = nil` at LuaUI entry point.