### PR TITLE
Fix depth check for non-fac seaplane buildability

### DIFF
--- a/doc/changelog.txt
+++ b/doc/changelog.txt
@@ -234,6 +234,7 @@ Fixes:
  - fix #5803 (move goals cancelled when issued onto blocked terrain)
  - fix Spring.{G,S}etConfigFloat not being callable
  - fix Spring.GetPlayerRoster sometimes excluding active players
+ - fix seaplane water buildability requirements (previously: canSubmerge AND NOT floater; now: canSubmerge OR floater)
 
 
 

--- a/rts/Game/GameHelper.cpp
+++ b/rts/Game/GameHelper.cpp
@@ -1365,8 +1365,7 @@ bool CGameHelper::CheckTerrainConstraints(
 			maxDepth = unitDef->maxWaterDepth;
 		} else {
 			// submerging or floating aircraft
-			maxDepth *= unitDef->canSubmerge;
-			maxDepth *= (1 - unitDef->floatOnWater);
+			maxDepth *= (unitDef->canSubmerge || unitDef->floatOnWater);
 		}
 	}
 


### PR DESCRIPTION
Before the patch:
 * neither `canSubmerge` nor `floater`: NOT buildable on water
 * just `canSubmerge`, but not `floater`: buildable on water
 * just `floater`, but not `canSubmerge`: NOT buildable on water
 * both `floater` and `canSubmerge`: NOT buildable on water

After the patch:
 * neither `canSubmerge` nor `floater`: NOT buildable on water
 * just `canSubmerge`, but not `floater`: buildable on water
 * just `floater`, but not `canSubmerge`: buildable on water
 * both `floater` and `canSubmerge`: buildable on water