### PR TITLE
Draw build call in (maintenance)

### DIFF
--- a/rts/Game/UI/GuiHandler.cpp
+++ b/rts/Game/UI/GuiHandler.cpp
@@ -3778,14 +3778,14 @@ void CGuiHandler::DrawMapStuff(bool onMiniMap)
 							}
 						}
 					}
-					if (drawBuildGrid || onMiniMap){
+					if (drawBuildGrid || onMiniMap) {
 						if (unitDrawer->ShowUnitBuildSquare(bi, buildCommands)) {
 							glColor4f(0.7f, 1.0f, 1.0f, 0.4f);
 						} else {
 							glColor4f(1.0f, 0.5f, 0.5f, 0.4f);
 						}
 					}
-					if (drawBuildGhost && !onMiniMap)  {
+					if (drawBuildGhost && !onMiniMap) {
 						glPushMatrix();
 						glLoadIdentity();
 						glTranslatef3(buildPos);

--- a/rts/Game/UI/GuiHandler.cpp
+++ b/rts/Game/UI/GuiHandler.cpp
@@ -3778,14 +3778,14 @@ void CGuiHandler::DrawMapStuff(bool onMiniMap)
 							}
 						}
 					}
-
-					if (unitDrawer->ShowUnitBuildSquare(bi, buildCommands)) {
-						glColor4f(0.7f, 1.0f, 1.0f, 0.4f);
-					} else {
-						glColor4f(1.0f, 0.5f, 0.5f, 0.4f);
+					if (drawBuildGrid || onMiniMap){
+						if (unitDrawer->ShowUnitBuildSquare(bi, buildCommands)) {
+							glColor4f(0.7f, 1.0f, 1.0f, 0.4f);
+						} else {
+							glColor4f(1.0f, 0.5f, 0.5f, 0.4f);
+						}
 					}
-
-					if (!onMiniMap) {
+					if (drawBuildGhost && !onMiniMap)  {
 						glPushMatrix();
 						glLoadIdentity();
 						glTranslatef3(buildPos);

--- a/rts/Game/UI/GuiHandler.h
+++ b/rts/Game/UI/GuiHandler.h
@@ -103,6 +103,10 @@ public:
 	void SetDrawSelectionInfo(bool dsi) { drawSelectionInfo = dsi; }
 	bool GetDrawSelectionInfo() const { return drawSelectionInfo; }
 
+	void SetDrawBuild(bool grid, bool ghost) { drawBuildGrid = grid; drawBuildGhost = ghost; }
+	bool GetDrawBuildGrid() const { return drawBuildGrid; }
+	bool GetDrawBuildGhost() const { return drawBuildGhost; }
+
 	void SetBuildFacing(unsigned int facing) { buildFacing = facing % NUM_FACINGS; }
 	void SetBuildSpacing(int spacing) { buildSpacing = std::max(spacing, 0); }
 
@@ -174,10 +178,13 @@ public:
 	int inCommand = -1;
 	int buildFacing = FACING_SOUTH;
 	int buildSpacing = 0;
+	bool drawBuildGrid = true;
+	bool drawBuildGhost = true;
 
 private:
 	int maxPage = 0;
 	int activePage = 0;
+
 	int defaultCmdMemory = -1;
 	int explicitCommand = -1;
 	int curIconCommand = -1;

--- a/rts/Lua/LuaUnsyncedCtrl.cpp
+++ b/rts/Lua/LuaUnsyncedCtrl.cpp
@@ -244,6 +244,8 @@ bool LuaUnsyncedCtrl::PushEntries(lua_State* L)
 
 	REGISTER_LUA_CFUNC(SetDrawSelectionInfo);
 
+	REGISTER_LUA_CFUNC(SetDrawBuild);
+
 	REGISTER_LUA_CFUNC(SetBuildSpacing);
 	REGISTER_LUA_CFUNC(SetBuildFacing);
 
@@ -1051,7 +1053,6 @@ int LuaUnsyncedCtrl::SetDrawModelsDeferred(lua_State* L)
 	lua_pushboolean(L, featureDrawer->DrawForward());
 	return 4;
 }
-
 
 int LuaUnsyncedCtrl::SetVideoCapturingMode(lua_State* L)
 {
@@ -2771,6 +2772,16 @@ int LuaUnsyncedCtrl::SetDrawSelectionInfo(lua_State* L)
 
 /******************************************************************************/
 /******************************************************************************/
+
+
+int LuaUnsyncedCtrl::SetDrawBuild(lua_State* L)
+{
+	if (guihandler != nullptr){
+			guihandler->drawBuildGrid = !!luaL_checkboolean(L, 1);
+			guihandler->drawBuildGhost = !!luaL_checkboolean(L, 2);
+	}
+	return 0;
+}
 
 int LuaUnsyncedCtrl::SetBuildSpacing(lua_State* L)
 {

--- a/rts/Lua/LuaUnsyncedCtrl.cpp
+++ b/rts/Lua/LuaUnsyncedCtrl.cpp
@@ -2776,10 +2776,11 @@ int LuaUnsyncedCtrl::SetDrawSelectionInfo(lua_State* L)
 
 int LuaUnsyncedCtrl::SetDrawBuild(lua_State* L)
 {
-	if (guihandler != nullptr){
-			guihandler->drawBuildGrid = !!luaL_checkboolean(L, 1);
-			guihandler->drawBuildGhost = !!luaL_checkboolean(L, 2);
-	}
+	if (guihandler == nullptr)
+		return 0;
+	
+	guihandler->drawBuildGrid = luaL_checkboolean(L, 1);
+	guihandler->drawBuildGhost = luaL_checkboolean(L, 2);
 	return 0;
 }
 

--- a/rts/Lua/LuaUnsyncedCtrl.h
+++ b/rts/Lua/LuaUnsyncedCtrl.h
@@ -150,6 +150,8 @@ class LuaUnsyncedCtrl {
 
 		static int SetDrawSelectionInfo(lua_State* L);
 
+		static int SetDrawBuild(lua_State* L);
+
 		static int SetBuildSpacing(lua_State* L);
 		static int SetBuildFacing(lua_State* L);
 

--- a/rts/Lua/LuaUnsyncedRead.cpp
+++ b/rts/Lua/LuaUnsyncedRead.cpp
@@ -188,8 +188,12 @@ bool LuaUnsyncedRead::PushEntries(lua_State* L)
 	REGISTER_LUA_CFUNC(GetActiveCmdDescs);
 	REGISTER_LUA_CFUNC(GetActiveCmdDesc);
 	REGISTER_LUA_CFUNC(GetCmdDescIndex);
+
+	REGISTER_LUA_CFUNC(GetDrawBuild);
+
 	REGISTER_LUA_CFUNC(GetBuildFacing);
 	REGISTER_LUA_CFUNC(GetBuildSpacing);
+
 	REGISTER_LUA_CFUNC(GetGatherMode);
 	REGISTER_LUA_CFUNC(GetActivePage);
 
@@ -1995,6 +1999,16 @@ int LuaUnsyncedRead::GetCmdDescIndex(lua_State* L)
 
 
 /******************************************************************************/
+
+int LuaUnsyncedRead::GetDrawBuild(lua_State* L)
+{
+	if (guihandler == nullptr)
+		return 0;
+
+	lua_pushboolean(L, guihandler->drawBuildGrid);
+	lua_pushboolean(L, guihandler->drawBuildGhost);
+	return 2;
+}
 
 int LuaUnsyncedRead::GetBuildFacing(lua_State* L)
 {

--- a/rts/Lua/LuaUnsyncedRead.h
+++ b/rts/Lua/LuaUnsyncedRead.h
@@ -126,6 +126,8 @@ class LuaUnsyncedRead {
 
 		static int GetGatherMode(lua_State* L);
 
+		static int GetDrawBuild(lua_State* L);
+
 		static int GetBuildFacing(lua_State* L);
 		static int GetBuildSpacing(lua_State* L);
 


### PR DESCRIPTION
Getter/Setter CallIn controlling the main map drawing of build grid and build ghost (don't change build grid drawn on minimap).
For the purpose of removing them when one want to draw customized elevation of ghost/grid along with auto terraforming widget.
usage:
Spring.SetDrawBuild(bool grid, bool ghost)
Spring.GetDrawBuild() -> bool grid, bool ghost