### PR TITLE
Fix floating units leaving tracks on sea floor

### DIFF
--- a/rts/Rendering/Env/Decals/LegacyTrackHandler.cpp
+++ b/rts/Rendering/Env/Decals/LegacyTrackHandler.cpp
@@ -421,6 +421,8 @@ void LegacyTrackHandler::AddTrack(const CUnit* unit, const float3& newPos)
 		return;
 	if (!unitDef->IsGroundUnit())
 		return;
+	if (unitDef->floatOnWater && newPos[1] <= unitDef->waterline * -1.0f)
+		return;
 
 
 	// -2 := failed to load texture, do not try again

--- a/rts/Rendering/Env/Decals/LegacyTrackHandler.cpp
+++ b/rts/Rendering/Env/Decals/LegacyTrackHandler.cpp
@@ -421,7 +421,7 @@ void LegacyTrackHandler::AddTrack(const CUnit* unit, const float3& newPos)
 		return;
 	if (!unitDef->IsGroundUnit())
 		return;
-	if (unitDef->floatOnWater && newPos[1] <= unitDef->waterline * -1.0f)
+	if (unit->IsInWater() && !unit->IsOnGround())
 		return;
 
 


### PR DESCRIPTION
This allows defining units which both leave tracks on ground and float on water, such as bots that swim on the surface.