### PR TITLE
Fix pessimizing std::move / allow copy elision

### DIFF
--- a/rts/Rendering/GL/RenderDataBuffer.hpp
+++ b/rts/Rendering/GL/RenderDataBuffer.hpp
@@ -166,9 +166,9 @@ namespace GL {
 			if (inited)
 				return false;
 
-			elems = std::move(VBO(GL_ARRAY_BUFFER, persistent, readable));
-			indcs = std::move(VBO(GL_ELEMENT_ARRAY_BUFFER, persistent, readable));
-			shader = std::move(Shader::GLSLProgramObject());
+			elems = VBO(GL_ARRAY_BUFFER, persistent, readable);
+			indcs = VBO(GL_ELEMENT_ARRAY_BUFFER, persistent, readable);
+			shader = Shader::GLSLProgramObject();
 
 			elems.Generate();
 			indcs.Generate();


### PR DESCRIPTION
/home/travis/build/spring/spring/rts/Rendering/GL/RenderDataBuffer.hpp:169:12: warning: moving a temporary object prevents copy elision [-Wpessimizing-move]