### PR TITLE
Set SUBSYSTEM CONSOLE for Windows system

### DIFF
--- a/rts/builds/dedicated/CMakeLists.txt
+++ b/rts/builds/dedicated/CMakeLists.txt
@@ -179,6 +179,11 @@ if    (MSVC)
 endif (MSVC)
 add_dependencies(engine-dedicated generateVersionFiles)
 
+if    (MINGW)
+	# To enable console output/force a console window to open
+	set_target_properties(engine-dedicated PROPERTIES LINK_FLAGS "-Wl,-subsystem,console")
+endif (MINGW)
+
 install(TARGETS engine-dedicated DESTINATION ${BINDIR})
 
 # Only build & install spring-dedicated executable & dependencies


### PR DESCRIPTION
This allows Windows users to actually see the output of spring-dedicated.exe without having to redirect it.
This is already done correctly for spring-headless, but for some reason it seems it was forgotten for spring-dedicated.