### PR TITLE
fix cmake OS conditions for OpenBSD

### DIFF
--- a/rts/CMakeLists.txt
+++ b/rts/CMakeLists.txt
@@ -89,7 +89,7 @@ if    (USE_TCMALLOC AND TCMALLOC_LIBRARY)
 endif ()
 
 
-if(UNIX AND NOT OPENBSD)
+if(UNIX AND (NOT CMAKE_SYSTEM_NAME MATCHES "OpenBSD"))
 	find_package_static(Libunwind REQUIRED)
 	list(APPEND engineCommonLibraries ${LIBUNWIND_LIBRARIES})
 	if(LIBUNWIND_FOUND)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -5,7 +5,7 @@ endif ()
 # defines spring_test_compile_fail macro
 include(${CMAKE_CURRENT_SOURCE_DIR}/tools/CompileFailTest/CompileFailTest.cmake)
 
-if    (UNIX AND (NOT APPLE) AND (NOT MINGW) AND (NOT OPENBSD))
+if    (UNIX AND (NOT APPLE) AND (NOT MINGW) AND (NOT CMAKE_SYSTEM_NAME MATCHES "OpenBSD"))
 	find_library(REALTIME_LIBRARY rt)
 
 	if    (PREFER_STATIC_LIBS AND NOT EXISTS "${REALTIME_LIBRARY}")


### PR DESCRIPTION
I made a mistake with the logical syntax in the last PR. This correctly accounts for OpenBSD in the logic of the CMakeLists.txt files.