### PR TITLE
[unitsync] Default install destination

### DIFF
--- a/tools/unitsync/CMakeLists.txt
+++ b/tools/unitsync/CMakeLists.txt
@@ -147,9 +147,9 @@ if (MINGW)
 endif (MINGW)
 fix_lib_name(unitsync)
 
-install (TARGETS unitsync
-	RUNTIME DESTINATION ${LIBDIR}
-	LIBRARY DESTINATION ${LIBDIR})
+include(GNUInstallDirs)
+install(TARGETS unitsync
+	LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
 
 add_subdirectory(test)
 


### PR DESCRIPTION
The `libunitsync.so` is force installed in `/usr/lib`, but depending on the architecture and the target, that folder can be `lib`, `lib32`, `lib64`... so let the default destination in `install()`, thus allowing the CMake caller to specify the right destination folder through `CMAKE_INSTALL_LIBDIR` (see https://cmake.org/cmake/help/v3.22/command/install.html).

I am not enough experienced with Spring RTS to propagate that change to the whole source tree, so only modified the `CMakeLists.txt` that impacts the actual destination of `libunitsync.so`. I suggest to cleanup the whole `LIBDIR` stuff accordingly.