### PR TITLE
Fix compile error

### DIFF
--- a/rts/Lua/LuaObjectRendering.h
+++ b/rts/Lua/LuaObjectRendering.h
@@ -11,13 +11,10 @@ struct lua_State;
 template<LuaObjType T> class LuaObjectRendering;
 
 class LuaObjectRenderingImpl {
-#if __GNUC__ == 11
 public:
-#else
-private:
 	friend class LuaObjectRendering<LUAOBJ_UNIT>;
 	friend class LuaObjectRendering<LUAOBJ_FEATURE>;
-#endif
+	
 	static void CreateMatRefMetatable(lua_State* L);
 	static void PushFunction(lua_State* L, int (*fnPntr)(lua_State*), const char* fnName);
 


### PR DESCRIPTION
Compiling with the preprocessor code causes a compile error
```
/home/elperson/Downloads/spring-error/rts/Lua/LuadObjectRendering.h: In static member function ‘static int LuaObjectRendering<T>::SetForwardMaterialUniform( lua_State*)’:
/home/elperson/Downloads/spring-error/rts/Lua/LuaObjectRendering.h:168:82: ‘static int LuaObjectRenderi
ngImpl::SetForwardMaterialUniform(lua_State*)’ is private within this context
```
I am running Arch linux and my gcc version is 12.1.0