### PR TITLE
Provide PCG32::result_type

### DIFF
--- a/rts/System/GlobalRNG.h
+++ b/rts/System/GlobalRNG.h
@@ -46,6 +46,8 @@ public:
 	typedef uint32_t res_type;
 	typedef uint64_t val_type;
 
+	using result_type = res_type;
+
 	PCG32(const val_type _val = def_val, const val_type _seq = def_seq) { seed(_val, _seq); }
 	PCG32(const PCG32& rng) { *this = rng; }
 


### PR DESCRIPTION
Provide result_type member type in PCG32, which makes it compatible with C++ UniformRandomBitGenerator and, as result, makes it usable in std::shuffle (which deprecated std::random_shuffle calls in Spring should be replaced with).