### PR TITLE
Unit/Feature defs loading: accept `health`

### DIFF
--- a/doc/changelog.txt
+++ b/doc/changelog.txt
@@ -15,6 +15,7 @@ Sim:
  - change default ownerExpAccWeight to 0 for all weapon-types
  - remove salvoError multiplier hack for positional and out-of-los targets
  - add new UnitDef tag "stopToAttack"
+ - defs: accept "health" in addition to "maxdamage" (units) or "damage" (features)
 
 Lua:
  - add math.tau

--- a/rts/Sim/Features/FeatureDefHandler.cpp
+++ b/rts/Sim/Features/FeatureDefHandler.cpp
@@ -104,7 +104,11 @@ FeatureDef* CFeatureDefHandler::CreateFeatureDef(const LuaTable& fdTable, const 
 
 	fd.metal       = fdTable.GetFloat("metal",  0.0f);
 	fd.energy      = fdTable.GetFloat("energy", 0.0f);
-	fd.health      = fdTable.GetFloat("damage", 0.0f);
+
+	// "damage" is the legacy Total Annihilation spelling
+	fd.health      = fdTable.GetFloat("health", fdTable.GetFloat("damage", 0.0f));
+	fd.health      = std::max(0.1f, fd.health);
+
 	fd.reclaimTime = std::max(1.0f, fdTable.GetFloat("reclaimTime", (fd.metal + fd.energy) * 6.0f));
 
 	fd.smokeTime = fdTable.GetInt("smokeTime", 300);

--- a/rts/Sim/Units/UnitDef.cpp
+++ b/rts/Sim/Units/UnitDef.cpp
@@ -277,7 +277,11 @@ UnitDef::UnitDef(const LuaTable& udTable, const std::string& unitName, int id)
 	makesMetal   = udTable.GetFloat("makesMetal", 0.0f);
 	energyMake   = udTable.GetFloat("energyMake", 0.0f);
 
-	health       = std::max(0.1f, udTable.GetFloat("maxDamage",  0.0f)); //avoid some nasty divide by 0
+	/* maxDamage is the legacy Total Annihilation spelling,
+	 * and what most games use, so not really deprecatable */
+	health       = udTable.GetFloat("health", udTable.GetFloat("maxDamage", 0.0f));
+	health       = std::max(0.1f, health); // avoid some nasty divide by 0
+
 	autoHeal     = udTable.GetFloat("autoHeal",      0.0f) * (UNIT_SLOWUPDATE_RATE / float(GAME_SPEED));
 	idleAutoHeal = udTable.GetFloat("idleAutoHeal", 10.0f) * (UNIT_SLOWUPDATE_RATE / float(GAME_SPEED));
 	idleTime     = udTable.GetInt("idleTime", 600);


### PR DESCRIPTION
More natural and it's also the key under which the value later gets exposed to wupgets.
`maxDamage` (or `damage` for features) still accepted because it's the TA spelling and what is currently used.