### PR TITLE
Add missing include

### DIFF
--- a/rts/System/Sync/SHA512.cpp
+++ b/rts/System/Sync/SHA512.cpp
@@ -2,6 +2,7 @@
 
 #include <cassert>
 #include <cstring>
+#include <cstdio>
 
 #include "SHA512.hpp"
 


### PR DESCRIPTION
snprintf() lives there.