### PR TITLE
Draw build call in

### DIFF
--- a/rts/Game/UI/GuiHandler.cpp
+++ b/rts/Game/UI/GuiHandler.cpp
@@ -3936,7 +3936,8 @@ void CGuiHandler::DrawMapStuff(bool onMiniMap)
 		assert(buildeeDef != nullptr);
 
 		if (!buildInfoQueue.empty()) {
-			unitDrawer->SetupShowUnitBuildSquares(onMiniMap, true);
+			if (drawBuildGrid || onMiniMap)
+				unitDrawer->SetupShowUnitBuildSquares(onMiniMap, true);
 
 			// first pass; grid squares
 			for (const BuildInfo& bi: buildInfoQueue) {
@@ -3954,26 +3955,28 @@ void CGuiHandler::DrawMapStuff(bool onMiniMap)
 						}
 					}
 				}
-
-				if (unitDrawer->ShowUnitBuildSquares(bi, buildCommands, true)) {
-					buildColors.emplace_back(0.7f, 1.0f, 1.0f, 0.4f); // yellow
-				} else {
-					buildColors.emplace_back(1.0f, 0.5f, 0.5f, 0.4f); // red
+				if (drawBuildGrid || onMiniMap){
+					if (unitDrawer->ShowUnitBuildSquares(bi, buildCommands, true)) {
+						buildColors.emplace_back(0.7f, 1.0f, 1.0f, 0.4f); // yellow
+					} else {
+						buildColors.emplace_back(1.0f, 0.5f, 0.5f, 0.4f); // red
+					}
 				}
 			}
+			if (drawBuildGrid || onMiniMap){
+				unitDrawer->ResetShowUnitBuildSquares(onMiniMap, true);
+				unitDrawer->SetupShowUnitBuildSquares(onMiniMap, false);
 
-			unitDrawer->ResetShowUnitBuildSquares(onMiniMap, true);
-			unitDrawer->SetupShowUnitBuildSquares(onMiniMap, false);
+				// second pass; water-depth indicator lines
+				for (const BuildInfo& bi: buildInfoQueue) {
+					unitDrawer->ShowUnitBuildSquares(bi, {}, false);
+				}
 
-			// second pass; water-depth indicator lines
-			for (const BuildInfo& bi: buildInfoQueue) {
-				unitDrawer->ShowUnitBuildSquares(bi, {}, false);
-			}
-
-			unitDrawer->ResetShowUnitBuildSquares(onMiniMap, false);
+				unitDrawer->ResetShowUnitBuildSquares(onMiniMap, false);
+			}				
 		}
 
-		if (!onMiniMap && !buildInfoQueue.empty()) {
+		if (drawBuildGhost && !onMiniMap && !buildInfoQueue.empty()) {
 			// render a pending line/area-build queue
 			assert((buildInfoQueue.front()).def == (buildInfoQueue.back()).def);
 			assert(buildInfoQueue.size() == buildColors.size());

--- a/rts/Game/UI/GuiHandler.cpp
+++ b/rts/Game/UI/GuiHandler.cpp
@@ -3955,7 +3955,7 @@ void CGuiHandler::DrawMapStuff(bool onMiniMap)
 						}
 					}
 				}
-				if (drawBuildGrid || onMiniMap){
+				if (drawBuildGrid || onMiniMap) {
 					if (unitDrawer->ShowUnitBuildSquares(bi, buildCommands, true)) {
 						buildColors.emplace_back(0.7f, 1.0f, 1.0f, 0.4f); // yellow
 					} else {
@@ -3963,7 +3963,7 @@ void CGuiHandler::DrawMapStuff(bool onMiniMap)
 					}
 				}
 			}
