### PR TITLE
add some OpenBSD codepaths, mostly following FreeBSD

### DIFF
--- a/rts/CMakeLists.txt
+++ b/rts/CMakeLists.txt
@@ -58,7 +58,7 @@ if    (UNIX AND NOT MINGW)
 	list(APPEND engineCommonLibraries ${CMAKE_DL_LIBS})
 
 	# Needed for backtrace* on some systems
-	if(CMAKE_SYSTEM_NAME MATCHES "FreeBSD")
+	if(CMAKE_SYSTEM_NAME MATCHES "FreeBSD" OR CMAKE_SYSTEM_NAME MATCHES "OpenBSD")
 		list(APPEND engineCommonLibraries execinfo)
 	endif ()
 endif ()
@@ -89,7 +89,7 @@ if    (USE_TCMALLOC AND TCMALLOC_LIBRARY)
 endif ()
 
 
-if(UNIX)
+if(UNIX AND NOT OPENBSD)
 	find_package_static(Libunwind REQUIRED)
 	list(APPEND engineCommonLibraries ${LIBUNWIND_LIBRARIES})
 	if(LIBUNWIND_FOUND)

--- a/rts/System/Platform/Linux/ThreadSupport.cpp
+++ b/rts/System/Platform/Linux/ThreadSupport.cpp
@@ -12,6 +12,10 @@
 	#include <pthread_np.h>  // for pthread_getthreadid_np
 #endif
 
+#if defined(__OpenBSD__)
+	#include <unistd.h>  // for getthrid
+#endif
+
 #include "System/Log/ILog.h"
 #include "System/Platform/Threading.h"
 
@@ -48,6 +52,8 @@ enum LinuxThreadState {
 static int gettid() {
 #if defined(__FreeBSD__)
 	return pthread_getthreadid_np();
+#elif defined(__OpenBSD__)
+	return getthrid();
 #else
 	return syscall(SYS_gettid);
 #endif

--- a/rts/System/Platform/Misc.cpp
+++ b/rts/System/Platform/Misc.cpp
@@ -28,7 +28,7 @@
 
 	#include <mach-o/dyld.h>
 
-#elif defined( __FreeBSD__)
+#elif defined( __FreeBSD__) || defined(__OpenBSD__)
 	#include <sys/types.h>
 	#include <sys/sysctl.h>
 	#include <ifaddrs.h>
@@ -249,7 +249,7 @@ namespace Platform
 		// this will only be used if moduleFilePath stays empty
 		const char* error = nullptr;
 
-	#if defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__)
+	#if defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__)
 		#ifdef __APPLE__
 		#define SHARED_LIBRARY_EXTENSION "dylib"
 		#else
@@ -383,6 +383,8 @@ namespace Platform
 		return "Linux";
 		#elif defined(__FreeBSD__)
 		return "FreeBSD";
+		#elif defined(__OpenBSD__)
+		return "OpenBSD";
 		#elif defined(__APPLE__)
 		return "MacOS";
 		#else
@@ -716,7 +718,7 @@ namespace Platform
 		return (GetMacType(macAddr, 0), macAddr);
 	}
 
-	#elif defined(__APPLE__) || defined (__FreeBSD__)
+	#elif defined(__APPLE__) || defined (__FreeBSD__) || defined(__OpenBSD__)
 
 	std::array<uint8_t, 6> GetRawMacAddr() {
 		// TODO: http://lists.freebsd.org/pipermail/freebsd-hackers/2004-June/007415.html

--- a/rts/System/Platform/Threading.cpp
+++ b/rts/System/Platform/Threading.cpp
@@ -12,7 +12,7 @@
 #include <functional>
 #include <memory>
 #include <cinttypes>
-#if defined(__APPLE__) || defined(__FreeBSD__)
+#if defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__)
 #elif defined(_WIN32)
 	#include <windows.h>
 #else
@@ -36,7 +36,7 @@ namespace Threading {
 	static NativeThreadId nativeThreadIDs[THREAD_IDX_LAST] = {};
 	static Error threadError;
 
-#if defined(__APPLE__) || defined(__FreeBSD__)
+#if defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__)
 #elif defined(_WIN32)
 	static DWORD_PTR cpusSystem = 0;
 #else
@@ -46,7 +46,7 @@ namespace Threading {
 
 	void DetectCores()
 	{
-	#if defined(__APPLE__) || defined(__FreeBSD__)
+	#if defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__)
 		// no-op
 
 	#elif defined(_WIN32)
@@ -65,7 +65,7 @@ namespace Threading {
 
 
 
-	#if defined(__APPLE__) || defined(__FreeBSD__)
+	#if defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__)
 	#elif defined(_WIN32)
 	#else
 	static std::uint32_t CalcCoreAffinityMask(const cpu_set_t* cpuSet) {
@@ -100,7 +100,7 @@ namespace Threading {
 
 	std::uint32_t GetAffinity()
 	{
-	#if defined(__APPLE__) || defined(__FreeBSD__)
+	#if defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__)
 		// no-op
 		return 0;
 
@@ -124,7 +124,7 @@ namespace Threading {
 		if (coreMask == 0)
 			return (~0);
 
-	#if defined(__APPLE__) || defined(__FreeBSD__)
+	#if defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__)
 		// no-op
 		return 0;
 
@@ -180,7 +180,7 @@ namespace Threading {
 
 	std::uint32_t GetAvailableCoresMask()
 	{
-	#if defined(__APPLE__) || defined(__FreeBSD__)
+	#if defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__)
 		// no-op
 		return (~0);
 	#elif defined(_WIN32)
@@ -209,7 +209,7 @@ namespace Threading {
 
 	void SetThreadScheduler()
 	{
-	#if defined(__APPLE__) || defined(__FreeBSD__)
+	#if defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__)
 		// no-op
 
 	#elif defined(_WIN32)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -5,7 +5,7 @@ endif ()
 # defines spring_test_compile_fail macro
 include(${CMAKE_CURRENT_SOURCE_DIR}/tools/CompileFailTest/CompileFailTest.cmake)
 
-if    (UNIX AND (NOT APPLE) AND (NOT MINGW))
+if    (UNIX AND (NOT APPLE) AND (NOT MINGW) AND (NOT OPENBSD))
 	find_library(REALTIME_LIBRARY rt)
 
 	if    (PREFER_STATIC_LIBS AND NOT EXISTS "${REALTIME_LIBRARY}")


### PR DESCRIPTION
This is some of the low-hanging fruit to help work towards running spring on OpenBSD. Mostly follows the FreeBSD codepaths. With these (and a handful more selected changes), I'm able to launch Spring on OpenBSD. Some OpenBSD specifics are the use of `getthrid()` for thread id, and that we don't have a separate librt (similar to Apple, apparently).