### PR TITLE
Fixed particles clipping into existing geometry (so-called soft edge …

### DIFF
--- a/cont/base/springcontent/shaders/GLSL/ProjFXFragProg.glsl
+++ b/cont/base/springcontent/shaders/GLSL/ProjFXFragProg.glsl
@@ -8,26 +8,28 @@ in vec4 vsPos;
 
 #define projMatrix gl_ProjectionMatrix
 
-uniform vec2 invScreenRes;
+uniform vec2 invScreenSize;
 
 #define NORM2SNORM(value) (value * 2.0 - 1.0)
 #define SNORM2NORM(value) (value * 0.5 + 0.5)
 
-float GetViewSpaceDepth(float depthNDC) {
-	return -projMatrix[3][2] / (projMatrix[2][2] + depthNDC);
-}
-
-float GetViewSpaceDepthFromTexture(float depthNDC) {
+float GetViewSpaceDepth(float d) {
 	#ifndef DEPTH_CLIP01
-		depthNDC = NORM2SNORM(depthNDC);
+		d = NORM2SNORM(d);
 	#endif
-	return GetViewSpaceDepth(depthNDC);
+	return -projMatrix[3][2] / (projMatrix[2][2] + d);
 }
 
 void main() {
 	vec4 color = texture(atlasTex, gl_TexCoord[0].xy);
-	float depthVS = GetViewSpaceDepthFromTexture(texture(depthTex, gl_FragCoord.xy * invScreenRes).x);
-	float edgeSmoothness = smoothstep(0.0, 5.0, vsPos.z - depthVS);
+	vec2 screenUV = gl_FragCoord.xy * invScreenSize;
+
+	float depthZO = texture(depthTex, screenUV).x;
+	float depthVS = GetViewSpaceDepth(depthZO);
+
+	float edgeSmoothness = smoothstep(-16.0, 0.0, vsPos.z - depthVS);
+
 	gl_FragColor = color * vertColor;
 	gl_FragColor *= edgeSmoothness;
+	gl_FragDepth = min(gl_FragCoord.z, depthZO - 1e-3); //always 0 to -1, no matter clip_ctrl
 }

--- a/cont/base/springcontent/shaders/GLSL/ProjFXFragProg.glsl
+++ b/cont/base/springcontent/shaders/GLSL/ProjFXFragProg.glsl
@@ -1,0 +1,33 @@
+#version 130
+
+uniform sampler2D atlasTex;
+uniform sampler2D depthTex;
+
+in vec4 vertColor;
+in vec4 vsPos;
+
+#define projMatrix gl_ProjectionMatrix
+
+uniform vec2 invScreenRes;
+
+#define NORM2SNORM(value) (value * 2.0 - 1.0)
+#define SNORM2NORM(value) (value * 0.5 + 0.5)
+
+float GetViewSpaceDepth(float depthNDC) {
+	return -projMatrix[3][2] / (projMatrix[2][2] + depthNDC);
+}
+
+float GetViewSpaceDepthFromTexture(float depthNDC) {
+	#ifndef DEPTH_CLIP01
+		depthNDC = NORM2SNORM(depthNDC);
+	#endif
+	return GetViewSpaceDepth(depthNDC);
+}
+
+void main() {
+	vec4 color = texture(atlasTex, gl_TexCoord[0].xy);
+	float depthVS = GetViewSpaceDepthFromTexture(texture(depthTex, gl_FragCoord.xy * invScreenRes).x);
+	float edgeSmoothness = smoothstep(0.0, 5.0, vsPos.z - depthVS);
+	gl_FragColor = color * vertColor;
+	gl_FragColor *= edgeSmoothness;
+}

--- a/cont/base/springcontent/shaders/GLSL/ProjFXVertProg.glsl
+++ b/cont/base/springcontent/shaders/GLSL/ProjFXVertProg.glsl
@@ -1,0 +1,11 @@
+#version 130
+
+out vec4 vertColor;
+out vec4 vsPos;
+
+void main() {
+	gl_TexCoord[0] = gl_MultiTexCoord0;
+	vertColor = gl_Color;
+	vsPos = gl_ModelViewMatrix * gl_Vertex;
+    gl_Position = gl_ProjectionMatrix * vsPos;
+}

--- a/cont/base/springcontent/shaders/GLSL/ProjFXVertProg.glsl
+++ b/cont/base/springcontent/shaders/GLSL/ProjFXVertProg.glsl
@@ -7,5 +7,5 @@ void main() {
 	gl_TexCoord[0] = gl_MultiTexCoord0;
 	vertColor = gl_Color;
 	vsPos = gl_ModelViewMatrix * gl_Vertex;
-    gl_Position = gl_ProjectionMatrix * vsPos;
+	gl_Position = gl_ProjectionMatrix * vsPos;
 }

--- a/rts/Rendering/Env/Particles/ProjectileDrawer.cpp
+++ b/rts/Rendering/Env/Particles/ProjectileDrawer.cpp
@@ -279,6 +279,7 @@ void CProjectileDrawer::Init() {
 			fxShader = shaderHandler->CreateProgramObject("[ProjectileDrawer::VFS]", "FX Shader", false);
 			fxShader->AttachShaderObject(shaderHandler->CreateShaderObject("GLSL/ProjFXVertProg.glsl", "", GL_VERTEX_SHADER));
 			fxShader->AttachShaderObject(shaderHandler->CreateShaderObject("GLSL/ProjFXFragProg.glsl", "", GL_FRAGMENT_SHADER));
+			fxShader->SetFlag("DEPTH_CLIP01", globalRendering->supportClipSpaceControl);
 			fxShader->Enable();
 			fxShader->SetUniform("atlasTex", 0);
 			fxShader->SetUniform("depthTex", 8);
@@ -686,7 +687,6 @@ void CProjectileDrawer::Draw(bool drawReflection, bool drawRefraction) {
 			glActiveTexture(GL_TEXTURE8); glBindTexture(GL_TEXTURE_2D, depthTexture);
 			glCopyTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, globalRendering->viewPosX, 0, globalRendering->viewSizeX, globalRendering->viewSizeY);
 
-			fxShader->SetFlag("DEPTH_CLIP01", globalRendering->supportClipSpaceControl);
 			fxShader->Enable();
 			fxShader->SetUniform("invScreenRes", 1.0f / globalRendering->viewSizeX, 1.0f / globalRendering->viewSizeY);
 		}

--- a/rts/Rendering/Env/Particles/ProjectileDrawer.h
+++ b/rts/Rendering/Env/Particles/ProjectileDrawer.h
@@ -7,6 +7,8 @@
 
 #include "Rendering/GL/myGL.h"
 #include "Rendering/GL/FBO.h"
+#include "Rendering/Shaders/ShaderHandler.h"
+#include "Rendering/Shaders/Shader.h"
 #include "Rendering/Models/3DModel.h"
 #include "Rendering/Models/ModelRenderContainer.h"
 #include "Sim/Projectiles/ProjectileFunctors.h"
@@ -105,6 +107,9 @@ public:
 	AtlasedTexture* groundringtex = nullptr;
 
 	AtlasedTexture* seismictex = nullptr;
+
+	GLuint depthTexture = 0u;
+	Shader::IProgramObject* fxShader = nullptr;
 
 private:
 	static void ParseAtlasTextures(const bool, const LuaTable&, spring::unordered_set<std::string>&, CTextureAtlas*);

--- a/rts/Rendering/Env/Particles/ProjectileDrawer.h
+++ b/rts/Rendering/Env/Particles/ProjectileDrawer.h
@@ -45,7 +45,10 @@ public:
 
 
 	bool WantsEvent(const std::string& eventName) {
-		return (eventName == "RenderProjectileCreated" || eventName == "RenderProjectileDestroyed");
+		return
+			(eventName == "RenderProjectileCreated") ||
+			(eventName == "RenderProjectileDestroyed") ||
+			(eventName == "ViewResize");
 	}
 	bool GetFullRead() const { return true; }
 	int GetReadAllyTeam() const { return AllAccessTeam; }
@@ -53,6 +56,7 @@ public:
 	void RenderProjectileCreated(const CProjectile* projectile);
 	void RenderProjectileDestroyed(const CProjectile* projectile);
 
+	void ViewResize() override;
 
 	unsigned int NumSmokeTextures() const { return (smokeTextures.size()); }
 


### PR DESCRIPTION
This one implements "soft edges" of the particles, similar to how all other engines (Unity, UE4, Godot) do that.

This time around it's only for maintenance. I have no game to test it on develop, but should be easy to integrate it in the future.

No soft edges, status quo, visible clipping areas
![screen01784](https://user-images.githubusercontent.com/1476261/83690293-25552c00-a5f9-11ea-8c2a-421ecea360c4.png)

Softened edges (5.0 elmo, hardcoded), no visible clipping areas
![screen01785](https://user-images.githubusercontent.com/1476261/83690298-271eef80-a5f9-11ea-8a01-5a78d69781ea.png)
