### PR TITLE
Fix building errors for non-prefixed docbook versions

### DIFF
--- a/rts/build/cmake/FindAsciiDoc.cmake
+++ b/rts/build/cmake/FindAsciiDoc.cmake
@@ -49,6 +49,9 @@ find_file(DOCBOOK_XSL
 
 IF    (NOT DOCBOOK_XSL)
 	file(GLOB DOCBOOK_XSL / /usr/share/xml/docbook/xsl-stylesheets-*/manpages/docbook.xsl)
+	IF    (DOCBOOK_XSL)
+		list(GET DOCBOOK_XSL 0 DOCBOOK_XSL)
+	ENDIF (DOCBOOK_XSL)
 ENDIF (NOT DOCBOOK_XSL)
 
 # handle the QUIETLY and REQUIRED arguments and set ASCIIDOC_FOUND to TRUE if


### PR DESCRIPTION
In my manjaro docbook-xsl version is 1.79.2, which is not considered [in the prefixed list](https://github.com/spring/spring/blob/develop/rts/build/cmake/FindAsciiDoc.cmake#L38), so it fallbacks to [file based search](https://github.com/spring/spring/blob/develop/rts/build/cmake/FindAsciiDoc.cmake#L51).

Unfortunately, if I manually type the list command I get 2 files:

```
$ ls /usr/share/xml/docbook/xsl-stylesheets-*/manpages/docbook.xsl
/usr/share/xml/docbook/xsl-stylesheets-1.79.2/manpages/docbook.xsl  /usr/share/xml/docbook/xsl-stylesheets-1.79.2-nons/manpages/docbook.xsl
```

Driving to errors. This PR fix that error, getting just the first found file. Tested just on maintenance version in my current computer.