### PR TITLE
Fix /aicontrol crash

### DIFF
--- a/rts/Net/GameParticipant.cpp
+++ b/rts/Net/GameParticipant.cpp
@@ -9,6 +9,10 @@
 
 GameParticipant::GameParticipant()
 {
+	// HAX: reserve enough buckets to avoid rehash of container
+	//      while traversing and processing /aicontrol command
+	aiClientLinks.reserve(MAX_AIS);
+
 	aiClientLinks[MAX_AIS] = ClientLinkData(false);
 }
 


### PR DESCRIPTION
Several /aicontrol commands for different teams can crash spring with:
```
Thread 13 "netcode" received signal SIGSEGV, Segmentation fault.
[Switching to Thread 0x7fffa37fe700 (LWP 5978)]
0x00005555557f732d in CGameServer::ServerReadNet (this=0x555599a27930) at .../rts/Net/GameServer.cpp:2020
2020                                    if (!bwLimitIsReached || dropPacket)
(gdb) bt
#0  0x00005555557f732d in CGameServer::ServerReadNet (this=0x555599a27930) at .../rts/Net/GameServer.cpp:2020
#1  0x00005555557f7ee5 in CGameServer::UpdateLoop (this=0x555599a27930) at .../rts/Net/GameServer.cpp:2647
#2  0x00007ffff6f42b24 in std::execute_native_thread_routine (__p=0x555599a52840) at /build/gcc/src/gcc/libstdc++-v3/src/c++11/thread.cc:80
#3  0x00007ffff7de546f in start_thread () from /usr/lib/libpthread.so.0
#4  0x00007ffff6c4c3d3 in clone () from /usr/lib/libc.so.6
```
Inside ```for (auto& aiLinkData: aiClientLinks) {...}``` loop
aiLink = aiLinkData.second.link and points to garbage.
```
(gdb) p aiLinkData.second.link
$1 = std::shared_ptr<netcode::CConnection> (empty) = {get() = 0x75}
```
That's because ProcessPacket() adds value to aiClientLinks that invokes rehashing and invalidates iterator.
Until b964617a02ee86cf13d08202375547f0baa7339d (switch from std::map to spring::unordered_map) the issue was hidden by std::map that required much more inserts to invalidate iterator and so remained unnoticed.

Presented hack reserves enough space to avoid any rehash and iterator invalidation.
Estimated wasted memory: `sizeof(std::pair<char, ClientLinkData>) * MAX_AIS * MAX_PLAYERS = 2048160` B

Feel free to fix /aicontrol in any other proper way, such as slow copy:
```
diff --git a/rts/Net/GameServer.cpp b/rts/Net/GameServer.cpp
index f3f057033a..7cbfa9f55d 100644
--- a/rts/Net/GameServer.cpp
+++ b/rts/Net/GameServer.cpp
@@ -1994,7 +1994,8 @@ void CGameServer::ServerReadNet()
                        }
                }
 
-               for (auto& aiLinkData: aiClientLinks) {
+               auto aiClientLinksCopy = aiClientLinks;
+               for (auto& aiLinkData: aiClientLinksCopy) {
                        int  bandwidthUsage = aiLinkData.second.bandwidthUsage;
                        int& numPacketsSent = aiLinkData.second.numPacketsSent;
```