-			if (drawBuildGrid || onMiniMap){
+			if (drawBuildGrid || onMiniMap) {
 				unitDrawer->ResetShowUnitBuildSquares(onMiniMap, true);
 				unitDrawer->SetupShowUnitBuildSquares(onMiniMap, false);
 

--- a/rts/Game/UI/GuiHandler.h
+++ b/rts/Game/UI/GuiHandler.h
@@ -98,6 +98,10 @@ public:
 	void SetDrawSelectionInfo(bool dsi) { drawSelectionInfo = dsi; }
 	bool GetDrawSelectionInfo() const { return drawSelectionInfo; }
 
+	void SetDrawBuild(bool grid, bool ghost) { drawBuildGrid = grid; drawBuildGhost = ghost; }
+	bool GetDrawBuildGrid() const { return drawBuildGrid; }
+	bool GetDrawBuildGhost() const { return drawBuildGhost; }
+
 	void SetBuildFacing(unsigned int facing) { buildFacing = facing % NUM_FACINGS; }
 	void SetBuildSpacing(int spacing) { buildSpacing = std::max(spacing, 0); }
 
@@ -182,7 +186,8 @@ public:
 	int inCommand = -1;
 	int buildFacing = FACING_SOUTH;
 	int buildSpacing = 0;
-
+	bool drawBuildGrid = true;
+	bool drawBuildGhost = true;
 private:
 	int maxPage = 0;
 	int activePage = 0;

--- a/rts/Lua/LuaUnsyncedCtrl.cpp
+++ b/rts/Lua/LuaUnsyncedCtrl.cpp
@@ -244,6 +244,8 @@ bool LuaUnsyncedCtrl::PushEntries(lua_State* L)
 
 	REGISTER_LUA_CFUNC(SetDrawSelectionInfo);
 
+	REGISTER_LUA_CFUNC(SetDrawBuild);
+
 	REGISTER_LUA_CFUNC(SetBuildSpacing);
 	REGISTER_LUA_CFUNC(SetBuildFacing);
 
@@ -2768,6 +2770,15 @@ int LuaUnsyncedCtrl::SetDrawSelectionInfo(lua_State* L)
 
 /******************************************************************************/
 /******************************************************************************/
+
+int LuaUnsyncedCtrl::SetDrawBuild(lua_State* L)
+{
+	if (guihandler != nullptr){
+			guihandler->drawBuildGrid = !!luaL_checkboolean(L, 1);
+			guihandler->drawBuildGhost = !!luaL_checkboolean(L, 2);
+	}
+	return 0;
+}
 
 int LuaUnsyncedCtrl::SetBuildSpacing(lua_State* L)
 {

--- a/rts/Lua/LuaUnsyncedCtrl.cpp
+++ b/rts/Lua/LuaUnsyncedCtrl.cpp
@@ -2773,10 +2773,11 @@ int LuaUnsyncedCtrl::SetDrawSelectionInfo(lua_State* L)
 
 int LuaUnsyncedCtrl::SetDrawBuild(lua_State* L)
 {
-	if (guihandler != nullptr){
-			guihandler->drawBuildGrid = !!luaL_checkboolean(L, 1);
-			guihandler->drawBuildGhost = !!luaL_checkboolean(L, 2);
-	}
+	if (guihandler == nullptr)
+		return 0;
+
+	guihandler->drawBuildGrid = luaL_checkboolean(L, 1);
+	guihandler->drawBuildGhost = luaL_checkboolean(L, 2);
 	return 0;
 }
 

--- a/rts/Lua/LuaUnsyncedCtrl.h
+++ b/rts/Lua/LuaUnsyncedCtrl.h
@@ -150,6 +150,8 @@ class LuaUnsyncedCtrl {
 
 		static int SetDrawSelectionInfo(lua_State* L);
 
+		static int SetDrawBuild(lua_State* L);
+
 		static int SetBuildSpacing(lua_State* L);
 		static int SetBuildFacing(lua_State* L);
 

--- a/rts/Lua/LuaUnsyncedRead.cpp
+++ b/rts/Lua/LuaUnsyncedRead.cpp
@@ -191,8 +191,12 @@ bool LuaUnsyncedRead::PushEntries(lua_State* L)
 	REGISTER_LUA_CFUNC(GetActiveCmdDescs);
 	REGISTER_LUA_CFUNC(GetActiveCmdDesc);
 	REGISTER_LUA_CFUNC(GetCmdDescIndex);
+
+	REGISTER_LUA_CFUNC(GetDrawBuild);
+
 	REGISTER_LUA_CFUNC(GetBuildFacing);
 	REGISTER_LUA_CFUNC(GetBuildSpacing);
+
 	REGISTER_LUA_CFUNC(GetGatherMode);
 	REGISTER_LUA_CFUNC(GetActivePage);
 
@@ -2031,6 +2035,16 @@ int LuaUnsyncedRead::GetCmdDescIndex(lua_State* L)
 
 
 /******************************************************************************/
+
+int LuaUnsyncedRead::GetDrawBuild(lua_State* L)
+{
+	if (guihandler == nullptr)
+		return 0;
+
+	lua_pushboolean(L, guihandler->drawBuildGrid);
+	lua_pushboolean(L, guihandler->drawBuildGhost);
+	return 2;
+}
 
 int LuaUnsyncedRead::GetBuildFacing(lua_State* L)
 {

--- a/rts/Lua/LuaUnsyncedRead.h
+++ b/rts/Lua/LuaUnsyncedRead.h
@@ -129,6 +129,8 @@ class LuaUnsyncedRead {
 
 		static int GetGatherMode(lua_State* L);
 
+		static int GetDrawBuild(lua_State* L);
+
 		static int GetBuildFacing(lua_State* L);
 		static int GetBuildSpacing(lua_State* L);
 


### PR DESCRIPTION
Getter/Setter CallIn controlling the main map drawing of build grid and build ghost (don't change build grid drawn on minimap).
For the purpose of removing them when one want to draw customized elevation of ghost/grid along with auto terraforming widget.
usage:
Spring.SetDrawBuild(bool grid, bool ghost)
Spring.GetDrawBuild() -> bool grid, bool ghost